### PR TITLE
Preparation of button for when applications open

### DIFF
--- a/network-api/networkapi/fellows/templates/fellows_apply.html
+++ b/network-api/networkapi/fellows/templates/fellows_apply.html
@@ -43,7 +43,8 @@
         </div>
 
         <div class="col-12 offset-md-3 mt-2 mb-5">
-          <a class="btn btn-normal disabled">applications will open soon</a>
+          <a class="btn btn-normal" href="https://mozilla.fluxx.io/user_sessions/new">Apply to be a fellow today</a>
+          <p class="small-gray mt-3">Applications are due by 5 pm Eastern Time on April 20th, 2018.<br> <strong> Make sure to register by April 18th</strong>.</p>
         </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Related issue:  #1202
Summary: button copy changes + added helper text when we launch Fellowships application.

This is how this button should look like:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/22157921/37677169-7bcfbb1a-2c37-11e8-92d6-421c7b1974ca.png">

