### PR TITLE
Revisit missing migration tests

### DIFF
--- a/network-api/networkapi/tests.py
+++ b/network-api/networkapi/tests.py
@@ -1,3 +1,5 @@
+from io import StringIO
+
 from django.contrib.auth.models import User, Group
 from django.core.management import call_command
 from django.test import TestCase
@@ -28,7 +30,11 @@ class MissingMigrationsTests(TestCase):
         """
         Ensure we didn't forget a migration
         """
-        call_command('makemigrations', interactive=False, dry_run=True, check_changes=True)
+        output = StringIO()
+        call_command('makemigrations', interactive=False, dry_run=True, stdout=output)
+
+        if output.getvalue() != "No changes detected\n":
+            raise AssertionError("Missing migrations detected:\n" + output.getvalue())
 
 
 class DeleteNonStaffTest(TestCase):


### PR DESCRIPTION
Current test failure is not helpful:

```
ERROR: test_no_migrations_missing (networkapi.tests.MissingMigrationsTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/mozilla/foundation.mozilla.org/network-api/networkapi/tests.py", line 31, in test_no_migrations_missing
    call_command('makemigrations', interactive=False, dry_run=True, check_changes=True)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/django/core/management/__init__.py", line 131, in call_command
    return command.execute(*args, **defaults)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/wagtail_modeltranslation/management/commands/makemigrations_translation.py", line 27, in handle
    super(Command, self).handle(*args, **options)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/django/core/management/commands/makemigrations.py", line 195, in handle
    sys.exit(1)
SystemExit: 1
```

Replace this test by one that output missing migrations:

```
======================================================================
FAIL: test_no_migrations_missing (networkapi.tests.MissingMigrationsTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/lucie/code/network/network-api/networkapi/tests.py", line 37, in test_no_migrations_missing
    raise AssertionError("Missing migrations detected:\n" + output.getvalue())
AssertionError: Missing migrations detected. Run 'inv makemigrations' to solve this issue.
Migrations for 'wagtailpages':
  network-api/networkapi/wagtailpages/migrations/0045_auto_20190215_1413.py
    - Alter field body on modularpage
    - Alter field body_de on modularpage
    - Alter field body_en on modularpage
    - Alter field body_es on modularpage
    - Alter field body_fr on modularpage
    - Alter field body_pl on modularpage
    - Alter field body_pt on modularpage
    - Alter field body on primarypage
    - Alter field body_de on primarypage
    - Alter field body_en on primarypage
    - Alter field body_es on primarypage
    - Alter field body_fr on primarypage
    - Alter field body_pl on primarypage
    - Alter field body_pt on primarypage
```

Inspired by [how Django tests](https://github.com/django/django/blob/master/tests/user_commands/tests.py#L30-L34) their management command.