### PR TITLE
Fix#752 - Chevron rotation fix for iOS devices

### DIFF
--- a/source/js/components/multipage-nav/multipage-nav.scss
+++ b/source/js/components/multipage-nav/multipage-nav.scss
@@ -11,7 +11,7 @@
     .expander {
       background: url('../_images/chevron.svg') no-repeat;
       background-size: contain;
-	  font-size: 0;
+      font-size: 0;
       border: 0;
       width: 15px;
       height: 10px;

--- a/source/js/components/multipage-nav/multipage-nav.scss
+++ b/source/js/components/multipage-nav/multipage-nav.scss
@@ -11,6 +11,7 @@
     .expander {
       background: url('../_images/chevron.svg') no-repeat;
       background-size: contain;
+	  font-size: 0;
       border: 0;
       width: 15px;
       height: 10px;


### PR DESCRIPTION
The `font-size: 100%` style is use for the button element. This has an affect on the CSS class `.expander` on certain iOS devices. When attached with button element, the transform rotation makes the pivot point to be seen shifted to the right.

I have explicitly set the `font-size: 0` in the `.expander` class to override this problem.

Hope this helps 👍 
