### PR TITLE
Fix 500 error when Debug=False

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -332,7 +332,7 @@ STATICFILES_DIRS = [
     app('static'),
 ]
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'networkapi.utility.staticfiles.NonStrictCompressedManifestStaticFilesStorage'
 
 STATIC_ROOT = root('staticfiles')
 
@@ -432,7 +432,12 @@ LOGGING = {
             'handlers': ['console'],
             'level': DJANGO_LOG_LEVEL,
             'propagate': True,
-        }
+        },
+        'django.request': {
+            'handlers': ['console'],
+            'level': DJANGO_LOG_LEVEL,
+            'propagate': True,
+        },
     },
 }
 

--- a/network-api/networkapi/utility/staticfiles.py
+++ b/network-api/networkapi/utility/staticfiles.py
@@ -1,0 +1,5 @@
+from whitenoise.storage import CompressedManifestStaticFilesStorage
+
+
+class NonStrictCompressedManifestStaticFilesStorage(CompressedManifestStaticFilesStorage):
+    manifest_strict = False


### PR DESCRIPTION
This patch subclasses the CompressedManifestStaticFilesStorage class provided by whitenoise to set manifest_strict to False.

[According to the docs](https://docs.djangoproject.com/en/1.11/ref/contrib/staticfiles/\#manifeststaticfilesstorage), in Django 1.11, `manifest_strict` is `True` by default, and this breaks our use case, so we have to set it False via a sub class.

STR: set `DEBUG=False` and boot the app with `runserver`. without the patch, it errors out. with it, it does not.

It also adds in some extra console logging so we can better diagnose these errors in the future. We should get stack traces to console if prod or staging hit an unhandled exception.