### PR TITLE
Allow PrimaryPage type as child of PrimaryPage

### DIFF
--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -318,7 +318,7 @@ class PrimaryPage(Page):
         StreamFieldPanel('body'),
     ]
 
-    parent_page_types = ['Homepage']
+    parent_page_types = ['Homepage', 'PrimaryPage']
 
 
 class Homepage(Page):


### PR DESCRIPTION
For sections like “About”