### PR TITLE
Only hide title if we're using a menu, not when we have children page…

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/mini_site_name_space.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/mini_site_name_space.html
@@ -38,7 +38,7 @@
 
 
 {% block h1 %}
-  <h1 class="h1-heading {% if singleton_page == False %}hidden-sm-down{% endif %}">
+  <h1 class="h1-heading {% if uses_menu %}hidden-sm-down{% endif %}">
   {% if page.header %}
     {{ page.header }}
   {% else %}


### PR DESCRIPTION
…s, because if a parent page has children that are all told to not be displayed in the menu, we end up with no menu, thus no title.

Related issue:
Summary:

If you don't know who to ask for a review, try @alanmoo or @xmatthewx. If you do, please delete this line.
