### PR TITLE
Fixed multi-line text link's underline bug

### DIFF
--- a/source/js/components/multipage-nav/multipage-nav.jsx
+++ b/source/js/components/multipage-nav/multipage-nav.jsx
@@ -23,7 +23,7 @@ export default class MultipageNav extends React.Component {
       let className = `multipage-link${ link.isActive ? ` multipage-link-active` : `` }`;
 
       if (link.isActive) {
-        activeLinkLabel = <a className={`active-link-label d-inline-block ${className}`}>{link.label}</a>;
+        activeLinkLabel = <a className={`active-link-label ${className}`}>{link.label}</a>;
       }
 
       return (
@@ -36,8 +36,8 @@ export default class MultipageNav extends React.Component {
     links.unshift(<div key="current-active-link">
       <button className="expander" onClick={this.toggle}>
         <div className="d-flex justify-content-between">
-          {activeLinkLabel}
-          <div className="d-inline-block control"></div>
+          <div>{activeLinkLabel}</div>
+          <div className="d-inline-block align-self-center control"></div>
         </div>
       </button>
     </div>);

--- a/source/js/components/multipage-nav/multipage-nav.scss
+++ b/source/js/components/multipage-nav/multipage-nav.scss
@@ -2,12 +2,6 @@
   background: #f2f2f2;
 
   .multipage-nav {
-    div:first-child {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
-
     .expander {
       background: none;
       text-align: left;

--- a/source/sass/type.scss
+++ b/source/sass/type.scss
@@ -44,8 +44,6 @@ a {
 @mixin yellow-underline-nav-link($active-class-name) {
   font-family: "Nunito Sans";
   color: #231f20;
-  position: relative;
-  top: 0;
 
   &:hover,
   &#{$active-class-name} {

--- a/source/sass/type.scss
+++ b/source/sass/type.scss
@@ -51,15 +51,7 @@ a {
   &#{$active-class-name} {
     color: inherit;
     text-decoration: none;
-
-    &::before {
-      content: '';
-      display: inline-block;
-      border-bottom: 5px solid #ffed00;
-      width: 100%;
-      position: absolute;
-      bottom: -5px;
-    }
+    box-shadow: 0 5px #ffed00;
   }
 }
 


### PR DESCRIPTION
Related to #977 

Bug discovered in https://github.com/mozilla/foundation.mozilla.org/issues/977#issuecomment-364309364


![screenshot-2018-2-8 mozilla foundation super long title 123 hello there how are you](https://user-images.githubusercontent.com/2896608/36011027-78d4d988-0d09-11e8-9180-502e9808e513.png)
<img src="https://user-images.githubusercontent.com/2896608/36011030-7a8ceb9e-0d09-11e8-8061-25321c22a391.png" width=320>
<img src="https://user-images.githubusercontent.com/2896608/36011031-7c4597d8-0d09-11e8-8126-5ea881b1fb52.png" width=320>
