### PR TITLE
remove "npm install" from the start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ If you're on windows, you need an extra step: run `inv manage createsuperuser` t
 
 You're done :tada:
 
+To catch up on new dependencies, migrations, etc. after initial setup, you can use the `inv catch-up` command.
+
 ## Development
 
 ### Pipenv and Invoke commands

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "optimize": "run-p optimize:**",
     "percy": "percy exec -- npm run cypress",
     "server": "pipenv run python network-api/manage.py runserver",
-    "start": "npm i && run-p build-uncompressed server watch:**",
+    "start": "run-p build-uncompressed server watch:**",
     "snyk": "snyk test --file=package.json",
     "test:procfile": "node test/test-procfile.js",
     "test:eslint": "eslint --config ./.eslintrc.yaml \"source/js/**/*.js\" \"source/js/**/*.jsx\" webpack.config.js",


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/2608

Everyone tagged for signoff mostly because it's a change to how to install and run the foundation site.