### PR TITLE
Fix self-closing div

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
@@ -5,4 +5,4 @@
   data-issues="{{ value.issues }}"
   data-max="{{ value.size }}"
   data-query="{{ value.search_terms }}"
-  data-reversed="{{ value.newest_first }}" />
+  data-reversed="{{ value.newest_first }}"></div>


### PR DESCRIPTION
Content after the pulse component was being swallowed by React content replacement

https://foundation-mofostaging-pr-1679.herokuapp.com/opportunity/global-sprint/global-sprint/
Notice that content now appears before and after. Before this PR, anything after gets captured in the replaced div.