### PR TITLE
Fix project list block

### DIFF
--- a/network-api/networkapi/wagtailpages/customblocks.py
+++ b/network-api/networkapi/wagtailpages/customblocks.py
@@ -224,7 +224,7 @@ class PulseProjectQueryValue(blocks.StructValue):
         return query
 
     @property
-    def max(self):
+    def size(self):
         max_number_of_results = self['max_number_of_results']
         return '' if max_number_of_results <= 0 else max_number_of_results
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
@@ -1,7 +1,7 @@
 <div
   class="pulse-project-list"
-  query="{{ value.query }}"
-  max="{{ value.max }}"
+  for="{{ value.query }}"
+  size="{{ value.size }}"
   rev="{{ value.rev }}"
   featured="{{ value.only_featured_entries}}"
 ></div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
@@ -3,5 +3,5 @@
   for="{{ value.query }}"
   size="{{ value.size }}"
   rev="{{ value.rev }}"
-  featured="{{ value.only_featured_entries}}"
+  checked="{{ value.only_featured_entries}}"
 ></div>

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -286,7 +286,7 @@ let main = {
           env={env}
           query={ target.getAttribute(`for`) || '' }
           reverseChronological={ !!target.getAttribute(`rev`) && target.getAttribute(`rev`) !== `False` }
-          featured={ !!target.getAttribute(`featured`) && target.getAttribute(`featured`) !== `False` }
+          featured={ !!target.getAttribute(`checked`) && target.getAttribute(`checked`) !== `False` }
           max={parseInt(target.getAttribute(`size`), 10) || null} />,
         target
       );

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -284,10 +284,10 @@ let main = {
       return ReactDOM.render(
         <PulseProjectList
           env={env}
-          query={target.getAttribute(`for`) || target.getAttribute(`query`)}
+          query={ target.getAttribute(`for`) || '' }
           reverseChronological={ !!target.getAttribute(`rev`) && target.getAttribute(`rev`) !== `False` }
           featured={ !!target.getAttribute(`featured`) && target.getAttribute(`featured`) !== `False` }
-          max={parseInt(target.getAttribute(`max`), 10) || null} />,
+          max={parseInt(target.getAttribute(`size`), 10) || null} />,
         target
       );
     });

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -284,7 +284,7 @@ let main = {
       return ReactDOM.render(
         <PulseProjectList
           env={env}
-          query={ target.getAttribute(`for`) || '' }
+          query={ target.getAttribute(`for`) || `` }
           reverseChronological={ !!target.getAttribute(`rev`) && target.getAttribute(`rev`) !== `False` }
           featured={ !!target.getAttribute(`checked`) && target.getAttribute(`checked`) !== `False` }
           max={parseInt(target.getAttribute(`size`), 10) || null} />,


### PR DESCRIPTION
Both the pulse entry listing block and the changes to main.js for that had some weirdness.

This should show pulse entries on:
- http://localhost:8000/ (6 of them)
- http://localhost:8000/style-guide/ (6 of them)
- http://localhost:8000/opportunity/global-sprint/2018-projects/ (lots of them)