### PR TITLE
don't show minisite titles when the child tree does not cause a menu

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/mini_site_name_space.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/mini_site_name_space.html
@@ -4,7 +4,7 @@
 
 
 {% block minisite_title_mb %}
-  {% if singleton_page == False %}
+  {% if uses_menu %}
   <div class="container">
     <div class="row">
       <div class="col-12 mt-3">
@@ -20,7 +20,7 @@
 
 
 {% block mini_site_title %}
-  {% if singleton_page == False %}
+  {% if uses_menu %}
     <p class="h5-heading hidden-sm-down">{{ mini_site_title }}</p>
   {% endif %}
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -19,6 +19,9 @@ def get_page_tree_information(page, context):
     has_children = len(children) > 0
     context['singleton_page'] = (is_top_page and not has_children)
 
+    mchildren = root.get_children().live().in_menu()
+    context['uses_menu'] = len(mchildren) > 0
+
     return context
 
 


### PR DESCRIPTION
fixes https://github.com/mozilla/foundation.mozilla.org/issues/1373