### PR TITLE
Remove mentions of mezzanine from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,6 @@ As this is REST API and CMS built on top of Django, there are some "gotcha!"s to
 
 The `DEBUG` flag does all sorts of magical things, to the point where testing with debugging turned on effectively runs a completely different setup compared to testing with debugging turned off. When debugging is on, the following things happen:
 
-- Django uses its own built-in static content server, in which template tags may behave *differently* from the Mezzanine static server, which can lead to `400 Bad Request` errors in `DEBUG=False` setting.
 - Django bypasses the `ALLOWED_HOST` restrictions, which again can lead to `400 Bad Request` errors in `DEBUG=False` setting.
 - Rather than HTTP error pages, Django will generate stack traces pages that expose pretty much all environment variables except any that match certain substrings such as `KEY`, `PASS`, etc. for obvious security reasons.
 - ...there are probably more gotchas just for `DEBUG` so if you find any please add them to this list.
-
-#### Use of `{ static "...." }` in templates
-
-Using the `static` tag in templates is supposed both in Django and Mezzanine, but they work differently: in Django, `{static "/..." }` works fine, but in Mezzanine this is a breaking pattern and there **should not** be a leading slash: `{ static "..." }`.


### PR DESCRIPTION
Mezziene was replaced with wagtail a while a go, so a change was requested in #2762 to remove mentions of it from our docs.

Closes #2762 
Related PRs/issues #2746 

## Checklist

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] If my changes are not backward-compatible, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [x] Did I update the READMEs or wagtail documentation?
