### PR TITLE
Python version bump (Heroku)

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.4
+python-3.6.5


### PR DESCRIPTION
Fix warning:
```
 !     The latest version of Python 3 is python-3.6.5 (you are using python-3.6.4, which is unsupported).
 !     We recommend upgrading by specifying the latest version (python-3.6.5).
```