### PR TITLE
Include product name in og:title tag

### DIFF
--- a/network-api/networkapi/buyersguide/templates/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/bg_base.html
@@ -4,7 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="privacy not included" />
+    {% block og-title %}
+      <meta property="og:title" content="privacy not included" />
+    {% endblock %}
     <meta property="og:description" content="This year, learn what tech comes with privacy included, using Mozilla's buyer's guide for connected gadgets." />
     <meta property="og:image" content="{{request.scheme}}://{{request.get_host}}/_images/buyers-guide/share.jpg" />
     <meta property="og:url" content="{{request.scheme}}://{{request.get_host}}{{request.path}}" />

--- a/network-api/networkapi/buyersguide/templates/product_page.html
+++ b/network-api/networkapi/buyersguide/templates/product_page.html
@@ -4,7 +4,9 @@
 {% load product-update %}
 {% load yes_no %}
 {% load env %}
-
+{% block og-title %}
+  <meta property="og:title" content="privacy not included - {{ product.name }}" />
+{% endblock %}
 {% block body-id %}product-page{% endblock %}
 
 {% block guts %}


### PR DESCRIPTION
This PR adds an og-title block in the base buyers guide template that can be overridden in child templates to set a new, more descriptive og-title meta tag.
