### PR TITLE
Django 1.11

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -157,8 +157,6 @@ MIDDLEWARE = [
 
     'mezzanine.core.request.CurrentRequestMiddleware',
     'mezzanine.core.middleware.RedirectFallbackMiddleware',
-    'mezzanine.core.middleware.TemplateForDeviceMiddleware',
-    'mezzanine.core.middleware.TemplateForHostMiddleware',
     'mezzanine.core.middleware.AdminLoginInterfaceSelectorMiddleware',
     'mezzanine.core.middleware.SitePermissionMiddleware',
     'mezzanine.pages.middleware.PageMiddleware',

--- a/network-api/networkapi/utility/templatetags/adminsortable_tags_custom.py
+++ b/network-api/networkapi/utility/templatetags/adminsortable_tags_custom.py
@@ -10,7 +10,6 @@ def render_sortable_objects(
     objects,
     sortable_objects_template='adminsortable/shared/objects.html'
 ):
-    context.update({'objects': objects})
     tmpl = template.loader.get_template(sortable_objects_template)
     return tmpl.render({
         'objects': objects,
@@ -25,7 +24,6 @@ def render_nested_sortable_objects(
     group_expression,
     sortable_nested_objects_template='adminsortable/shared/nested_objects.html'
 ):
-    context.update({'objects': objects, 'group_expression': group_expression})
     tmpl = template.loader.get_template(sortable_nested_objects_template)
     return tmpl.render({
         'objects': objects,

--- a/network-api/networkapi/utility/templatetags/adminsortable_tags_custom.py
+++ b/network-api/networkapi/utility/templatetags/adminsortable_tags_custom.py
@@ -12,7 +12,10 @@ def render_sortable_objects(
 ):
     context.update({'objects': objects})
     tmpl = template.loader.get_template(sortable_objects_template)
-    return tmpl.render(context)
+    return tmpl.render({
+        'objects': objects,
+        'opts': context.get('opts'),
+    })
 
 
 @register.simple_tag(takes_context=True)
@@ -24,7 +27,11 @@ def render_nested_sortable_objects(
 ):
     context.update({'objects': objects, 'group_expression': group_expression})
     tmpl = template.loader.get_template(sortable_nested_objects_template)
-    return tmpl.render(context)
+    return tmpl.render({
+        'objects': objects,
+        'group_expression': group_expression,
+        'opts': context.get('opts'),
+    })
 
 
 @register.simple_tag(takes_context=True)
@@ -33,9 +40,11 @@ def render_list_items(
     list_objects,
     sortable_list_items_template='adminsortable/shared/list_items.html'
 ):
-    context.update({'list_objects': list_objects})
     tmpl = template.loader.get_template(sortable_list_items_template)
-    return tmpl.render(context)
+    return tmpl.render({
+        'list_objects': list_objects,
+        'opts': context.get('opts'),
+    })
 
 
 @register.simple_tag(takes_context=True, name='render_object_rep')
@@ -44,10 +53,13 @@ def render_object_rep(
     obj,
     forloop
 ):
-    context.update({'object': obj, 'forloop': forloop})
     tmpl = template.loader.get_template(
         '{app_name}/adminsortable_objects_custom.html'.format(
             app_name=context.get('opts').app_label
         )
     )
-    return tmpl.render(context)
+    return tmpl.render({
+        'object': obj,
+        'forloop': forloop,
+        'opts': context.get('opts'),
+    })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # Core
-Django==1.10.8
+Django==1.11
 gunicorn==19.6.0
 djangorestframework==3.5.4
 django-filter==1.0.2
 
-# Mezzanine CMS
-Mezzanine==4.2.3
+# Mezzanine CMS - Use version with Django 1.11 LTS support
+git+https://github.com/stephenmcd/mezzanine@521a98c39bb6351c4b46067069f33caf95fe0a5e#egg=Mezzanine
 filebrowser_s3==1.0.0
 
 # social auth is useful
@@ -37,7 +37,7 @@ django-cors-headers==2.0.2
 django-csp==3.3
 
 # Admin sort models
-django-admin-sortable==2.1.0
+django-admin-sortable==2.1.2
 
 # HTTP requests
 requests==2.13.0


### PR DESCRIPTION
1. Use the lastest master branch commit of Mezzanine (Django 1.11 support)
2. Update Django to 1.11
3. Fix custom adminsortable template tags that were passing Context into the render method
4. Remove deprecated Middleware