### PR TITLE
Restore CMS unordered list style

### DIFF
--- a/source/sass/cms.scss
+++ b/source/sass/cms.scss
@@ -4,4 +4,9 @@
   img {
     height: auto;
   }
+
+  ul {
+    list-style: initial;
+    padding-left: 40px;
+  }
 }


### PR DESCRIPTION
Fixes #1035.

I think we should still remove the reset as suggested in #1014, but that's a conversation for that ticket.