### PR TITLE
pip3 instead of just pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 **Requirements**: [Node](https://nodejs.org), [npm](https://www.npmjs.com/), [git](https://git-scm.com/), [python3.6 or later](https://www.python.org/), [pip](https://pypi.python.org/pypi), [pipenv](https://docs.pipenv.org/), [invoke](http://www.pyinvoke.org/installing.html).
 
+If you installed [Python with Homebrew](https://docs.brew.sh/Homebrew-and-Python), use `pip3 install` instead of `pip install` when installing the relevant requirements.
+
 ### Check your environment
 
 - `python --version` should return 3.6 or higher,


### PR DESCRIPTION
Someone ran into an issue of invoke using python 2.7 on MacOs instead of python 3.

From [Python Homebrew page](https://docs.brew.sh/Homebrew-and-Python):

```
pip3 points to Homebrew’s Python 3.x’s pip (if installed)
pip and pip2 point to Homebrew’s Python 2.7.x’s pip (if installed)
```