### PR TITLE
Changed button copy to "Application Coming Soon"

### DIFF
--- a/network-api/networkapi/fellows/templates/fellows_apply.html
+++ b/network-api/networkapi/fellows/templates/fellows_apply.html
@@ -21,7 +21,7 @@
         <p class="mb-4">Our fellows in open media are creators and media-makers inspired by the open web to explore the boundaries of technology privacy, politics, public awareness, and surveillance.</p>
       </div>
       <div class="col-12 mt-2 mb-5">
-        <a href="https://mozilla.fluxx.io/apply/2018fellows" class="btn btn-normal">Apply to be a fellow today</a>
+        <a href="https://mozilla.fluxx.io/apply/2018fellows" class="btn btn-normal">Application Coming Soon</a>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Temporary fix to issue #1134 in GitHub. 

Once we have the final link, we will replace the current button copy with “Apply to Be a Fellow Today”.
