### PR TITLE
A small fix that unbreaks windows

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -409,7 +409,7 @@ if USE_S3:
 
 else:
     # Otherwise use the default filesystem storage
-    MEDIA_ROOT = root('media/')
+    MEDIA_ROOT = root('media')
     MEDIA_URL = '/media/'
 
 # CORS


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/2326, or at least seems to, but I'm not entirely happy about the fact that I don't know _why_ it fixes it.

A lot of stackoverflow answers suggest this would be the culprit, though, and `inv setup` runs to completion with it applied, rather than throwing the error listed in the abovementioned issue...

This was on Windows 10 Pro x64, with Python 3.6.7, pipenv v2018.11.26, pip 18.1