### PR TITLE
Pin pip to 18.0 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 services:
 - postgresql
 install:
-- pip install --upgrade pip
+- pip install pip==18.0
 - pip install pipenv
 - pipenv install --dev --deploy
 - nvm install --lts=carbon

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - "npm install -g npm@latest"
   - "npm ci"
-  - "python -m pip install --upgrade pip"
+  - "python -m pip install pip==18.0"
   - "python -m pip install pipenv"
   - "python -m pipenv install --dev --deploy"
   - "python -m pipenv run python network-api/manage.py collectstatic --no-input"


### PR DESCRIPTION
Related issue: CI is broken because of an issue around pipenv/pip.
Summary: I'm pinning pip to 18.0 for now but the next step would be to unify Heroku and CI config: they should run the same version of pipenv and pip. This will be a second PR because I need to discuss it with @cadecairos 

Feel free to merge it if I'm out of the office by the time it's reviewed.