### PR TITLE
Buyer's Guide: raise Http404 in product view

### DIFF
--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -1,8 +1,12 @@
+from django.contrib.auth.models import User
+from django.http import Http404
 from django.urls import reverse
 from rest_framework.test import APITestCase
+from django.test import TestCase, RequestFactory
 
 from networkapi.buyersguide.factory import ProductFactory
 from networkapi.buyersguide.models import RangeVote, BooleanVote
+from networkapi.buyersguide.views import product_view
 from django.core.management import call_command
 
 VOTE_URL = reverse('product-vote')
@@ -266,3 +270,21 @@ class BuyersGuideVoteTest(APITestCase):
         }, format='json')
 
         self.assertEqual(response.status_code, 400)
+
+
+class BuyersGuideViewTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username='testuser',
+            email='testuser@example.com',
+            password='testuser password'
+        )
+
+    def test_product_view_404(self):
+        """
+        Test that the product view raises an Http404 if the product name doesn't exist
+        """
+        request = self.factory.get('/privacynotincluded/products/this is not a product')
+        request.user = self.user
+        self.assertRaises(Http404, product_view, request, 'this is not a product')

--- a/network-api/networkapi/buyersguide/views.py
+++ b/network-api/networkapi/buyersguide/views.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import Error
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
 from django.views.decorators.csrf import csrf_protect
@@ -40,7 +40,7 @@ def category_view(request, categoryname):
 
 @login_required
 def product_view(request, productname):
-    product = Product.objects.get(name__iexact=productname)
+    product = get_object_or_404(Product, name__iexact=productname)
     return render(request, 'product_page.html', {
         'categories': BuyersGuideProductCategory.objects.all(),
         'product': product.to_dict(),


### PR DESCRIPTION
1. Use the get_object_or_404 helper when looking up buyers guide products.
2. Include a test that enforces that an Http404 is raised when a product doesn't exist

Closes #1949 

- [X] Includes tests, if appropriate

