### PR TITLE
update python version used on Heroku

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.6
+python-3.6.7


### PR DESCRIPTION
Heroku updated their supported version of Python to 3.6.7