### PR TITLE
proxy'd

### DIFF
--- a/source/js/analytics.js
+++ b/source/js/analytics.js
@@ -1,5 +1,3 @@
-import ReactGA from 'react-ga';
-
 export default {
   initialize: function() {
     var _dntStatus = navigator.doNotTrack || navigator.msDoNotTrack;
@@ -30,10 +28,7 @@ export default {
     if (!window.ga) {
       return;
     }
-
     window.ga('send', category, 'navigation', action, label);
-
-
     window.ga('send', 'event', 'navigation', 'page footer cta', document.querySelectorAll('.cms h1').length > 0 ? document.querySelectorAll('.cms h1')[0].innerText + ' - footer cta' : '');
   }
 };

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactGA from 'react-ga';
+import ReactGA from './react-ga-proxy.js';
 
 import primaryNav from './components/primary-nav/primary-nav.js';
 import CreepVote from './components/creep-vote/creep-vote.jsx';
@@ -11,14 +11,10 @@ import Filter from './components/filter/filter.jsx';
 import HomepageSlider from './homepage-c-slider.js';
 import ProductGA from './product-analytics.js';
 
-import DNT from './dnt.js';
-
 let main = {
   init() {
-    if (DNT.allowTracking) {
-      ReactGA.initialize(`UA-87658599-6`);
-      ReactGA.pageview(window.location.pathname);
-    }
+    ReactGA.initialize(`UA-87658599-6`);
+    ReactGA.pageview(window.location.pathname);
 
     this.enableCopyLinks();
     this.injectReactComponents();
@@ -51,7 +47,7 @@ let main = {
             button.classList.toggle(`open`);
             help.classList.toggle(`open`);
 
-            if (help.classList.contains(`open`) && DNT.allowTracking) {
+            if (help.classList.contains(`open`)) {
               ReactGA.event({
                 category: `product`,
                 action: `expand accordion tap`,
@@ -71,16 +67,14 @@ let main = {
         element.addEventListener(`click`, (event) => {
           event.preventDefault();
 
-          if (DNT.allowTracking) {
-            let productBox = document.querySelector(`.product-detail .h1-heading`);
-            let productTitle = productBox ? productBox.textContent : `unknown product`;
+          let productBox = document.querySelector(`.product-detail .h1-heading`);
+          let productTitle = productBox ? productBox.textContent : `unknown product`;
 
-            ReactGA.event({
-              category: `product`,
-              action: `copy link tap`,
-              label: `copy link ${productTitle}`
-            });
-          }
+          ReactGA.event({
+            category: `product`,
+            action: `copy link tap`,
+            label: `copy link ${productTitle}`
+          });
 
           let textArea = document.createElement(`textarea`);
 

--- a/source/js/buyers-guide/components/filter/filter.jsx
+++ b/source/js/buyers-guide/components/filter/filter.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import ReactGA from 'react-ga';
-import DNT from '../../dnt.js';
+import ReactGA from '../../react-ga-proxy.js';
 
 /**
  * A simple class for radio-group-looking things.
@@ -85,13 +84,11 @@ export default class Filter extends React.Component {
       this.updateWithCSSvalues(update);
       this.setState(update);
 
-      if(DNT.allowTracking) {
-        ReactGA.event({
-          category: `buyersguide`,
-          action: `filter set`,
-          label: `filter on homepage`
-        });
-      }
+      ReactGA.event({
+        category: `buyersguide`,
+        action: `filter set`,
+        label: `filter on homepage`
+      });
     }
   }
 

--- a/source/js/buyers-guide/components/social-share/social-share.jsx
+++ b/source/js/buyers-guide/components/social-share/social-share.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import ReactGA from 'react-ga';
-import DNT from '../../dnt.js';
+import ReactGA from '../../react-ga-proxy';
 
 const SocialShareLink = (props) => {
   let classes = `social-button`;
@@ -35,13 +34,9 @@ const SocialShareLink = (props) => {
     link = `mailto:?&body=${encodeURIComponent(shareText)}`;
   }
 
-  let trackShareAction = () => {};
-
-  if (DNT.allowTracking) {
-    trackShareAction = () => {
-      ReactGA.event(shareEvent);
-    };
-  }
+  let trackShareAction = () => {
+    ReactGA.event(shareEvent);
+  };
 
   return <a target="_blank" className={classes} href={link} onClick={trackShareAction}><span class="sr-only">{srLabel}</span></a>;
 };

--- a/source/js/buyers-guide/product-analytics.js
+++ b/source/js/buyers-guide/product-analytics.js
@@ -1,4 +1,4 @@
-import ReactGA from 'react-ga';
+import ReactGA from './react-ga-proxy';
 import DNT from './dnt.js';
 
 function getElementGAInformation(pageTitle, productName) {

--- a/source/js/buyers-guide/react-ga-proxy.js
+++ b/source/js/buyers-guide/react-ga-proxy.js
@@ -1,0 +1,14 @@
+import DNT from './dnt.js';
+import ReactGA from 'react-ga';
+
+// A no-operation object with the same API surface
+// as ReactGA, for when tracking is not appreciated:
+const noop = {
+  initialize: () => {},
+  pageview: () => {},
+  event: () => {}
+};
+
+const TrackingObject = DNT.allowTracking ? ReactGA : noop;
+
+export default TrackingObject;


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/2193 by wrapping ReactGa and DNT into a single thing that either works without having to add DNT.allowTracking checks everywhere, or just does nothing because DNT.allowTracking is false to begin with.