### PR TITLE
Generate default landing pages and campaigns with documented URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ You can generate a specific set of fake model data by entering a seed value
 
 If a seed is not provided, a pseudorandom one will be generated and logged to the console. You can share this value with others if you need them to generate the same set of data that you have.
 
+##### Landing Page and Campaign links
+
+The `load_fake_data` command will output the following URLs every time:
+
+- `/opportunity/page/`
+- `/opportunity/page-with-signup/`
+- `/opportunity/page-side-nav/`
+- `/opportunity/page-side-nav/sub-page/`
+- `/opportunity/page-side-nav/sub-page-2/`
+- `/opportunity/page-side-nav/sub-page-with-signup/`
+- `/campaigns/important-issue/`
+- `/campaigns/important-issue/overview`
+- `/campaigns/important-issue/press`
+- `/campaigns/important-issue/take-action` (Petition page)
+
 #### Running the project for front-end development
 
 - At the root of the project you can run: `npm start`, which will start the server as well as watch tasks for recompiling changes to Pug, JS, and Sass files.

--- a/network-api/networkapi/management/commands/load_fake_data.py
+++ b/network-api/networkapi/management/commands/load_fake_data.py
@@ -7,7 +7,7 @@ from django.core.management import call_command
 # Factories
 from networkapi.highlights.factory import HighlightFactory
 from networkapi.landingpage.factory import LandingPageFactory, SignupFactory
-from networkapi.campaign.factory import CampaignFactory
+from networkapi.campaign.factory import CampaignFactory, PetitionFactory
 from networkapi.milestones.factory import MilestoneFactory
 from networkapi.news.factory import NewsFactory
 from networkapi.people.factory import (
@@ -75,6 +75,22 @@ class Command(BaseCommand):
         self.stdout.write('Generating CampaignPage objects')
         campaigns = LandingPageFactory.create(title='Campaigns', content='Placeholder page')
         [CampaignFactory.create(parent=campaigns) for i in range(3)]
+
+        self.stdout.write('Generating CampaignPage objects with known titles')
+        important_issue = LandingPageFactory.create(parent=campaigns, title='important-issue')
+        LandingPageFactory.create(parent=important_issue, title='overview')
+        LandingPageFactory.create(parent=important_issue, title='press')
+        CampaignFactory.create(parent=important_issue, title='take-action', petition=PetitionFactory.create())
+
+        self.stdout.write('Generating LandingPage objects with known titles')
+        LandingPageFactory.create(parent=opportunity, title='page')
+        LandingPageFactory.create(parent=opportunity, title='page-with-signup', signup=SignupFactory.create())
+
+        self.stdout.write('Generating LandingPage objects with known titles, and side-nav')
+        side_nav = LandingPageFactory.create(parent=opportunity, title='page-side-nav')
+        LandingPageFactory.create(parent=side_nav, title='sub-page')
+        LandingPageFactory.create(parent=side_nav, title='sub-pag-2')
+        LandingPageFactory.create(parent=side_nav, title='sub-page-with-signup', signup=SignupFactory.create())
 
         self.stdout.write('Generating Homepage')
         homepage = HomepageFactory.create()


### PR DESCRIPTION
Related issue: #1180 

The `load_fake_data` command will output the following URLs every time:

- `/opportunity/page/`
- `/opportunity/page-with-signup/`
- `/opportunity/page-side-nav/`
- `/opportunity/page-side-nav/sub-page/`
- `/opportunity/page-side-nav/sub-page-2/`
- `/opportunity/page-side-nav/sub-page-with-signup/`
- `/campaigns/important-issue/`
- `/campaigns/important-issue/overview`
- `/campaigns/important-issue/press`
- `/campaigns/important-issue/take-action` (Petition page)