### PR TITLE
Add different colors for review apps bot

### DIFF
--- a/network-api/networkapi/management/commands/review_app_admin.py
+++ b/network-api/networkapi/management/commands/review_app_admin.py
@@ -44,6 +44,16 @@ class Command(BaseCommand):
             except KeyError:
                 pr_title = ''
 
+            if r.json()['labels']:
+                for l in r.json()['labels']:
+                    if l['name'] == 'dependencies':
+                        color = '#BA55D3'
+                        break
+                    else:
+                        color = '#7CD197'
+            else:
+                color = '#7CD197'
+
             slack_payload = {
                 'attachments': [
                     {
@@ -56,7 +66,7 @@ class Command(BaseCommand):
                         'title':    f'PR {pr_number}{pr_title}\n',
                         'text':     'Login: admin\n'
                                     f'Password: {password}\n',
-                        'color':    '#7CD197',
+                        'color':    f'{color}',
                         'actions': [
                             {
                                 'type': 'button',


### PR DESCRIPTION
Dependabot is opening a lot of review apps, which makes it difficult to find yours on the review-apps slack channel.

Now:
- review app messages for prs opened by dependabot will be purple
- All others will stay green.
