### PR TITLE
Add the "this is a draft" notice back in.

### DIFF
--- a/network-api/networkapi/templates/pages/base-compiled.html
+++ b/network-api/networkapi/templates/pages/base-compiled.html
@@ -14,6 +14,7 @@
     <title>{% block pageTitle %}Mozilla Foundation - {{ page.meta_title }}{% endblock %}</title>
   </head>
   <body id="view-{% block bodyID %}{% endblock %}">
+    {% block page_top_content %}{% endblock %}
     <div class="takeover"></div>
     <div class="wrapper">
       <div id="member-notice">{% if page.status == 1 %}<div><strong>Draft preview.</strong> You must save as Published to make it public.</div>{% endif %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/modular_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/modular_page.html
@@ -8,9 +8,15 @@
     {% meta_tags %}
 {% endblock %}
 
-{% block content %}
-  {% block minisite_title_mb %}{% endblock %}
+{% block page_top_content %}
+  {% if page.live == False %}
+  <div class="wagtail-draft-warning">
+    This is a draft page, and is only visible to users who are logged in to the CMS admin.
+  </div>
+  {% endif %}
+{% endblock %}
 
+{% block content %}
   <div class="hidden-md-up" id="multipage-nav-mobile">
     <div class="container">
       <div class="row px-3">

--- a/source/sass/wagtail.scss
+++ b/source/sass/wagtail.scss
@@ -75,3 +75,10 @@
   font-size: inherit;
   line-height: inherit;
 }
+
+body div.wagtail-draft-warning {
+  background: #faf2cc;
+  text-align: center;
+  font-weight: bold;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
The draft warning apparently got lost during the mezzanine->wagtail migration, this adds it back in.

![image](https://user-images.githubusercontent.com/177243/40736999-62086822-63f4-11e8-8be5-8a4ce577d296.png)
