### PR TITLE
Add a meta tag to verify the site with The Google Search console

### DIFF
--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">{% block socialMetadata %}{% endblock %}
+    <meta name="google-site-verification" content="D7k-r3fHm-XfJ9E7T1uZ5aqHJG2mx-0uUZFeBUDN2lY">
     <link rel="stylesheet" href="/_css/main.compiled.css">
     <link rel="stylesheet" href="//code.cdn.mozilla.net/fonts/fira.css">
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Nunito+Sans:400,300,700,300i">


### PR DESCRIPTION
This meta tag will let us force Google to re-crawl the site and update search metadata.