### PR TITLE
Use model specific exception names when handling errors in load_fake_data

### DIFF
--- a/network-api/networkapi/management/commands/load_fake_data.py
+++ b/network-api/networkapi/management/commands/load_fake_data.py
@@ -3,7 +3,6 @@ from itertools import chain, combinations
 import factory
 from random import randint, random
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
 from django.conf import settings
@@ -139,7 +138,7 @@ class Command(BaseCommand):
         try:
             home_page = wagtailpages_models.Homepage.objects.get(title='Homepage')
             print('Homepage already exists')
-        except ObjectDoesNotExist:
+        except wagtailpages_models.Homepage.DoesNotExist:
             print('Generating a Homepage')
             site_root = WagtailPage.objects.get(title='Root')
             home_page = WagtailHomepageFactory.create(
@@ -168,7 +167,7 @@ class Command(BaseCommand):
             default_site.root_page = home_page
             default_site.save()
             print('Updated the default Site')
-        except ObjectDoesNotExist:
+        except WagtailSite.DoesNotExist:
             print('Generating a default Site')
             if settings.HEROKU_APP_NAME:
                 hostname = REVIEW_APP_HOSTNAME
@@ -188,7 +187,7 @@ class Command(BaseCommand):
         try:
             about_page = WagtailPage.objects.get(title='about')
             print('about page exists')
-        except ObjectDoesNotExist:
+        except WagtailPage.DoesNotExist:
             print('Generating an about Page (PrimaryPage)')
             about_page = PrimaryPageFactory.create(parent=home_page, title='about')
 
@@ -198,42 +197,42 @@ class Command(BaseCommand):
         try:
             WagtailPage.objects.get(title='styleguide')
             print('styleguide page exists')
-        except ObjectDoesNotExist:
+        except WagtailPage.DoesNotExist:
             print('Generating a Styleguide Page')
             StyleguideFactory.create(parent=home_page)
 
         try:
             WagtailPage.objects.get(title='people')
             print('people page exists')
-        except ObjectDoesNotExist:
+        except WagtailPage.DoesNotExist:
             print('Generating an empty People Page')
             PeoplePageFactory.create(parent=home_page)
 
         try:
             WagtailPage.objects.get(title='news')
             print('news page exists')
-        except ObjectDoesNotExist:
+        except WagtailPage.DoesNotExist:
             print('Generating an empty News Page')
             NewsPageFactory.create(parent=home_page)
 
         try:
             WagtailPage.objects.get(title='initiatives')
             print('initiatives page exists')
-        except ObjectDoesNotExist:
+        except WagtailPage.DoesNotExist:
             print('Generating an empty Initiatives Page')
             InitiativesPageFactory.create(parent=home_page)
 
         try:
             WagtailPage.objects.get(title='participate')
             print('participate page exists')
-        except ObjectDoesNotExist:
+        except WagtailPage.DoesNotExist:
             print('Generating an empty Participate Page')
             ParticipatePageFactory.create(parent=home_page)
 
         try:
             campaign_namespace = WagtailPage.objects.get(title='campaigns')
             print('campaigns namespace exists')
-        except ObjectDoesNotExist:
+        except WagtailPage.DoesNotExist:
             print('Generating a campaigns namespace')
             campaign_namespace = MiniSiteNameSpaceFactory.create(parent=home_page, title='campaigns', live=False)
 
@@ -246,14 +245,14 @@ class Command(BaseCommand):
         try:
             wagtailpages_models.CampaignPage.objects.get(title='single-page')
             print('single-page CampaignPage already exists')
-        except ObjectDoesNotExist:
+        except wagtailpages_models.CampaignPage.DoesNotExist:
             print('Generating single-page CampaignPage')
             CampaignPageFactory.create(parent=campaign_namespace, title='single-page')
 
         try:
             wagtailpages_models.CampaignPage.objects.get(title='multi-page')
             print('multi-page CampaignPage already exists.')
-        except ObjectDoesNotExist:
+        except wagtailpages_models.CampaignPage.DoesNotExist:
             print('Generating multi-page CampaignPage')
             multi_page_campaign = CampaignPageFactory(parent=campaign_namespace, title='multi-page')
             [CampaignPageFactory(parent=multi_page_campaign, no_cta=True) for k in range(3)]
@@ -261,7 +260,7 @@ class Command(BaseCommand):
         try:
             opportunity_namespace = WagtailPage.objects.get(title='opportunity')
             print('opportunity namespace exists')
-        except ObjectDoesNotExist:
+        except WagtailPage.DoesNotExist:
             print('Generating an opportunity namespace')
             opportunity_namespace = MiniSiteNameSpaceFactory.create(parent=home_page, title='opportunity', live=False)
 
@@ -271,21 +270,21 @@ class Command(BaseCommand):
         try:
             wagtailpages_models.OpportunityPage.objects.get(title='Global Sprint')
             print('Global Sprint OpportunityPage exists')
-        except ObjectDoesNotExist:
+        except wagtailpages_models.OpportunityPage.DoesNotExist:
             print('Generating Global Sprint OpportunityPage')
             OpportunityPageFactory.create(parent=opportunity_namespace, title='Global Sprint', no_cta=True)
 
         try:
             wagtailpages_models.OpportunityPage.objects.get(title='single-page')
             print('single-page OpportunityPage exists')
-        except ObjectDoesNotExist:
+        except wagtailpages_models.OpportunityPage.DoesNotExist:
             print('Generating single-page OpportunityPage')
             OpportunityPageFactory.create(parent=opportunity_namespace, title='single-page')
 
         try:
             wagtailpages_models.OpportunityPage.objects.get(title='multi-page')
             print('multi-page OpportunityPage exists')
-        except ObjectDoesNotExist:
+        except wagtailpages_models.OpportunityPage.DoesNotExist:
             print('Generating multi-page OpportunityPage')
             multi_page_opportunity = OpportunityPageFactory(parent=opportunity_namespace, title='multi-page')
             [OpportunityPageFactory(parent=multi_page_opportunity, no_cta=True) for k in range(3)]


### PR DESCRIPTION
This change stops uncaught exceptions arising from differing database states when running the `load_fake_data` command. "ObjectDoesNotExist" doesn't work, but `<model>.DoesNotExist` does.