### PR TITLE
Track policy links

### DIFF
--- a/network-api/networkapi/buyersguide/templates/fragments/product-policy.html
+++ b/network-api/networkapi/buyersguide/templates/fragments/product-policy.html
@@ -4,7 +4,7 @@
     <p class="d-flex align-items-center">
       <span>
           Reading level for {% if policy_url %}
-          <a target="_blank" href="{{ policy_url }}">Privacy policy</a>
+          <a target="_blank" id="privacy-policy-link" href="{{ policy_url }}">Privacy policy</a>
         {% else %}
           Privacy policy
         {% endif %}
@@ -18,7 +18,7 @@
         Can't determine
       {% else %}
         {% if level_url %}
-          <a target="_blank" href="{{ level_url }}">
+          <a target="_blank" id="reading-level-link" href="{{ level_url }}">
         {% endif %}
         Grade {{ product.reading_grade }}
         {% if level_url %}

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -30,8 +30,9 @@ let main = {
     if (document.getElementById(`pni-product-page`)) {
       ProductGA.init();
 
+      // Set up help text accordions where necessary:
       let productBox = document.querySelector(`.product-detail .h1-heading`);
-      let productTitle = productBox ? productBox.textContent : `unknown product`;
+      let productName = productBox ? productBox.textContent : `unknown product`;
       let criteriaWithHelp = document.querySelectorAll(`.criterion button.toggle`);
 
       if (criteriaWithHelp.length > 0) {
@@ -46,12 +47,13 @@ let main = {
               ReactGA.event({
                 category: `product`,
                 action: `expand accordion tap`,
-                label: `detail view on ${productTitle}`
+                label: `detail view on ${productName}`
               });
             }
           });
         });
       }
+
     }
   },
 

--- a/source/js/buyers-guide/product-analytics.js
+++ b/source/js/buyers-guide/product-analytics.js
@@ -96,6 +96,18 @@ function getElementGAInformation(pageTitle, productName) {
       action: `share tap`,
       label: `share ${productName} to Email`,
       transport: `beacon`
+    },
+    'privacy-policy-link': {
+      category: `product`,
+      action: `privacy policy link tap`,
+      label: `policy link for ${productName}`,
+      transport: `beacon`
+    },
+    'reading-level-link': {
+      category: `product`,
+      action: `carnegie mellon reading level links`,
+      label: `reading level link for ${productName}`,
+      transport: `beacon`
     }
   };
 }


### PR DESCRIPTION
Partial fulfillment of #2024, adds GA to the privacy policy and reading level links (if they exist for a product).