### PR TITLE
Adjust draft banner logic

### DIFF
--- a/source/pug/templates/base-for-django.pug
+++ b/source/pug/templates/base-for-django.pug
@@ -9,7 +9,8 @@ block masterParams
   - let pageTitle = `{{ page.meta_title }}`;
 
 block memberNotice
-  | {% if not page.published %}<div><strong>Draft preview.</strong> You must save as Published to make it public.</div>{% endif %}
+  //- Show warning if pages are a Mezzanine draft.
+  | {% if page.status == 1 %}<div><strong>Draft preview.</strong> You must save as Published to make it public.</div>{% endif %}
 
 block heroGuts
   | {% block heroGuts %}{% endblock %}


### PR DESCRIPTION
Fixes #1104. Now the banner won’t show up on pages that aren’t Mezzanine controlled and thus don’t have `page.published`.
