### PR TITLE
restrict anonymous users to public, live pages.

### DIFF
--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -44,10 +44,10 @@ def get_descendants(node, list, authenticated=False, depth=0, max_depth=2):
 
         nextset = node.get_children().in_menu()
 
-        # Do not show draft pages to users who are
+        # Do not show draft/private pages to users who are
         # not logged into the CMS itself.
         if authenticated is False:
-            nextset = nextset.live()
+            nextset = nextset.live().public()
 
         for child in nextset:
             get_descendants(child, list, authenticated, depth + 1)


### PR DESCRIPTION
This was set to just `.live()` before, which meant anonymous users could see menu items for pages that were marked as private. This fix adds in an extra queryset restriction to prevent private pages from showing up to users who shouldn't see them.