### PR TITLE
Product page titles

### DIFF
--- a/network-api/networkapi/buyersguide/templates/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/bg_base.html
@@ -21,7 +21,7 @@
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="/_images/favicons/apple-touch-icon-180x180@2x.png">
     <link rel="icon" type="image/png" sizes="196x196" href="/_images/favicons/favicon-196x196@2x.png">
     <link rel="shortcut icon" href="/_images/favicons/favicon.ico">
-    <title>Mozilla - *privacy not included</title>
+    <title>{% if pageTitle %}{{ pageTitle }}{% else %}Mozilla - *privacy not included{% endif %}</title>
     <script>
       var modernBrowser = (
         'fetch' in window &&

--- a/network-api/networkapi/buyersguide/views.py
+++ b/network-api/networkapi/buyersguide/views.py
@@ -100,6 +100,7 @@ def product_view(request, slug):
         'product': product.to_dict(),
         'mediaUrl': MEDIA_URL,
         'coralTalkServerUrl': settings.CORAL_TALK_SERVER_URL,
+        'pageTitle': f'*privacy not included - {product.name}',
     })
 
 


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/2246 by setting the product page title to `*privacy not included - {product name}`, which yields titles like `*privacy not included - Nintendo Switch`