### PR TITLE
remove an accidental lowercase 't' from highlight link text

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
@@ -99,7 +99,7 @@
             <div class="key-item mx-2 mx-md-4 p-3">
               <h5 class="h4-heading mb-2">{{highlight.highlight.title}}</h5>
               <p>{{highlight.highlight.description}}</p>
-              <a class="cta-link mb-2" href="{{highlight.highlight.link_url}}">{{highlight.highlight.link_label}}t</a>
+              <a class="cta-link mb-2" href="{{highlight.highlight.link_url}}">{{highlight.highlight.link_label}}</a>
             </div>
           </div>
       </div>


### PR DESCRIPTION
fixes https://github.com/mozilla/foundation.mozilla.org/issues/1368