### PR TITLE
fix to the donate popup GA label

### DIFF
--- a/source/js/buyers-guide/components/donate-modal/donate-modal.jsx
+++ b/source/js/buyers-guide/components/donate-modal/donate-modal.jsx
@@ -52,10 +52,12 @@ export default class DonateModal extends React.Component {
 
   handleBtnClick() {
     if (DNT.allowTracking) {
+      let url = window.location.pathname.replace(/\w\w(-\W\W)?\/privacynotincluded\//,'');
+
       ReactGA.event({
         category: `buyersguide`,
         action: `donate tap`,
-        label: `donate popup`
+        label: `donate popup on ${url}`
       });
     }
 

--- a/source/js/buyers-guide/components/donate-modal/donate-modal.jsx
+++ b/source/js/buyers-guide/components/donate-modal/donate-modal.jsx
@@ -52,7 +52,7 @@ export default class DonateModal extends React.Component {
 
   handleBtnClick() {
     if (DNT.allowTracking) {
-      let url = window.location.pathname.replace(/\w\w(-\W\W)?\/privacynotincluded\//,'');
+      let url = window.location.pathname.replace(/\w\w(-\W\W)?\/privacynotincluded\//,``);
 
       ReactGA.event({
         category: `buyersguide`,


### PR DESCRIPTION
Addresses the "donate tap" event not saying which page it was triggered on.

See https://github.com/mozilla/foundation.mozilla.org/issues/2024

Also see L15 in https://docs.google.com/spreadsheets/d/1x-CP_HYaAs3oRv2cjbSFu8w5Z938E4cyHQ3hvh17c6c/edit#gid=980429434