### PR TITLE
Changes on button copy due to stakeholder request

### DIFF
--- a/network-api/networkapi/fellows/templates/fellows_apply.html
+++ b/network-api/networkapi/fellows/templates/fellows_apply.html
@@ -43,7 +43,7 @@
         </div>
 
         <div class="col-12 offset-md-3 mt-2 mb-5">
-          <a href="#" class="btn btn-normal">applications will open soon</a>
+          <a href="#" class="btn btn-normal disabled">applications will open soon</a>
         </div>
     </div>
     <div class="row">

--- a/network-api/networkapi/fellows/templates/fellows_apply.html
+++ b/network-api/networkapi/fellows/templates/fellows_apply.html
@@ -43,7 +43,7 @@
         </div>
 
         <div class="col-12 offset-md-3 mt-2 mb-5">
-          <a href="#" class="btn btn-normal disabled">applications will open soon</a>
+          <a class="btn btn-normal disabled">applications will open soon</a>
         </div>
     </div>
     <div class="row">

--- a/network-api/networkapi/fellows/templates/fellows_apply.html
+++ b/network-api/networkapi/fellows/templates/fellows_apply.html
@@ -43,8 +43,7 @@
         </div>
 
         <div class="col-12 offset-md-3 mt-2 mb-5">
-          <a href="https://mozilla.fluxx.io/user_sessions/new" class="btn btn-normal">apply to be a fellow today</a>
-          <p class="small-gray mt-2">The call closes <strong>Friday, April 20, 2018 at 11:59PM PST</strong>.</p>
+          <a href="#" class="btn btn-normal">applications will open soon</a>
         </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Amy requested on Slack that we change the copy of the button from "apply to be a fellow today" to "applications will open soon" as the current link goes to Fluxx and applications are not yet open.

We also agreed to remove the grey copy under the button to make a better user experience in this new scenario.

CC: @alanmoo for visibility
