### PR TITLE
Aggregate on fake

### DIFF
--- a/network-api/networkapi/management/commands/load_fake_data.py
+++ b/network-api/networkapi/management/commands/load_fake_data.py
@@ -287,4 +287,7 @@ class Command(BaseCommand):
         print('Generating Buyer\'s Guide Products')
         generate_fake_data(ProductFactory, 20)
 
+        print('Aggregating Buyer\'s Guide Product votes')
+        call_command('aggregate_model_data')
+
         print(self.style.SUCCESS('Done!'))

--- a/network-api/networkapi/management/commands/load_fake_data.py
+++ b/network-api/networkapi/management/commands/load_fake_data.py
@@ -288,6 +288,6 @@ class Command(BaseCommand):
         generate_fake_data(ProductFactory, 20)
 
         print('Aggregating Buyer\'s Guide Product votes')
-        call_command('aggregate_model_data')
+        call_command('aggregate_product_votes')
 
         print(self.style.SUCCESS('Done!'))


### PR DESCRIPTION
Closes nothing. Makes sure that `aggregate_product_votes` runs as part of `load_fake_data`, so you only need to run one command.
