### PR TITLE
add testing for the Procfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "server": "pipenv run python network-api/manage.py runserver",
     "start": "npm i && npm run build-uncompressed && run-p server watch:**",
     "snyk": "snyk test --file=package.json",
+    "test:procfile": "node test/test-procfile.js",
     "test:eslint": "eslint --config ./.eslintrc.yaml \"source/js/**/*.js\" \"source/js/**/*.jsx\" webpack.config.js",
     "test:scss": "stylelint \"source/sass/**/*.scss\" \"source/js/**/*.scss\" --syntax scss",
-    "test": "npm run build && run-s test:**",
+    "test": "run-s test:** build",
     "watch:images": "chokidar \"source/images/**/*\" -c \"npm run build:images\"",
     "watch:js": "chokidar \"source/js/**/*.js\" \"source/js/**/*.jsx\" -c \"npm run build:js-uncompressed\"",
     "watch:sass": "chokidar \"source/**/*.scss\" -c \"npm run build:sass\""

--- a/test/test-procfile.js
+++ b/test/test-procfile.js
@@ -1,0 +1,15 @@
+let fs = require(`fs`);
+let path = require(`path`);
+let lines = fs.readFileSync(path.join(__dirname,`..`,`Procfile`))
+              .toString()
+              .split(`\n`);
+
+// A valid Procfile consists only of lines that start with
+// "keyword: ...", where the keyword arguments cannot be spread
+// over multiple lines, so we can test the start of every line
+// for that {keyword, colon} presence:
+let re = /^\w+:\s+/;
+let passes = lines.every(l => (!l || l.match(re)));
+
+// make sure to exit this script with the correct code:
+process.exit(passes ? 0 : 1);


### PR DESCRIPTION
Follow-up on https://github.com/mozilla/foundation.mozilla.org/pull/2167

This hardens the Procfile by adding a dumb, but effective, test script that checks whether there are only lines of the form `keyword: ...` in it. Empty lines are ignored, but lines that don't start with a `{keyword, colon}` combination are considered build-breakingly bad.

