### PR TITLE
add an event trigger for when main.js is done

### DIFF
--- a/cypress/integration/multi-page.js
+++ b/cypress/integration/multi-page.js
@@ -9,11 +9,16 @@ describe('multipage visual regression tests', () => {
     // Load the multipage campaign
     cy.visit(`/en/campaigns/multi-page/`);
 
-    // Give the browser a few seconds for JSX
-    // conversion to kick in.
-    cy.wait(10000);
+    // Attach a listener to the document that lets us know
+    // when main.js is done with all the JSX (re)placement.
+    cy.document().then((document) => {
+      document.addEventListener(`main-js:done`, evt => {
+        // wait one second just in case
+        cy.wait(1000);
 
-    // And take a snapshot for visual diffing
-    cy.percySnapshot();
+        // And take a snapshot for visual diffing
+        cy.percySnapshot();
+      });
+    });
   });
 });

--- a/cypress/integration/single-page.js
+++ b/cypress/integration/single-page.js
@@ -9,11 +9,16 @@ describe('Integration test with visual testing', () => {
     // Load the homepage
     cy.visit(`/`);
 
-    // Give the browser a few seconds for JSX
-    // conversion to kick in.
-    cy.wait(10000);
+    // Attach a listener to the document that lets us know
+    // when main.js is done with all the JSX (re)placement.
+    cy.document().then((document) => {
+      document.addEventListener(`main-js:done`, evt => {
+        // wait one second just in case
+        cy.wait(1000);
 
-    // Take a snapshot for visual diffing
-    cy.percySnapshot();
+        // And take a snapshot for visual diffing
+        cy.percySnapshot();
+      });
+    });
   });
 });

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -41,6 +41,10 @@ let main = {
 
       Analytics.initialize();
       this.bindGAEventTrackers();
+
+      document.dispatchEvent(new CustomEvent(`main-js:done`, {
+        detail: Date.now()
+      }));
     });
   },
 


### PR DESCRIPTION
closes https://github.com/mozilla/foundation.mozilla.org/issues/2550 by adding a custom event at the end of the main.js run, which cypress can pick up on in order to do its visual regression testing, cutting down the travis-ci runtime by quite a bit.