### PR TITLE
Basic fix for figuregrid

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/figure_grid_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/figure_grid_block.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
-<div class="figure-grid d-md-flex">
+<div class="figure-grid d-md-flex flex-wrap">
 {% for block in self.grid_items %}
 	{% with value=block %}
 	{% include "./figure_block.html" %}

--- a/source/sass/wagtail.scss
+++ b/source/sass/wagtail.scss
@@ -31,22 +31,26 @@
   }
 
   img {
-    &.icon {
+    &.icon,
+    &.icon + figcaption {
       max-width: 100px;
       max-height: 100px;
     }
 
-    &.small {
+    &.small,
+    &.small + figcaption {
       max-width: 200px;
       max-height: 200px;
     }
 
-    &.medium {
+    &.medium,
+    &.medium + figcaption {
       max-width: 400px;
       max-height: 400px;
     }
 
-    &.large {
+    &.large,
+    &.large + figcaption {
       max-width: 800px;
       max-height: 800px;
     }


### PR DESCRIPTION
So elements don’t forever escape the page, and so that captions contain themselves. See the problem on https://foundation.mozilla.org/wagtail/about/leadership/

Solution:
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/1682681/38680639-ce911b8c-3e34-11e8-9808-2cc3da9cef83.png">

Code-wise, this isn't a permanent fix, but it's good enough to get this page out the door. We should consider more carefully what we want this component to do.
