### PR TITLE
Fixes #940 - Configure flake8 to allow lines up to 119 characters long

### DIFF
--- a/network-api/tox.ini
+++ b/network-api/tox.ini
@@ -1,2 +1,3 @@
 [flake8]
 exclude=*migrations*
+max-line-length=119


### PR DESCRIPTION
The default was 79, so I'm following that convention with 119 :)