### PR TITLE
use the correct root values

### DIFF
--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -101,7 +101,7 @@ class MiniSiteNameSpace(ModularPage):
         """
         context = super(MiniSiteNameSpace, self).get_context(request)
         updated = get_page_tree_information(self, context)
-        updated['mini_site_title'] = updated['root_title']
+        updated['mini_site_title'] = updated['root'].title
         return updated
 
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/primary_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/primary_page.html
@@ -2,10 +2,10 @@
 {% load wagtailcore_tags wagtailimages_tags primary_page_tags %}
 
 
-{% block bodyID %}{% if root_slug %}{{ root_slug }}{% else %}primary{% endif %}{% endblock%}
+{% block bodyID %}{% if root.slug %}{{ root.slug }}{% else %}primary{% endif %}{% endblock%}
 
 {% block heroGuts %}
-  <h1 class="h1-heading pb-5">{% if root_title %}{{ root_title }}{% elif page.header %}{{ page.header }}{% else %}{{ page.title }}{% endif %}</h1>
+  <h1 class="h1-heading pb-5">{% if root.title %}{{ root.title }}{% elif page.header %}{{ page.header }}{% else %}{{ page.title }}{% endif %}</h1>
 {% endblock %}
 
 {% block content %}

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -11,8 +11,6 @@ def get_page_tree_information(page, context):
     ancestors = page.get_ancestors()
     root = next((n for n in ancestors if n.specific_class == page.specific_class), page)
     context['root'] = root
-    context['root_title'] = root.specific.header if root.specific.header else root.title
-    context['root_slug'] = root.slug if root.slug else False
 
     is_top_page = (root == page)
     context['is_top_page'] = is_top_page


### PR DESCRIPTION
this PR changes the logic for accessing root fields, which fixes the minisite title being a page header instead of a root title, while also removing a few lines of technically functionality-duplicating code.