### PR TITLE
"inv manage" tasks now support optional and positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ But it's a bit long. So instead, you can use invoke:
 - `inv setup`: Prepare your dev environment after a fresh git clone
 - `inv test`: Run tests
 
-For management commands not covered by an invoke tasks, use `inv manage [command]` (example: `inv manage load_fake_data`).
-
-Invoke tasks don't take options: use `pipenv run` instead (example: `pipenv run python network-api/manage.py runserver 3000`)
+For management commands not covered by an invoke tasks, use `inv manage [command]` (example: `inv manage load_fake_data`). You can pass flag and options to management commands using `inv manage [command] -o [positional argument] -f [optional argument]`. For example:
+- `inv manage runserver -o 3000`
+- `inv manage load_fake_data -f seed=VALUE`
+- `inv manage migrate -o news`
 
 ### Generating a new set of fake model data
 

--- a/tasks.py
+++ b/tasks.py
@@ -10,11 +10,16 @@ os.environ.pop('__PYVENV_LAUNCHER__', None)
 ROOT = os.path.dirname(os.path.realpath(__file__))
 
 
-@task
-def manage(ctx, command):
+@task(optional=['option', 'flag'])
+def manage(ctx, command, option=None, flag=None):
     """Shorthand to manage.py"""
     with ctx.cd(ROOT):
-        ctx.run(f"pipenv run python network-api/manage.py {command}")
+        if option:
+            ctx.run(f"pipenv run python network-api/manage.py {command} {option}")
+        elif flag:
+            ctx.run(f"pipenv run python network-api/manage.py {command} --{flag}")
+        else:
+            ctx.run(f"pipenv run python network-api/manage.py {command}")
 
 
 @task


### PR DESCRIPTION
I added support for optional (flags) and positional arguments for management commands called using `inv manage [COMMAND]`. The pattern is: `inv manage [command] -o [positional argument] -f [optional argument]`.

For example, now you can do `inv manage makemigrations -f merge` or `inv manage runserver -o 3000`.

If you don't want to pass args, you can still use `inv makemigrations` or any of the previous tasks.