### PR TITLE
Fix Related Products iterator in template

### DIFF
--- a/network-api/networkapi/buyersguide/templates/product_page.html
+++ b/network-api/networkapi/buyersguide/templates/product_page.html
@@ -163,7 +163,7 @@
       <h3 class="h3-heading mb-3 mt-5">Related Products</h3>
 
       <div class="row">
-      {% for product in product.related_products.all %}
+      {% for product in product.related_products %}
       <div class="col-12 col-md-3">
         <a href="/privacynotincluded/products/{{ product.name }}">
           <img src="{{mediaUrl}}{{"AWS_LOCATION"|env}}/{{product.image}}"/>


### PR DESCRIPTION
`Product.to_dict` unpacks `related_products` to a list when it's called, so in the template we don't need to get an iterable  using the `all()` method of what was a QuerySet.

Closes #1960 
