### PR TITLE
make homepage news and highlights reorderable

### DIFF
--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -377,6 +377,7 @@ class HomepageFeaturedNews(WagtailOrderable, models.Model):
     class Meta:
         verbose_name = 'news'
         verbose_name_plural = 'news'
+        ordering = ['sort_order'] # not automatically inherited!
 
     def __str__(self):
         return self.page.title + '->' + self.news.headline
@@ -395,6 +396,7 @@ class HomepageFeaturedHighlights(WagtailOrderable, models.Model):
     class Meta:
         verbose_name = 'highlight'
         verbose_name_plural = 'highlights'
+        ordering = ['sort_order'] # not automatically inherited!
 
     def __str__(self):
         return self.page.title + '->' + self.highlight.title

--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -377,7 +377,7 @@ class HomepageFeaturedNews(WagtailOrderable, models.Model):
     class Meta:
         verbose_name = 'news'
         verbose_name_plural = 'news'
-        ordering = ['sort_order'] # not automatically inherited!
+        ordering = ['sort_order']  # not automatically inherited!
 
     def __str__(self):
         return self.page.title + '->' + self.news.headline
@@ -396,7 +396,7 @@ class HomepageFeaturedHighlights(WagtailOrderable, models.Model):
     class Meta:
         verbose_name = 'highlight'
         verbose_name_plural = 'highlights'
-        ordering = ['sort_order'] # not automatically inherited!
+        ordering = ['sort_order']  # not automatically inherited!
 
     def __str__(self):
         return self.page.title + '->' + self.highlight.title


### PR DESCRIPTION
We were missing an explicit ordering in the `Meta` class.

This fixes https://github.com/mozilla/foundation.mozilla.org/issues/1371