### PR TITLE
Add a new fake petition page

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The `load_fake_data` command will output the following URLs every time:
 - `/campaigns/important-issue/overview`
 - `/campaigns/important-issue/press`
 - `/campaigns/important-issue/take-action` (Petition page)
+- `/campaigns/single-petition` (Petition page)
 
 #### Running the project for front-end development
 

--- a/network-api/networkapi/management/commands/load_fake_data.py
+++ b/network-api/networkapi/management/commands/load_fake_data.py
@@ -81,6 +81,7 @@ class Command(BaseCommand):
         LandingPageFactory.create(parent=important_issue, title='overview')
         LandingPageFactory.create(parent=important_issue, title='press')
         CampaignFactory.create(parent=important_issue, title='take-action', petition=PetitionFactory.create())
+        CampaignFactory.create(parent=campaigns, title='single-petition', petition=PetitionFactory.create())
 
         self.stdout.write('Generating LandingPage objects with known titles')
         LandingPageFactory.create(parent=opportunity, title='page')


### PR DESCRIPTION
Related issue: fix #1222
Summary: `load-fake-data` script now create a new independent page with a petition. The url is `/campaigns/single-petition`.
example: https://foundation-mofostaging-pr-1306.herokuapp.com/campaigns/single-petition/