### PR TITLE
Unlocalise Buyers Guide URLs

### DIFF
--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -319,16 +319,24 @@ class BuyersGuideViewTest(TestCase):
         Test that the homepage works.
         """
         request = self.factory.get('/privacynotincluded/')
-        request.user = self.user
         response = buyersguide_home(request)
         self.assertEqual(response.status_code, 200, 'homepage yields a working page')
+
+    def test_localised_homepage(self):
+        """
+        Test that the homepage works, despite a locale code.
+        """
+        response = self.client.get('/en/privacynotincluded/')
+        self.assertEqual(response.status_code, 302, 'simple locale gets redirected')
+
+        response = self.client.get('/fr-FR/privacynotincluded/')
+        self.assertEqual(response.status_code, 302, 'complex locale gets redirected')
 
     def test_product_view_404(self):
         """
         Test that the product view raises an Http404 if the product name doesn't exist
         """
         request = self.factory.get('/privacynotincluded/products/this is not a product')
-        request.user = self.user
         self.assertRaises(Http404, product_view, request, 'this is not a product')
 
     def test_category_view_404(self):
@@ -336,7 +344,6 @@ class BuyersGuideViewTest(TestCase):
         Test that the category view raises an Http404 if the category name doesn't exist
         """
         request = self.factory.get('/privacynotincluded/categories/this is not a category')
-        request.user = self.user
         self.assertRaises(Http404, category_view, request, 'this is not a category')
 
 

--- a/network-api/networkapi/buyersguide/urls.py
+++ b/network-api/networkapi/buyersguide/urls.py
@@ -3,14 +3,16 @@ from django.http import HttpResponseRedirect
 
 from networkapi.buyersguide import views
 
+
 def undo_locale_code(request, path):
     """
     Redirect to the base Buyers Guide URL
     """
     return HttpResponseRedirect(f"/privacynotincluded/{path}")
 
+
 # This will remove any locale code prefix for the Buyers Guide
-remove_locale_for_buyers_guide = url(r'^(\w\w(-\W\W)?)/privacynotincluded/(?P<path>[\w\W]*)$', undo_locale_code)
+remove_locale_for_buyers_guide = url(r'^(\w\w(-\w\w)?)/privacynotincluded/(?P<path>[\w\W]*)$', undo_locale_code)
 
 urlpatterns = [
     url(r'^$', views.buyersguide_home, name='buyersguide-home'),

--- a/network-api/networkapi/buyersguide/urls.py
+++ b/network-api/networkapi/buyersguide/urls.py
@@ -1,6 +1,16 @@
 from django.conf.urls import url
+from django.http import HttpResponseRedirect
+
 from networkapi.buyersguide import views
 
+def undo_locale_code(request, path):
+    """
+    Redirect to the base Buyers Guide URL
+    """
+    return HttpResponseRedirect(f"/privacynotincluded/{path}")
+
+# This will remove any locale code prefix for the Buyers Guide
+remove_locale_for_buyers_guide = url(r'^(\w\w(-\W\W)?)/privacynotincluded/(?P<path>[\w\W]*)$', undo_locale_code)
 
 urlpatterns = [
     url(r'^$', views.buyersguide_home, name='buyersguide-home'),

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -11,6 +11,7 @@ from wagtail.core import urls as wagtail_urls
 from wagtail.contrib.sitemaps.views import sitemap
 
 from networkapi.views import EnvVariablesView, review_app_help_view
+from networkapi.buyersguide.urls import remove_locale_for_buyers_guide
 
 admin.autodiscover()
 
@@ -36,7 +37,7 @@ urlpatterns = list(filter(None, [
     url(r'^privacynotincluded/', include('networkapi.buyersguide.urls')),
 
     # And for good measure, because these prefixed URLs keep poppung up:
-    url(r'^en/privacynotincluded/', include('networkapi.buyersguide.urls')),
+    remove_locale_for_buyers_guide,
 
     # network API routes:
 
@@ -63,7 +64,7 @@ urlpatterns = list(filter(None, [
 # url format with /<language_code>/ infixed needs
 # to be wrapped by django's i18n_patterns feature:
 urlpatterns += i18n_patterns(
-    url(r'', include(wagtail_urls)),
+   url(r'', include(wagtail_urls)),
 )
 
 if settings.USE_S3 is not True:

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -64,7 +64,7 @@ urlpatterns = list(filter(None, [
 # url format with /<language_code>/ infixed needs
 # to be wrapped by django's i18n_patterns feature:
 urlpatterns += i18n_patterns(
-   url(r'', include(wagtail_urls)),
+    url(r'', include(wagtail_urls)),
 )
 
 if settings.USE_S3 is not True:


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/2043 by intercepting anything that looks like a locale code (`xx` as well as `xx-yy`) before the buyers guide path and redirecting to the real URL instead.

[x] Includes tests

