### PR TITLE
Set video embed aspect ratio to 16:9

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/iframe_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/iframe_block.html
@@ -1,5 +1,6 @@
 {% load wagtailcore_tags %}
 
+{% block wrapper_open_tag %}{% endblock %}
 <iframe
     width="100%"
     height="{{ value.height }}"
@@ -7,3 +8,4 @@
     frameborder="0"
     {% block embed_specifics %}{% endblock %}
 ></iframe>
+{% block wrapper_close_tag %}{% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/iframe_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/iframe_block.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 
-{% block wrapper_open_tag %}{% endblock %}
+{% block wrapper_opening_tag %}{% endblock %}
 <iframe
     width="100%"
     height="{{ value.height }}"
@@ -8,4 +8,4 @@
     frameborder="0"
     {% block embed_specifics %}{% endblock %}
 ></iframe>
-{% block wrapper_close_tag %}{% endblock %}
+{% block wrapper_closing_tag %}{% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/video_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/video_block.html
@@ -2,7 +2,16 @@
 
 {% load wagtailcore_tags %}
 
+{% block wrapper_opening_tag %}
+<div class="embed-responsive embed-responsive-16by9">
+{% endblock %}
+
+{% block wrapper_closing_tag %}
+</div>
+{% endblock %}
+
 {% block embed_specifics %}
+    class="embed-responsive-item"
     allow="autoplay; encrypted-media"
     allowfullscreen
 {% endblock %}


### PR DESCRIPTION
Related to #1376

YouTube and Vimeo videos are all in 16x9 so I think we are good to just force that ratio on the embed too.