### PR TITLE
refine email validation RE based on user feedback

### DIFF
--- a/source/js/components/petition/petition.jsx
+++ b/source/js/components/petition/petition.jsx
@@ -345,7 +345,7 @@ export default class Petition extends React.Component {
     if (!input) {
       return false;
     }
-    return input.match(/[^@]+@[^@]+/) !== null;
+    return input.match(/[^@]+@[^.@]+(\.[^.@]+)+$/) !== null;
   }
 
   /**


### PR DESCRIPTION
CRM team would like a slightly tighter RE. This update:
- ensures there is only one `@` symbol
- requires a word-dot-word minimum as mailing domain (no max on the number of dot-word pairs after the first word)