### PR TITLE
Update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - pip install --upgrade pip
 - pip install pipenv
 - pipenv install --dev
-- npm ci # use package-lock.json
+- npm install # use package-lock.json
 - pipenv run python network-api/manage.py collectstatic --no-input
 before_script:
 - psql -c 'create database network;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
 - pip install --upgrade pip
 - pip install pipenv
 - pipenv install --dev
-- npm install -g npm@latest # Needed to use npm ci
 - npm ci # use package-lock.json
 - pipenv run python network-api/manage.py collectstatic --no-input
 before_script:


### PR DESCRIPTION
Ref: MozillaFoundation/mofo-devops#597
Removing npm update since Travis now support `npm ci` out of the box.
