### PR TITLE
CI fails if Pipfile.lock is outdated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 install:
 - pip install --upgrade pip
 - pip install pipenv
-- pipenv install --dev
+- pipenv install --dev --deploy
 - npm install -g npm@latest # Needed to use npm ci
 - npm ci # use package-lock.json
 - pipenv run python network-api/manage.py collectstatic --no-input

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ install:
   - "npm ci"
   - "python -m pip install --upgrade pip"
   - "python -m pip install pipenv"
-  - "python -m pipenv install --dev"
+  - "python -m pipenv install --dev --deploy"
   - "python -m pipenv run python network-api/manage.py collectstatic --no-input"
 
 test_script:


### PR DESCRIPTION
Related issue: MozillaFoundation/mofo-devops#618 

![screen shot 2018-08-10 at 11 28 09 am](https://user-images.githubusercontent.com/481052/43950413-82003284-9c90-11e8-82c4-006f491ae4d7.png)
