### PR TITLE
fix layout quirk for campaign pages with not-in-menu children

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/campaign_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/campaign_page.html
@@ -3,7 +3,7 @@
 
 {% block subcontent %}
 <div class="row">
-    <div class="cms {% if page.cta and singleton_page == True %}col-md-6{% else %}col-12{% endif %}">
+    <div class="cms {% if page.cta and uses_menu == False %}col-md-6{% else %}col-12{% endif %}">
     {% block html_content %}
         {% for block in page.body %}
 	        {% if block.block_type == 'heading' %}


### PR DESCRIPTION
We forgot to switch over to `use_menu` for campaigns as well as minisite pages when the `use_menus` context variable landed.

fixes https://github.com/mozilla/foundation.mozilla.org/issues/1398
