### PR TITLE
Add missing migrations test

### DIFF
--- a/network-api/networkapi/tests.py
+++ b/network-api/networkapi/tests.py
@@ -1,3 +1,4 @@
+from django.core.management import call_command
 from django.test import TestCase
 from unittest.mock import MagicMock
 
@@ -18,3 +19,12 @@ class ReferrerMiddlewareTests(TestCase):
 
         response = self.middleware.process_response(self.request, self.response)
         response.__setitem__.assert_called_with('Referrer-Policy', 'same-origin')
+
+
+class MissingMigrationsTests(TestCase):
+
+    def test_no_migrations_missing(self):
+        """
+        Ensure we didn't forget a migration
+        """
+        call_command('makemigrations', interactive=False, dry_run=True, check_changes=True)


### PR DESCRIPTION
Related issue: A few review apps failed their release steps because of missing migrations.
Summary: Add one test that will fail if we're missing one or more migrations.

The missing migration is [already addressed](https://github.com/mozilla/foundation.mozilla.org/commit/dc4997a6b69d0cae94fd365f13e4542f248b06f2).