### PR TITLE
Enable Google Compute Engine builds on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,3 +61,5 @@ cache:
   - "%LOCALAPPDATA%\\pip\\Cache"
 
 clone_depth: 1
+
+appveyor_build_worker_cloud: gce


### PR DESCRIPTION
This PR enables GCE builds on appveyor, which _might_ speed up the build process. 