### PR TITLE
Fix #1446 - Use wagtail petition model for POSTing to a petition

### DIFF
--- a/network-api/networkapi/campaign/views.py
+++ b/network-api/networkapi/campaign/views.py
@@ -9,7 +9,7 @@ import boto3
 import logging
 import json
 
-from networkapi.campaign.models import Petition
+from networkapi.wagtailpages.models import Petition
 
 if settings.AWS_SQS_ACCESS_KEY_ID:
     sqs = boto3.client(


### PR DESCRIPTION
We were using the wrong model to get petition data. Hence, petitions could not be signed. This fixes that.