### PR TITLE
CLOUDINARY_URL does not need to be set in the environment

### DIFF
--- a/app.json
+++ b/app.json
@@ -47,9 +47,6 @@
     "CLOUDINARY_API_SECRET": {
       "required": true
     },
-    "CLOUDINARY_URL": {
-      "required": true
-    },
     "DEBUG": "False",
     "CORS_WHITELIST": "*",
     "XSS_PROTECTION": "True",

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -72,7 +72,6 @@ env = environ.Env(
     CLOUDINARY_CLOUD_NAME=(str, ''),
     CLOUDINARY_API_KEY=(str, ''),
     CLOUDINARY_API_SECRET=(str, ''),
-    CLOUDINARY_URL=(str, ''),
 )
 
 # Read in the environment


### PR DESCRIPTION
Removes `CLOUDINARY_URL` as a required environment variable for review apps, and stops trying to load it in settings.py.
