### PR TITLE
second-level deep menus are now :cool:

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/mini_site_sidebar.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/mini_site_sidebar.html
@@ -3,10 +3,10 @@
 {% if singleton_page == False %}
 <div class="py-5 col-md-3 mb-3 hidden-sm-down">
   <div class="multipage-nav" id="multipage-nav">
-    {% for page in menu_pages %}
+    {% for entry in menu_pages %}
     <div>
-      <a class="multipage-link {% if page.title == current.title %}multipage-link-active{% endif %}" href="{% pageurl page %}">
-        {% if page.specific.header %}{{ page.specific.header }}{% else %}{{ page.title }}{% endif %}
+      <a class="multipage-link {% if page.title == current.title %}multipage-link-active{% endif %}" href="{% pageurl entry.page %}">{% if entry.depth == 2 %}→ {% endif %}
+        {% if entry.page.specific.header %}{{ entry.page.specific.header }}{% else %}{{ entry.page.title }}{% endif %}
       </a>
     </div>
     {% endfor %}

--- a/network-api/networkapi/wagtailpages/templatetags/mini_site_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/mini_site_tags.py
@@ -3,16 +3,22 @@ from django import template
 register = template.Library()
 
 
+def get_descendants(node, list, depth=0, max_depth=2):
+    if (depth <= max_depth):
+        list.append({
+            'page': node,
+            'depth': depth,
+        })
+        for child in node.get_children().live().in_menu():
+            get_descendants(child, list, depth + 1)
+
+
 # Instantiate a mini-site sidebar menu based on the current page's relation to other pages
 @register.inclusion_tag('wagtailpages/tags/mini_site_sidebar.html', takes_context=True)
 def mini_site_sidebar(context, page):
-    children = page.get_children().live()
-
+    menu_pages = list()
     root = context['root']
-    if page is not root:
-        children = root.get_children().live()
-
-    menu_pages = [root] + list(children.in_menu())
+    get_descendants(root, menu_pages)
 
     # Return the list of values we need to have our template
     # generate the appropriate sidebar HTML.


### PR DESCRIPTION
This swiches over the menu system to specifically include child depth so that we can add -> arrows to children-of-children.