### PR TITLE
Fix invalid script tag injected on product pages when talk is disabled

### DIFF
--- a/network-api/networkapi/buyersguide/templates/product_page.html
+++ b/network-api/networkapi/buyersguide/templates/product_page.html
@@ -189,12 +189,12 @@
 
 {% endblock %}
 
-{% if coralTalkServerUrl %}
-  {% block extra_scripts %}
+{% block extra_scripts %}
+  {% if coralTalkServerUrl %}
     <script src="{{ coralTalkServerUrl }}static/embed.js" async onload="
       Coral.Talk.render(document.getElementById('coral_talk_stream'), {
         talk: '{{ coralTalkServerUrl }}'
       });
     "></script>
-  {% endblock %}
-{% endif %}
+  {% endif %}
+{% endblock %}

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -64,7 +64,7 @@ env = environ.Env(
     GITHUB_TOKEN=(str, ''),
     SLACK_WEBHOOK_RA=(str, ''),
     BUYERS_GUIDE_VOTE_RATE_LIMIT=(str, '200/hour'),
-    CORAL_TALK_SERVER_URL=(str, ''),
+    CORAL_TALK_SERVER_URL=(str, None),
     PNI_STATS_DB_URL=(str, None),
     REDIS_URL=(str, ''),
 )


### PR DESCRIPTION
default CORAL_TALK_SERVER_URL to None and put the if check inside the extra_scripts block in the template

Closes #2082 

[ ] Generates new fake data, if necessary
[ ] Wagtail documentation has been updated, if necessary
[ ] Includes tests, if appropriate
[ ] Migrations squashed
