### PR TITLE
Removed underline from mobile active nav

### DIFF
--- a/source/sass/type.scss
+++ b/source/sass/type.scss
@@ -69,7 +69,7 @@ a {
   }
 
   @at-root #multipage-nav-mobile &#{$active-class-name} {
-    box-shadow: none;
+    border-bottom: none;
   }
 }
 


### PR DESCRIPTION
Closes #2369

- initiatives https://foundation-mofostaging-pr-2371.herokuapp.com/en/initiatives/
- about https://foundation-mofostaging-pr-2371.herokuapp.com/en/about/
- opportunity https://foundation-mofostaging-pr-2371.herokuapp.com/en/opportunity/multi-page/
- campaigns https://foundation-mofostaging-pr-2371.herokuapp.com/en/campaigns/multi-page/
- style guide https://foundation-mofostaging-pr-2371.herokuapp.com/en/styleguide/
- fellowships https://foundation-mofostaging-pr-2371.herokuapp.com/fellowships/ (active nav not showing up on mobile here as my other PR that fixes it hasn't been merged yet)
