### PR TITLE
Fix Cyclical redirect

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -33,7 +33,6 @@ wagtail-modeltranslation = "*"
 "psycopg2-binary" = "*"
 
 [dev-packages]
-django-debug-toolbar = "*"
 "flake8" = "*"
 python-coveralls = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4516ecb69735c761af8d2be3ba9688c66f16cffe518017f852439c4917cc3216"
+            "sha256": "a1f3c5d401614a151e96ac6e6d124dee54edce761caa43667776bac8aed7993d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,18 +26,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:1837a4eaaa6705e69fa24ebf4387eb1c9ab6ccf554d672291479d6ebc497a885",
-                "sha256:3b782268ebf09ae6ea811ba8b8bdfc38a58d27f4f7fc554658f07c11ddc4165d"
+                "sha256:cd7052ca5afd327b2c4ea09d2766703b52314dab2f33eeca08c1a84c7adaed38",
+                "sha256:d99e944da4976400a5a80ae79a5c6ec6212ded4db6c4292b9d48228770fd7db1"
             ],
             "index": "pypi",
-            "version": "==1.9.30"
+            "version": "==1.9.33"
         },
         "botocore": {
             "hashes": [
-                "sha256:5b371508cbb8511592b754d542bd128194585125b4f41914097abb689d135575",
-                "sha256:5e1210f096637479061ebeb3640d0ba5bcdbfe385e36bd3132289d2d26ae83f6"
+                "sha256:831ef636c525860644f9e322b4f23b0d5c2f959fd635281e4f4ed6d892495063",
+                "sha256:848c1f2600ce9e7f86ee769b7de1bd615d0b6c7ac9f123bd5555d8c15f7002fb"
             ],
-            "version": "==1.12.30"
+            "version": "==1.12.33"
         },
         "certifi": {
             "hashes": [
@@ -174,9 +174,9 @@
         },
         "draftjs-exporter": {
             "hashes": [
-                "sha256:d2ceeef98185ba02355496851aee17d25951f5d8c72c12f8af6c186e312e9598"
+                "sha256:9809f140c39d2084022c9ade69fe14c558a574dea5c1e34ba3bfe07c4b5f7844"
             ],
-            "version": "==2.1.2"
+            "version": "==2.1.3"
         },
         "factory-boy": {
             "hashes": [
@@ -203,10 +203,10 @@
         },
         "future": {
             "hashes": [
-                "sha256:e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb"
+                "sha256:eb6d4df04f1fb538c99f69c9a28b255d1ee4e825d479b9c62fc38c0cf38065a4"
             ],
             "index": "pypi",
-            "version": "==0.16.0"
+            "version": "==0.17.0"
         },
         "gunicorn": {
             "hashes": [
@@ -278,7 +278,7 @@
                 "sha256:ff8cff01582fa1a7e533cb97f628531c4014af4b5f38e33cdcfe5eec29b6d888"
             ],
             "index": "pypi",
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*'",
             "version": "==5.3.0"
         },
         "psycopg2-binary": {
@@ -326,11 +326,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
-                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
+                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==2.7.3"
+            "version": "==2.7.5"
         },
         "python-slugify": {
             "hashes": [
@@ -349,10 +349,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b",
-                "sha256:91e3ccf2c344ffaa6defba1ce7f38f97026943f675b7703f44789768e4cb0ece"
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
-            "version": "==2018.6"
+            "version": "==2018.7"
         },
         "redis": {
             "hashes": [
@@ -392,20 +392,20 @@
         },
         "social-auth-app-django": {
             "hashes": [
-                "sha256:25295c94375d28062f65d0b3cd4b7e304c7e2fb7bac1ec51b40650a654c352f4",
-                "sha256:4e34d86709bfa51fd2938307e00f12f4e1dfef8a8ed6bfbfe9aeb4e69d57148f",
-                "sha256:b7c28bef8fbd11ff357ddd885cb219cdb55565e01109c709dd28569e0bfb0dea"
+                "sha256:36aeb09d0b80a49987d606ff57e7436e51ae48e10fbe0bfcf9ed75dda409b473",
+                "sha256:6afa7c7b91a3ca8edfb15ed6092c31ae96eed23d44768b2d99c7ebb5ffecd5db",
+                "sha256:7578b9f27841736ad395b49d230ec24d750dbad4ee3e4e96207a42094c314513"
             ],
             "index": "pypi",
-            "version": "==2.1.0"
+            "version": "==3.0.0"
         },
         "social-auth-core": {
             "hashes": [
-                "sha256:273eb5bbeded3cfc178ca7e14f0641165df03133a2f787a6e412f782489d56ba",
-                "sha256:7b393754ab75f6e5176568554f4f7b5cd9e4cb6dab23d9614e5c9e1425f3fcf9",
-                "sha256:eb0d0e29d0cfa729cd52437314d4aeb83806c4d6e7824cbe988195b6a4b85163"
+                "sha256:744c8b8498cf7e970151e8ea96a8d3e3aa818986ace7e1a0f39295fc193f4529",
+                "sha256:b8a34e7eb71c66e4d68deb007c81d4f74d4e0bc52c1c4f871a7758db0a0c268e",
+                "sha256:cec8e0a2297a23c0e1cab21bbcfaf32c8378fdb98762f47e315bbc65c3a83c89"
             ],
-            "version": "==1.7.0"
+            "version": "==2.0.0"
         },
         "text-unidecode": {
             "hashes": [
@@ -532,22 +532,6 @@
             ],
             "version": "==4.0.3"
         },
-        "django": {
-            "hashes": [
-                "sha256:29268cc47816a44f27308e60f71da635f549c47d8a1d003b28de55141df75791",
-                "sha256:37f5876c1fbfd66085001f4c06fa0bf96ef05442c53daf8d4294b6f29e7fa6b8"
-            ],
-            "index": "pypi",
-            "version": "==1.11.16"
-        },
-        "django-debug-toolbar": {
-            "hashes": [
-                "sha256:08e0e43f6c1fd9820af4cbdcd54b5fb80bf83a2e08b2cc952547a671174999b8",
-                "sha256:1dcae28d430522debafde2602b3450eb784410b78e16c29a00448032df2a4c90"
-            ],
-            "index": "pypi",
-            "version": "==1.10.1"
-        },
         "flake8": {
             "hashes": [
                 "sha256:6a35f5b8761f45c5513e3405f110a86bea57982c3b75b766ce7b65217abe1670",
@@ -582,7 +566,7 @@
                 "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
                 "sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*'",
+            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==2.0.0"
         },
         "python-coveralls": {
@@ -592,13 +576,6 @@
             ],
             "index": "pypi",
             "version": "==2.9.1"
-        },
-        "pytz": {
-            "hashes": [
-                "sha256:642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b",
-                "sha256:91e3ccf2c344ffaa6defba1ce7f38f97026943f675b7703f44789768e4cb0ece"
-            ],
-            "version": "==2018.6"
         },
         "pyyaml": {
             "hashes": [
@@ -630,13 +607,6 @@
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
-        },
-        "sqlparse": {
-            "hashes": [
-                "sha256:ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec",
-                "sha256:d9cf190f51cbb26da0412247dfe4fb5f4098edb73db84e02f9fc21fdca31fed4"
-            ],
-            "version": "==0.2.4"
         },
         "urllib3": {
             "hashes": [

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -7,7 +7,7 @@ from django.test import TestCase, RequestFactory
 
 from networkapi.buyersguide.factory import ProductFactory
 from networkapi.buyersguide.models import RangeVote, BooleanVote, Product
-from networkapi.buyersguide.views import buyersguide_home, product_view, category_view
+from networkapi.buyersguide.views import product_view, category_view
 from django.core.management import call_command
 
 VOTE_URL = reverse('product-vote')

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -318,7 +318,7 @@ class BuyersGuideViewTest(TestCase):
         """
         Test that the homepage works.
         """
-        request = self.factory.get('/privacynotincluded/')
+        request = self.factory.get('/en/privacynotincluded/')
         response = buyersguide_home(request)
         self.assertEqual(response.status_code, 200, 'homepage yields a working page')
 
@@ -326,11 +326,8 @@ class BuyersGuideViewTest(TestCase):
         """
         Test that the homepage works, despite a locale code.
         """
-        response = self.client.get('/en/privacynotincluded/')
+        response = self.client.get('/privacynotincluded/')
         self.assertEqual(response.status_code, 302, 'simple locale gets redirected')
-
-        response = self.client.get('/fr-FR/privacynotincluded/')
-        self.assertEqual(response.status_code, 302, 'complex locale gets redirected')
 
     def test_product_view_404(self):
         """

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -318,13 +318,13 @@ class BuyersGuideViewTest(TestCase):
         """
         Test that the homepage works.
         """
-        request = self.factory.get('/en/privacynotincluded/')
-        response = buyersguide_home(request)
+        response = self.client.get('/en/privacynotincluded/')
+        # response = buyersguide_home(request)
         self.assertEqual(response.status_code, 200, 'homepage yields a working page')
 
     def test_localised_homepage(self):
         """
-        Test that the homepage works, despite a locale code.
+        Test that the homepage redirects when missing a locale code.
         """
         response = self.client.get('/privacynotincluded/')
         self.assertEqual(response.status_code, 302, 'simple locale gets redirected')

--- a/network-api/networkapi/buyersguide/urls.py
+++ b/network-api/networkapi/buyersguide/urls.py
@@ -1,18 +1,5 @@
 from django.conf.urls import url
-from django.http import HttpResponseRedirect
-
 from networkapi.buyersguide import views
-
-
-def undo_locale_code(request, path):
-    """
-    Redirect to the base Buyers Guide URL
-    """
-    return HttpResponseRedirect(f"/privacynotincluded/{path}")
-
-
-# This will remove any locale code prefix for the Buyers Guide
-remove_locale_for_buyers_guide = url(r'^(\w\w(-\w\w)?)/privacynotincluded/(?P<path>[\w\W]*)$', undo_locale_code)
 
 urlpatterns = [
     url(r'^$', views.buyersguide_home, name='buyersguide-home'),

--- a/network-api/networkapi/buyersguide/urls.py
+++ b/network-api/networkapi/buyersguide/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     url(r'^categories/(?P<categoryname>[\w\W]+)/', views.category_view, name='category-view'),
     url(r'^products/(?P<slug>[-\w]+)/$', views.product_view, name='product-view'),
     url(r'^vote$', views.product_vote, name='product-vote'),
-    url(r'^refresh-cache$', views.refresh_cache, name='refresh-cache')
+    url(r'^refresh-cache$', views.refresh_cache, name='refresh-cache'),
 ]

--- a/network-api/networkapi/buyersguide/urls.py
+++ b/network-api/networkapi/buyersguide/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+
 from networkapi.buyersguide import views
 
 urlpatterns = [
@@ -7,5 +8,5 @@ urlpatterns = [
     url(r'^categories/(?P<categoryname>[\w\W]+)/', views.category_view, name='category-view'),
     url(r'^products/(?P<slug>[-\w]+)/$', views.product_view, name='product-view'),
     url(r'^vote$', views.product_vote, name='product-vote'),
-    url(r'^refresh-cache$', views.refresh_cache, name='refresh-cache'),
+    url(r'^refresh-cache$', views.refresh_cache, name='refresh-cache')
 ]

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -42,7 +42,6 @@ env = environ.Env(
     CORS_WHITELIST=(tuple, ()),
     DATABASE_URL=(str, None),
     DEBUG=(bool, False),
-    DISABLE_DEBUG_TOOLBAR=(bool, False),
     DJANGO_LOG_LEVEL=(str, 'INFO'),
     DOMAIN_REDIRECT_MIDDLWARE_ENABLED=(bool, False),
     FILEBROWSER_DEBUG=(bool, False),
@@ -86,7 +85,6 @@ SECRET_KEY = env('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = FILEBROWSER_DEBUG = env('DEBUG')
-DISABLE_DEBUG_TOOLBAR = env('DISABLE_DEBUG_TOOLBAR')
 
 # Force permanent redirects to the domain specified in TARGET_DOMAIN
 DOMAIN_REDIRECT_MIDDLWARE_ENABLED = env('DOMAIN_REDIRECT_MIDDLWARE_ENABLED')
@@ -130,9 +128,6 @@ INSTALLED_APPS = list(filter(None, [
     'django.contrib.staticfiles',
     'django.contrib.redirects',
     'django.contrib.sitemaps',
-
-    'debug_toolbar'
-    if DEBUG and not DISABLE_DEBUG_TOOLBAR else None,
 
     'networkapi.wagtailcustomization',
 
@@ -205,9 +200,6 @@ MIDDLEWARE = list(filter(None, [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-
-    'debug_toolbar.middleware.DebugToolbarMiddleware'
-    if DEBUG and not DISABLE_DEBUG_TOOLBAR else None,
 
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
@@ -490,18 +482,6 @@ FRONTEND = {
     'TARGET_DOMAIN': env('TARGET_DOMAIN'),
     'SHOW_TAKEOVER': env('SHOW_TAKEOVER'),
 }
-
-
-# DEBUG toolbar
-if DEBUG and not DISABLE_DEBUG_TOOLBAR:
-    INTERNAL_IPS = ('127.0.0.1',)
-
-    def show_toolbar(request):
-        return True
-
-    DEBUG_TOOLBAR_CONFIG = {
-        "SHOW_TOOLBAR_CALLBACK": show_toolbar,
-    }
 
 # Review apps' slack bot
 GITHUB_TOKEN = env('GITHUB_TOKEN')

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -72,5 +72,5 @@ if settings.USE_S3 is not True:
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns = [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        url(r'^debug/', include(debug_toolbar.urls)),
     ] + urlpatterns

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -33,12 +33,6 @@ urlpatterns = list(filter(None, [
         query_string=True
     )),
 
-    # Buyer's Guide / Privacy Not Included
-    url(r'^privacynotincluded/', include('networkapi.buyersguide.urls')),
-
-    # And for good measure, because these prefixed URLs keep popping up:
-    remove_locale_for_buyers_guide,
-
     # network API routes:
 
     url(r'^api/campaign/', include('networkapi.campaign.urls')),
@@ -64,6 +58,9 @@ urlpatterns = list(filter(None, [
 # url format with /<language_code>/ infixed needs
 # to be wrapped by django's i18n_patterns feature:
 urlpatterns += i18n_patterns(
+    # Buyer's Guide / Privacy Not Included
+    url(r'^privacynotincluded/', include('networkapi.buyersguide.urls')),
+
     url(r'', include(wagtail_urls)),
 )
 

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -11,7 +11,6 @@ from wagtail.core import urls as wagtail_urls
 from wagtail.contrib.sitemaps.views import sitemap
 
 from networkapi.views import EnvVariablesView, review_app_help_view
-from networkapi.buyersguide.urls import remove_locale_for_buyers_guide
 
 admin.autodiscover()
 

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -68,9 +68,3 @@ if settings.USE_S3 is not True:
         settings.MEDIA_URL,
         document_root=settings.MEDIA_ROOT
     )
-
-if settings.DEBUG:
-    import debug_toolbar
-    urlpatterns = [
-        url(r'^debug/', include(debug_toolbar.urls)),
-    ] + urlpatterns


### PR DESCRIPTION
Closes #2074 

We created this cyclical redirect because any actual 404 url under the `/privacynotincluded/` path would eventually hit the redirect created by the i18n routing. This would append a `/en/` to the path, and redirect it back into the route we added to strip that locale prefix, thus creating a loop.

The only real way to prevent this issue is to stop trying to "un-i18n-ify" the `privacynotincluded` namespace with redirect views. The site is in english, so it can safely live at `/en/` and we can safely rely on the i18n code to redirect non-en prefixed urls in the wild to the prefixed version.