### PR TITLE
wrap whenLoaded()

### DIFF
--- a/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
+++ b/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
@@ -44,7 +44,9 @@ export default class CreepVote extends React.Component {
   }
 
   componentDidMount() {
-    this.props.whenLoaded();
+    if (this.props.whenLoaded) {
+      this.props.whenLoaded();
+    }
   }
 
   showVoteResult() {

--- a/source/js/buyers-guide/components/creepometer/creepometer.jsx
+++ b/source/js/buyers-guide/components/creepometer/creepometer.jsx
@@ -18,7 +18,9 @@ export default class Creepometer extends React.Component {
   }
 
   componentDidMount() {
-    this.props.whenLoaded();
+    if (this.props.whenLoaded) {
+      this.props.whenLoaded();
+    }
   }
 
   setupDocumentListeners() {

--- a/source/js/buyers-guide/components/filter/filter.jsx
+++ b/source/js/buyers-guide/components/filter/filter.jsx
@@ -59,7 +59,9 @@ export default class Filter extends React.Component {
       });
     }
 
-    this.props.whenLoaded();
+    if (this.props.whenLoaded) {
+      this.props.whenLoaded();
+    }
   }
 
   reset() {

--- a/source/js/components/fellow-list/single-filter-fellow-list.jsx
+++ b/source/js/components/fellow-list/single-filter-fellow-list.jsx
@@ -48,7 +48,9 @@ export default class SingleFilterFellowList extends React.Component {
   }
 
   componentDidMount() {
-    this.props.whenLoaded();
+    if (this.props.whenLoaded) {
+      this.props.whenLoaded();
+    }
   }
 
   render() {

--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -57,7 +57,9 @@ export default class JoinUs extends React.Component {
   }
 
   componentDidMount() {
-    this.props.whenLoaded();
+    if (this.props.whenLoaded) {
+      this.props.whenLoaded();
+    }
   }
 
   render() {

--- a/source/js/components/member-notice/member-notice.jsx
+++ b/source/js/components/member-notice/member-notice.jsx
@@ -59,7 +59,9 @@ export default class MemberNotice extends React.Component {
   }
 
   componentDidMount() {
-    this.props.whenLoaded();
+    if (this.props.whenLoaded) {
+      this.props.whenLoaded();
+    }
   }
 
   render() {

--- a/source/js/components/multipage-nav-mobile/multipage-nav-mobile.jsx
+++ b/source/js/components/multipage-nav-mobile/multipage-nav-mobile.jsx
@@ -18,7 +18,9 @@ export default class MultipageNavMobile extends React.Component {
   }
 
   componentDidMount() {
-    this.props.whenLoaded();
+    if (this.props.whenLoaded) {
+      this.props.whenLoaded();
+    }
   }
 
   render() {

--- a/source/js/components/news/news.jsx
+++ b/source/js/components/news/news.jsx
@@ -25,7 +25,9 @@ export default class News extends React.Component {
       this.setState({
         news: JSON.parse(xhr.response)
       }, () => {
-        this.props.whenLoaded();
+        if (this.props.whenLoaded) {
+          this.props.whenLoaded();
+        }
       });
     });
 

--- a/source/js/components/people/people.jsx
+++ b/source/js/components/people/people.jsx
@@ -24,7 +24,9 @@ export default class People extends React.Component {
       this.setState({
         people: JSON.parse(xhr.response)
       }, () => {
-        this.props.whenLoaded();
+        if (this.props.whenLoaded) {
+          this.props.whenLoaded();
+        }
       });
     });
 

--- a/source/js/components/petition/petition.jsx
+++ b/source/js/components/petition/petition.jsx
@@ -339,7 +339,9 @@ export default class Petition extends React.Component {
   }
 
   componentDidMount() {
-    this.props.whenLoaded();
+    if (this.props.whenLoaded) {
+      this.props.whenLoaded();
+    }
   }
 
   /**

--- a/source/js/components/pulse-project-list/pulse-project-list.jsx
+++ b/source/js/components/pulse-project-list/pulse-project-list.jsx
@@ -27,7 +27,9 @@ export default class PulseProjectList extends React.Component {
       this.setState({
         projects: this.props.max ? projects.results.slice(0, this.props.max) : projects.results
       }, () => {
-        this.props.whenLoaded();
+        if (this.props.whenLoaded) {
+          this.props.whenLoaded();
+        }
       });
     });
 

--- a/source/js/components/takeover/takeover.jsx
+++ b/source/js/components/takeover/takeover.jsx
@@ -38,7 +38,9 @@ export default class Takeover extends React.Component {
   }
 
   componentDidMount() {
-    this.props.whenLoaded();
+    if (this.props.whenLoaded) {
+      this.props.whenLoaded();
+    }
   }
 
   render() {


### PR DESCRIPTION
Category slugs added `whenLoaded` behaviour to bg-main.js but the components involved did not wrap those calls in an `if function exists, call it` and so break the bundle when blindly called.