### PR TITLE
Bring back most updated version of styleguide

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/static/styleguide.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/static/styleguide.html
@@ -4,247 +4,238 @@
 {% block bodyID %}style-guide{% endblock%}
 
 {% block content %}
-<div class="container">
-    <div class="row">
-      <div class="col-12 pb-5">
-        <h1>Style Guide</h1>
-        <h2>Colors</h2>
-        <div class="row">
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 black"></div>
-              <div class="p-2"><strong>Black ($black)</strong>
-                <div class="color-code small">#000000</div>
-                <div class="color-code small">rgba(0, 0, 0, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 white"></div>
-              <div class="p-2"><strong>White ($white)</strong>
-                <div class="color-code small">#ffffff</div>
-                <div class="color-code small">rgba(255, 255, 255, 1)</div>
-              </div>
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-12 pb-5">
+      <h1>Style Guide</h1>
+      <h2>Colors</h2>
+      <div class="row">
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 black"></div>
+            <div class="p-2"><strong>Black ($black)</strong>
+              <div class="color-code small">#000000</div>
+              <div class="color-code small">rgba(0, 0, 0, 1)</div>
             </div>
           </div>
         </div>
-        <div class="row">
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 dark-gray"></div>
-              <div class="p-2"><strong>Dark Gray ($dark-gray)</strong>
-                <div class="color-code small">#666666</div>
-                <div class="color-code small">rgb(102, 102, 102, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 medium-gray"></div>
-              <div class="p-2"><strong>Medium Gray ($medium-gray)</strong>
-                <div class="color-code small">#909090</div>
-                <div class="color-code small">rgba(144, 144, 144, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 light-gray"></div>
-              <div class="p-2"><strong>Light Gray ($light-gray)</strong>
-                <div class="color-code small">#cccccc</div>
-                <div class="color-code small">rgba(204, 204, 204, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 subtle-gray"></div>
-              <div class="p-2"><strong>Subtle Gray ($subtle-gray)</strong>
-                <div class="color-code small">#f2f2f2</div>
-                <div class="color-code small">rgba(242, 242, 242, 1)</div>
-              </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 white"></div>
+            <div class="p-2"><strong>White ($white)</strong>
+              <div class="color-code small">#ffffff</div>
+              <div class="color-code small">rgba(255, 255, 255, 1)</div>
             </div>
           </div>
         </div>
-        <div class="row">
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 yellow"></div>
-              <div class="p-2"><strong>Yellow ($yellow)</strong>
-                <div class="color-code small">#ffed00</div>
-                <div class="color-code small">rgba(255, 237, 0, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 dark-yellow"></div>
-              <div class="p-2"><strong>Dark Yellow ($dark-yellow)</strong>
-                <div class="color-code small">#e7c121</div>
-                <div class="color-code small">rgba(231, 193, 33, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 blue"></div>
-              <div class="p-2"><strong>Blue ($blue)</strong>
-                <div class="color-code small">#3bb7ef</div>
-                <div class="color-code small">rgba(59, 183, 239, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 dark-blue"></div>
-              <div class="p-2"><strong>Dark Blue ($dark-blue)</strong>
-                <div class="color-code small">#4383bf</div>
-                <div class="color-code small">rgba(67, 131, 191, 1)</div>
-              </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 dark-gray"></div>
+            <div class="p-2"><strong>Dark Gray ($dark-gray)</strong>
+              <div class="color-code small">#666666</div>
+              <div class="color-code small">rgb(102, 102, 102, 1)</div>
             </div>
           </div>
         </div>
-        <div class="row">
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 neon-blue"></div>
-              <div class="p-2"><strong>Neon Blue ($neon-blue)</strong>
-                <div class="color-code small">#3dfefd</div>
-                <div class="color-code small">rgba(61, 254, 253, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 green"></div>
-              <div class="p-2"><strong>Green ($green)</strong>
-                <div class="color-code small">#b7d43f</div>
-                <div class="color-code small">rgba(183, 212, 63, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 neon-blue-green-gradient"></div>
-              <div class="p-2"><strong>Neon Blue Green Gradient ($neon-blue-green-gradient)</strong>
-                <div class="color-code small">#3dfefd to #b7d43f</div>
-                <div class="color-code small">rgba(61, 254, 253, 1) to rgba(183, 212, 63, 1)</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-3 mb-3">
-            <div class="color-display d-flex flex-column h-100">
-              <div class="color-block w-100 px-2 py-5 bright-green"></div>
-              <div class="p-2"><strong>Bright Green ($bright-green)</strong>
-                <div class="color-code small">#b6d806</div>
-                <div class="color-code small">rgba(182, 216, 6, 1)</div>
-              </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 medium-gray"></div>
+            <div class="p-2"><strong>Medium Gray ($medium-gray)</strong>
+              <div class="color-code small">#909090</div>
+              <div class="color-code small">rgba(144, 144, 144, 1)</div>
             </div>
           </div>
         </div>
-        <h2>Typography</h2>
-        <h3 class="my-5">Headers</h3>
-        <div class="py-2">
-          <h1 class="h1-white">.h1-white</h1>
-        </div>
-        <div class="py-2">
-          <h2 class="h2-headings-white">.h2-headings-white</h2>
-        </div>
-        <div class="py-2">
-          <h2 class="h2-typeaccents-gray">.h2-typeaccents-gray</h2>
-        </div>
-        <div class="py-2">
-          <h3 class="h3-black">.h3-black</h3>
-        </div>
-        <div class="py-2">
-          <h3 class="h3-cta-black">.h3-cta-black</h3>
-        </div>
-        <div class="py-2">
-          <h4 class="h4-medium-black">.h4-medium-black</h4>
-        </div>
-        <div class="py-2">
-          <h4 class="h4-light-black">.h4-light-black</h4>
-        </div>
-        <div class="py-2">
-          <h4 class="h4-headingcontract-black">.h4-headingcontract-black</h4>
-        </div>
-        <div class="py-2">
-          <h5 class="h5-black">.h5-black</h5>
-        </div>
-        <div class="py-2">
-          <h6 class="h6-gray">.h6-gray</h6>
-        </div>
-        <h3 class="my-5">Paragraphs</h3>
-        <div class="py-2">
-          <p class="lead-black">.lead-black</p>
-        </div>
-        <div class="py-2">
-          <p class="quote-small">.quote-small</p>
-        </div>
-        <div class="py-2">
-          <p class="body-black">.body-black</p>
-        </div>
-        <div class="py-2">
-          <p class="italic-black">.italic-black</p>
-        </div>
-        <div class="py-2">
-          <p class="small-gray">.small-gray</p>
-        </div>
-        <h3 class="my-5">Anchors</h3>
-        <div class="py-2"><a class="body-link" href="#">.body-link</a></div>
-        <div class="py-2"><a class="cta-link" href="#">.cta-link</a></div>
-        <h3 class="my-5">Buttons</h3>
-        <div class="py-2">
-          <button class="btn btn-ghost">.btn-ghost</button>
-        </div>
-        <div class="py-2">
-          <button class="btn btn-normal">.btn-normal</button>
-        </div>
-        <div class="py-2">
-          <button class="btn btn-pop">.btn-pop</button>
-        </div>
-        <h3 class="my-5">Components</h3>
-        <h4>.jump-bar</h4>
-        <ul class="jump-bar mb-3">
-          <li class="no-link">Featured</li>
-          <li><a href="https://www.mozillapulse.org/issues/online-privacy-and-security">Privacy & Security</a></li>
-          <li><a href="https://www.mozillapulse.org/search?keyword=mozfest">Mozfest</a></li>
-          <li><a href="https://www.mozillapulse.org/issues/open-innovation">Open Innovation</a></li>
-        </ul>
-        <h4>.hr-gradient</h4>
-        <hr class="hr-gradient">
-        <h4>.join-us</h4>
-        <div class="join-us mb-5"></div>
-        <h4 class="h5">.pulse-project-list(for="SEARCH_QUERY", size="MAX_TO_DISPLAY", rev="BOOLEAN_TO_INDICATE_ORDERING")</h4>
-        <div class="pulse-project-list" for="mozfest" size="6" rev="false"></div>
-        <h4>.feature-quote
-          <div class="feature-quote">
-            <h3>We want to give users the knowledge and the power to make informed decisions by themselves to prevent abusive practices.</h3>
-            <p class="h6-gray">Rishab Nithyanand, Mozilla Fellow</p>
-          </div>
-        </h4>
-        <h4>multipage-nav (used as secondary nav )</h4>
-        <div class="hidden-md-up" id="multipage-nav-mobile">
-          <div class="container">
-            <div class="row">
-              <div class="col-12"></div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 light-gray"></div>
+            <div class="p-2"><strong>Light Gray ($light-gray)</strong>
+              <div class="color-code small">#cccccc</div>
+              <div class="color-code small">rgba(204, 204, 204, 1)</div>
             </div>
           </div>
         </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 subtle-gray"></div>
+            <div class="p-2"><strong>Subtle Gray ($subtle-gray)</strong>
+              <div class="color-code small">#f2f2f2</div>
+              <div class="color-code small">rgba(242, 242, 242, 1)</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 yellow"></div>
+            <div class="p-2"><strong>Yellow ($yellow)</strong>
+              <div class="color-code small">#ffed00</div>
+              <div class="color-code small">rgba(255, 237, 0, 1)</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 dark-yellow"></div>
+            <div class="p-2"><strong>Dark Yellow ($dark-yellow)</strong>
+              <div class="color-code small">#e7c121</div>
+              <div class="color-code small">rgba(231, 193, 33, 1)</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 blue"></div>
+            <div class="p-2"><strong>Blue ($blue)</strong>
+              <div class="color-code small">#3bb7ef</div>
+              <div class="color-code small">rgba(59, 183, 239, 1)</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 dark-blue"></div>
+            <div class="p-2"><strong>Dark Blue ($dark-blue)</strong>
+              <div class="color-code small">#4383bf</div>
+              <div class="color-code small">rgba(67, 131, 191, 1)</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 neon-blue"></div>
+            <div class="p-2"><strong>Neon Blue ($neon-blue)</strong>
+              <div class="color-code small">#3dfefd</div>
+              <div class="color-code small">rgba(61, 254, 253, 1)</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 green"></div>
+            <div class="p-2"><strong>Green ($green)</strong>
+              <div class="color-code small">#b7d43f</div>
+              <div class="color-code small">rgba(183, 212, 63, 1)</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 neon-blue-green-gradient"></div>
+            <div class="p-2"><strong>Neon Blue Green Gradient ($neon-blue-green-gradient)</strong>
+              <div class="color-code small">#3dfefd to #b7d43f</div>
+              <div class="color-code small">rgba(61, 254, 253, 1) to rgba(183, 212, 63, 1)</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-3 mb-3">
+          <div class="color-display d-flex flex-column h-100">
+            <div class="color-block w-100 px-2 py-5 bright-green"></div>
+            <div class="p-2"><strong>Bright Green ($bright-green)</strong>
+              <div class="color-code small">#b6d806</div>
+              <div class="color-code small">rgba(182, 216, 6, 1)</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2>Typography</h2>
+      <h3 class="my-5">Headers</h3>
+      <div class="py-2">
+        <h1 class="h1-heading">.h1-heading</h1>
+      </div>
+      <div class="py-2">
+        <h2 class="h2-heading">.h2-heading</h2>
+      </div>
+      <div class="py-2">
+        <h2 class="h2-typeaccent">.h2-typeaccent</h2>
+      </div>
+      <div class="py-2">
+        <h3 class="h3-heading">.h3-heading</h3>
+      </div>
+      <div class="py-2">
+        <h4 class="h4-heading">.h4-heading</h4>
+      </div>
+      <div class="py-2">
+        <h5 class="h5-heading">.h5-heading</h5>
+      </div>
+      <div class="py-2">
+        <h6 class="h6-heading-uppercase">.h6-heading-uppercase</h6>
+      </div>
+      <div class="py-2">
+        <h6 class="h6-heading">.h6-heading</h6>
+      </div>
+      <h3 class="my-5">Paragraphs</h3>
+      <div class="py-2">
+        <p class="body-large">.body-large</p>
+      </div>
+      <div class="py-2">
+        <p class="quote-small">.quote-small</p>
+      </div>
+      <div class="py-2">
+        <p class="quote-feature">.quote-feature</p>
+      </div>
+      <div class="py-2">
+        <p class="normal">.normal</p>
+      </div>
+      <h3 class="my-5">Anchors</h3>
+      <div class="py-2"><a class="body-link" href="#">.body-link</a></div>
+      <div class="py-2"><a class="cta-link" href="#">.cta-link</a></div>
+      <h3 class="my-5">Buttons</h3>
+      <div class="py-2">
+        <button class="btn btn-ghost">.btn-ghost</button>
+      </div>
+      <div class="py-2">
+        <button class="btn btn-normal">.btn-normal</button>
+      </div>
+      <div class="py-2">
+        <button class="btn btn-pop">.btn-pop</button>
+      </div>
+      <h3 class="my-5">Components</h3>
+      <h4>.jump-bar</h4>
+      <ul class="jump-bar mb-3">
+        <li class="no-link">Featured</li>
+        <li><a href="https://www.mozillapulse.org/issues/online-privacy-and-security">Privacy & Security</a></li>
+        <li><a href="https://www.mozillapulse.org/search?keyword=mozfest">Mozfest</a></li>
+        <li><a href="https://www.mozillapulse.org/issues/open-innovation">Open Innovation</a></li>
+      </ul>
+      <h4>.hr-gradient</h4>
+      <hr class="hr-gradient">
+      <h4>.join-us</h4>
+      <div class="join-us mb-5"></div>
+      <h4 class="h5">.pulse-project-list(for="SEARCH_QUERY", size="MAX_TO_DISPLAY", rev="BOOLEAN_TO_INDICATE_ORDERING")</h4>
+      <div class="pulse-project-list" for="mozfest" size="6" rev="false"></div>
+      <h4>.feature-quote
+        <div class="feature-quote">
+          <h3>We want to give users the knowledge and the power to make informed decisions by themselves to prevent abusive practices.</h3>
+          <p class="h6-heading-uppercase">Rishab Nithyanand, Mozilla Fellow</p>
+        </div>
+      </h4>
+      <h4>multipage-nav (used as secondary nav )</h4>
+      <div class="hidden-md-up" id="multipage-nav-mobile">
         <div class="container">
           <div class="row">
-            <div class="col-12 hidden-sm-down">
-              <div class="multipage-nav" id="multipage-nav">
-                <div><a class="multipage-link" href="/">Home</a></div>
-                <div><a class="multipage-link" href="/about">About</a></div>
-                <div><a class="multipage-link multipage-link-active" href="/style-guide">Style Guide</a></div>
-                <div><a class="multipage-link" href="/sign-up">Sign Up</a></div>
-              </div>
+            <div class="col-12"></div>
+          </div>
+        </div>
+      </div>
+      <div class="container">
+        <div class="row">
+          <div class="col-12 hidden-sm-down">
+            <div class="multipage-nav" id="multipage-nav">
+              <div><a class="multipage-link" href="/">Home</a></div>
+              <div><a class="multipage-link" href="/about">About</a></div>
+              <div><a class="multipage-link multipage-link-active" href="/style-guide">Style Guide</a></div>
+              <div><a class="multipage-link" href="/sign-up">Sign Up</a></div>
             </div>
           </div>
         </div>
       </div>
     </div>
   </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
Fixes #1387 

Looks like the updates to the guide hadn't landed on master yet when I made the wagtail version of the pages. I just copied the markup of the guide from the commit right before we did the switch, so this should be the latest version of the guide markup available.