### PR TITLE
May be fixing a bug where minisite title was removed on mobile.

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/modular_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/modular_page.html
@@ -17,6 +17,7 @@
 {% endblock %}
 
 {% block content %}
+  {% block minisite_title_mb %}{% endblock %}
   <div class="hidden-md-up" id="multipage-nav-mobile">
     <div class="container">
       <div class="row px-3">


### PR DESCRIPTION
While testing https://github.com/mozilla/foundation.mozilla.org/pull/1571 I noticed this bug.

If you go to a modular page, the header is gone on mobile. Example: https://screenshots.firefox.com/9Agx181o3tNFWFfk/foundation.mozilla.org

Should look like this: https://screenshots.firefox.com/g2cKSnvKVbu0u8TP/foundation.mozilla.org

I tracked it down to probably an oversight in https://github.com/mozilla/foundation.mozilla.org/commit/6e3cda7f5ede20bc66886c47b0efc45b29975a47 where it looks like the header got removed. I'm first trying to add it back, as I don't see a reason as to why it was removed.