### PR TITLE
make help text obvious for narrow-content checkbox

### DIFF
--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -61,7 +61,9 @@ class ModularPage(MetadataPageMixin, Page):
     body = StreamField(base_fields)
 
     settings_panels = Page.settings_panels + [
-        FieldPanel('narrowed_page_content'),
+        MultiFieldPanel([
+            FieldPanel('narrowed_page_content'),
+        ])
     ]
 
     content_panels = Page.content_panels + [
@@ -299,7 +301,9 @@ class PrimaryPage(MetadataPageMixin, Page):
     body = StreamField(base_fields)
 
     settings_panels = Page.settings_panels + [
-        FieldPanel('narrowed_page_content'),
+        MultiFieldPanel([
+            FieldPanel('narrowed_page_content'),
+        ])
     ]
 
     content_panels = Page.content_panels + [


### PR DESCRIPTION
closes #1364 by using the code suggested in the wagtail issue's comment.

This PR changes this:

![image](https://user-images.githubusercontent.com/177243/38707718-617c1e2e-3e67-11e8-9184-319a6a9de80d.png)

to this:

![image](https://user-images.githubusercontent.com/177243/38831339-e80c544a-4173-11e8-9a62-37e519443f26.png)
