### PR TITLE
add /en/ prefix support for buyers guide

### DIFF
--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -35,6 +35,9 @@ urlpatterns = list(filter(None, [
     # Buyer's Guide / Privacy Not Included
     url(r'^privacynotincluded/', include('networkapi.buyersguide.urls')),
 
+    # And for good measure, because these prefixed URLs keep poppung up:
+    url(r'^en/privacynotincluded/', include('networkapi.buyersguide.urls')),
+
     # network API routes:
 
     url(r'^api/campaign/', include('networkapi.campaign.urls')),


### PR DESCRIPTION
Adds an `/en/` infix for the buyers guide routes.

Closes #2023