### PR TITLE
Fix CSP not serving on Whitenoise served pages

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -181,7 +181,11 @@ MIDDLEWARE = list(filter(None, [
     'mezzanine.core.middleware.UpdateCacheMiddleware',
 
     'csp.middleware.CSPMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'networkapi.middleware.ReferrerMiddleware',
+
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -189,12 +193,10 @@ MIDDLEWARE = list(filter(None, [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
     'debug_toolbar.middleware.DebugToolbarMiddleware'
     if DEBUG and not DISABLE_DEBUG_TOOLBAR else None,
 
-    'corsheaders.middleware.CorsMiddleware',
 
     'mezzanine.core.request.CurrentRequestMiddleware',
     'mezzanine.core.middleware.RedirectFallbackMiddleware',
@@ -205,8 +207,6 @@ MIDDLEWARE = list(filter(None, [
 
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
-
-    'networkapi.middleware.ReferrerMiddleware',
 ]))
 
 if SOCIAL_SIGNIN:

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -180,6 +180,7 @@ MIDDLEWARE = list(filter(None, [
 
     'mezzanine.core.middleware.UpdateCacheMiddleware',
 
+    'csp.middleware.CSPMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -194,7 +195,6 @@ MIDDLEWARE = list(filter(None, [
     if DEBUG and not DISABLE_DEBUG_TOOLBAR else None,
 
     'corsheaders.middleware.CorsMiddleware',
-    'csp.middleware.CSPMiddleware',
 
     'mezzanine.core.request.CurrentRequestMiddleware',
     'mezzanine.core.middleware.RedirectFallbackMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ wagtail-metadata==2.0.0
 django-cors-headers==2.0.2
 
 # CSP
-django-csp==3.3
+django-csp==3.4
 
 # Admin sort models
 django-admin-sortable==2.1.2


### PR DESCRIPTION
This PR bumps the CSP Middleware Version, and move the CSP middleware higher in the list so it runs for statically served content.

Related issue: Fixes #1310 
