### PR TITLE
Change "replace by" to "replace with" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For management commands not covered by an invoke tasks, use `inv manage [command
 By default, your dev site will use production data (read only!). To load fake model data into your dev site:
 
 - Run `inv manage load_fake_data`
-- Replace `NETWORK_SITE_URL` value by `http://localhost:8000` in your `.env` file.
+- Replace `NETWORK_SITE_URL` value with `http://localhost:8000` in your `.env` file.
 
 You can empty your database and create a full new set of fake model data using the following command
 
@@ -340,7 +340,7 @@ create table product_stats
   would_buy        integer,
   would_not_buy    integer
 );
-  
+
 create table comment_counts
 (
   url            varchar(2048) not null constraint comment_counts_pkey primary key,


### PR DESCRIPTION
Changes wording from passive voice to active voice more appropriate for instructions.