### PR TITLE
Remove useless step in 'inv setup" + add flake8 to `inv test`

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -43,6 +43,9 @@ def makemigrations(ctx):
 @task
 def test(ctx):
     """Run tests"""
+    print("Running flake8")
+    ctx.run(f"pipenv run flake8 network-api")
+    print("Running tests")
     manage(ctx, "test")
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -58,8 +58,6 @@ def setup(ctx):
         ctx.run("pipenv install --dev")
         print("Applying database migrations.")
         ctx.run("inv migrate")
-        print("Updating the site domain.")
-        ctx.run("inv manage update_site_domain")
         print("Creating superuser.")
         # Windows doesn't support pty, skipping this step
         if platform == 'win32':


### PR DESCRIPTION
Related issue: #1528
Summary:
- Fix bug in `inv setup` (the management command `update_site_domain` was remove in PR #1509)
- `inv test` now also run flake8