### PR TITLE
Temporarily hard-code redirect for fellowships

### DIFF
--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -27,7 +27,11 @@ admin.autodiscover()
 
 urlpatterns = list(filter(None, [
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^soc/', include('social_django.urls', namespace='social'))
+    url(r'^soc/', include('social_django.urls', namespace='social')),
+    # Don't remove this redirect until Fellowships pages are live
+    url(r'^fellowships/$', RedirectView.as_view(
+            url='https://advocacy.mozilla.org/open-web-fellows'
+        ))
     if settings.SOCIAL_SIGNIN else '',
     # network-api routes:
     url(r'^api/people/', include('networkapi.people.urls')),


### PR DESCRIPTION
So that we can get this url into an article or something.