### PR TITLE
Fixed fellowships broken links

### DIFF
--- a/network-api/networkapi/fellows/templates/contact_banner.html
+++ b/network-api/networkapi/fellows/templates/contact_banner.html
@@ -1,5 +1,5 @@
 <hr class="my-2">
 <div class="opp-foot d-flex align-items-center"><img class="mr-3" src="/_images/fellowships/svg/mini_contact_us-fellows-with-gradient.svg" width="47" height="42">
-  <p class="mb-0">Any further questions about fellowships at Mozilla? Please check out our <a href="/opportunity/fellowships">FAQ page</a> or <a href="mailto:fellowships@mozillafoundation.org">contact us</a>.</p>
+  <p class="mb-0">Any further questions about fellowships at Mozilla? Please check out our <a href="/opportunity/fellowships-faq">FAQ page</a> or <a href="mailto:fellowships@mozillafoundation.org">contact us</a>.</p>
 </div>
 <hr class="my-2">

--- a/network-api/networkapi/fellows/templates/fellows_home.html
+++ b/network-api/networkapi/fellows/templates/fellows_home.html
@@ -80,7 +80,7 @@
       <div class="col-md-9">
         <p>Mozilla Fellowships provide resources, tools, community and amplification to those building a more ​humane​ ​digital​ ​world. During their tenure, Fellows use their skill sets — in technology, in advocacy, in law — to design products, run campaigns, influence policy and ultimately lay the groundwork for a more open and inclusive internet.</p>
         <p>Mozilla Fellows hail from a range of disciplines and geographies: They are policymakers in Kenya, journalists in Brazil, engineers in Germany, privacy activists in the United States, and data scientists in the Netherlands. Fellows work on individual projects, but also collaborate on cross-disciplinary solutions to the internet’s biggest challenges. Fellows are awarded competitive compensation and benefits.</p>
-        <p><strong>For additional details about Mozilla Fellowships, visit our <a href="/opportunity/fellowships">Fellowship FAQ</a></strong>.</p>
+        <p><strong>For additional details about Mozilla Fellowships, visit our <a href="/opportunity/fellowships-faq">Fellowship FAQ</a></strong>.</p>
       </div>
     </div>
   </div>
@@ -151,7 +151,7 @@
           <li>Design impactful projects with the potential to reach millions. <a href="https://{{pulse_domain}}/featured">See what Fellows and their collaborators are working on</a>.</li>
           <li>Learn from and collaborate with a global community of Mozillians. <a href="https://www.mozilla.org/contribute/">Meet more than 10,000 Mozilla contributors around the world</a>.</li>
         </ul>
-        <p class="mt-4">Any further questions about Fellowships at Mozilla? Please check out our <a href="/opportunity/fellowships">FAQ page</a> or <a href="mailto:fellowships@mozillafoundation.org">contact us</a>.</p>
+        <p class="mt-4">Any further questions about Fellowships at Mozilla? Please check out our <a href="/opportunity/fellowships-faq">FAQ page</a> or <a href="mailto:fellowships@mozillafoundation.org">contact us</a>.</p>
       </div>
       <div class="col-md-6 mb-4 mb-md-0">
         <img src="/_images/fellowships/group-fellows-overview-page-cropped@2x.jpg">


### PR DESCRIPTION
Related to #1450

https://foundation-mofostaging-pr-1458.herokuapp.com/fellowships/

Next, after pushing this fix to prod:

set up a redirect in the wagtail admin for /opportunity/fellowships/ to go to /fellowships