### PR TITLE
fixes the campaign template content classes

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/mini_site_name_space.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/mini_site_name_space.html
@@ -18,13 +18,13 @@
 
 {% block heading_classes %}
   py-5
-  {% if singleton_page %}
+  {% if uses_menu == False %}
     col-{% if page.specific.narrowed_page_content %}md-8
-      offset-md-{% if singleton_page == False %}0{% else %}2{% endif %}{% else %}12{% endif %}
+      offset-md-2{% else %}12{% endif %}
     col-lg-10 offset-lg-1
   {% else %}
     col-{% if page.specific.narrowed_page_content %}md-8
-      offset-md-{% if singleton_page == False %}0{% else %}2{% endif %}{% else %}12{% endif %}
+      offset-md-0{% else %}12{% endif %}
     col-md-9
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
fixes #1418
fixes #1422 

This PR fixes a silly class code error in the campaign template that went wrong in https://github.com/mozilla/foundation.mozilla.org/commit/3a10a69270090d6a4e745d327a58c54cf288820a#diff-4a150ee1cd0f35515268680729ac5ed5R21

This fixes all four cases:

# 1: singleton page (e.g. equifax)

![screenshot 320](https://user-images.githubusercontent.com/177243/38966370-c98728dc-4336-11e8-90f6-c0928c92a665.png)

# 2: page with children, but none of them in-menu (e.g. facebook)

![screenshot 321](https://user-images.githubusercontent.com/177243/38966368-c77a78e6-4336-11e8-841a-363eebc3d262.png)

# 3: page with children, with menu (e.g. aadhaar)

![image](https://user-images.githubusercontent.com/177243/38966388-d811952c-4336-11e8-9d6e-dcf8e591eb07.png)

# 4: page on a menu'd "minisite" but set to "narrowed content" (e.g. aadhaar "take action")

![image](https://user-images.githubusercontent.com/177243/38966392-dee1c6f6-4336-11e8-89a0-4d3b5ddea3ff.png)


