### PR TITLE
open post-vote shares in new tabs, and try to track clicks if allowed

### DIFF
--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -9,29 +9,16 @@ import Creepometer from './components/creepometer/creepometer.jsx';
 import HomepageSlider from './homepage-c-slider.js';
 import ProductGA from './product-analytics.js';
 
+import DNT from './dnt.js';
+
 let main = {
   init() {
-    let _dntStatus = navigator.doNotTrack || navigator.msDoNotTrack,
-        fxMatch = navigator.userAgent.match(/Firefox\/(\d+)/),
-        ie10Match = navigator.userAgent.match(/MSIE 10/i),
-        w8Match = navigator.appVersion.match(/Windows NT 6.2/);
-
-    if (fxMatch && Number(fxMatch[1]) < 32) {
-      _dntStatus = `Unspecified`;
-    } else if (ie10Match && w8Match) {
-      _dntStatus = `Unspecified`;
-    } else {
-      _dntStatus = { '0': `Disabled`, '1': `Enabled` }[_dntStatus] || `Unspecified`;
-    }
-
-    let allowTracking = (_dntStatus !== `Enabled`);
-
-    if (allowTracking) {
+    if (DNT.allowTracking) {
       ReactGA.initialize(`UA-87658599-6`);
       ReactGA.pageview(window.location.pathname);
     }
 
-    this.enableCopyLinks(allowTracking);
+    this.enableCopyLinks();
     this.injectReactComponents();
 
     primaryNav.init();
@@ -41,9 +28,7 @@ let main = {
     }
 
     if (document.getElementById(`pni-product-page`)) {
-      if (allowTracking) {
-        ProductGA.init();
-      }
+      ProductGA.init();
 
       let criteriaWithHelp = document.querySelectorAll(`.criterion button.toggle`);
 
@@ -60,13 +45,13 @@ let main = {
     }
   },
 
-  enableCopyLinks(allowAnalytics) {
+  enableCopyLinks() {
     if (document.querySelectorAll(`.copy-link`)) {
       Array.from(document.querySelectorAll(`.copy-link`)).forEach(element => {
         element.addEventListener(`click`, (event) => {
           event.preventDefault();
 
-          if (allowAnalytics) {
+          if (DNT.allowTracking) {
             let productBox = document.querySelector(`.product-detail .h1-heading`);
             let productTitle = productBox ? productBox.textContent : `unknown product`;
 

--- a/source/js/buyers-guide/components/social-share/social-share.jsx
+++ b/source/js/buyers-guide/components/social-share/social-share.jsx
@@ -5,7 +5,7 @@ import DNT from '../../dnt.js';
 const SocialShareLink = (props) => {
   let classes = `social-button`;
   let srLabel = ``;
-  let link = `PrivacyNotINcluded.org`;
+  let link = `privacynotincluded.org`;
   let shareText = `I think ${props.productName} is ${props.creepType.toUpperCase()}. What do you think? Check out the Creep-O-Meter over on @mozilla’s ${link} holiday buyer’s guide.`;
   let shareEvent = {
     category: `product`,

--- a/source/js/buyers-guide/components/social-share/social-share.jsx
+++ b/source/js/buyers-guide/components/social-share/social-share.jsx
@@ -1,33 +1,49 @@
 import React from 'react';
+import ReactGA from 'react-ga';
+import DNT from '../../dnt.js';
 
 const SocialShareLink = (props) => {
   let classes = `social-button`;
   let srLabel = ``;
   let link = `PrivacyNotINcluded.org`;
   let shareText = `I think ${props.productName} is ${props.creepType.toUpperCase()}. What do you think? Check out the Creep-O-Meter over on @mozilla’s ${link} holiday buyer’s guide.`;
+  let shareEvent = {
+    category: `product`,
+    action: `share tap`,
+    label: `share vote `,
+    transport: `beacon`
+  };
 
-  switch (props.type) {
-    case 'facebook':
+  if (props.type === `facebook`) {
       classes += " social-button-fb";
       srLabel = `Facebook`;
+      shareEvent.label += `to facebook`;
       link = `https://www.facebook.com/sharer/sharer.php?u=https://${link}`;
-
-      break;
-    case 'twitter':
-      classes += " social-button-twitter";
-      srLabel = `Twitter`;
-      link = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`;
-
-      break;
-    case 'email':
-      classes += " social-button-email";
-      srLabel = `Email`;
-      link = `mailto:?&body=${encodeURIComponent(shareText)}`;
-
-      break;
   }
 
-  return <a className={classes} href={link}><span class="sr-only">{srLabel}</span></a>;
+  if (props.type === `twitter`) {
+      classes += " social-button-twitter";
+      srLabel = `Twitter`;
+      shareEvent.label += `to twitter`;
+      link = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`;
+  }
+
+  if (props.type === `email`) {
+      classes += " social-button-email";
+      srLabel = `Email`;
+      shareEvent.label += `via email`;
+      link = `mailto:?&body=${encodeURIComponent(shareText)}`;
+  }
+
+  let trackShareAction = () => {};
+
+  if (DNT.allowTracking) {
+    trackShareAction = evt => {
+      ReactGA.event(shareEvent);
+    };
+  }
+
+  return <a target="_blank" className={classes} href={link} onClick={trackShareAction}><span class="sr-only">{srLabel}</span></a>;
 };
 
 const SocialShare = (props) => {

--- a/source/js/buyers-guide/dnt.js
+++ b/source/js/buyers-guide/dnt.js
@@ -1,0 +1,18 @@
+let _dntStatus = navigator.doNotTrack || navigator.msDoNotTrack,
+    fxMatch = navigator.userAgent.match(/Firefox\/(\d+)/),
+    ie10Match = navigator.userAgent.match(/MSIE 10/i),
+    w8Match = navigator.appVersion.match(/Windows NT 6.2/);
+
+if (fxMatch && Number(fxMatch[1]) < 32) {
+  _dntStatus = `Unspecified`;
+} else if (ie10Match && w8Match) {
+  _dntStatus = `Unspecified`;
+} else {
+  _dntStatus = { '0': `Disabled`, '1': `Enabled` }[_dntStatus] || `Unspecified`;
+}
+
+const DNT = {
+  allowTracking: (_dntStatus !== `Enabled`)
+};
+
+export default DNT;

--- a/source/js/buyers-guide/product-analytics.js
+++ b/source/js/buyers-guide/product-analytics.js
@@ -1,4 +1,5 @@
 import ReactGA from 'react-ga';
+import DNT from './dnt.js';
 
 function getElementGAInformation(pageTitle, productName) {
   return {
@@ -111,6 +112,10 @@ function setupElementGA(elementId, opts) {
 
 const ProductGA = {
   init: () => {
+    if (!DNT.allowTracking) {
+      return;
+    }
+
     let productBox = document.querySelector(`.product-detail .h1-heading`);
     let productName = productBox ? productBox.textContent : `unknown product`;
     let pageTitle = document.querySelector(`meta[property='og:title']`).getAttribute(`content`);


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/2046 by making social share votes open in a new tab, as well as introducing GA for share clicks.