### PR TITLE
adds the meta_title property to wagtail pages we use

### DIFF
--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -53,6 +53,15 @@ class ModularPage(Page):
         StreamFieldPanel('body'),
     ]
 
+    # Legacy field for now, necessary to make sure that the
+    # actualy <title> element has the correct value in it.
+    # This uses page.meta_title in the base-compiled.html
+    # master template, which is still based on Mezzanine
+    # page models, rather than Wagtail pages models.
+    @property
+    def meta_title(self):
+        return self.title
+
     show_in_menus_default = True
 
 


### PR DESCRIPTION
Wagtail uses `title` rather than `meta_title`, so in order to see our page titles properly templated in, this PR adds a `meta_title` soft-property to the ModularPage class, which resolves to `title` when requested.