### PR TITLE
[WIP] disallow unsafe-inline scripts

### DIFF
--- a/env.default
+++ b/env.default
@@ -46,7 +46,7 @@ CRM_PETITION_SQS_QUEUE_URL=""
 # CSP config
 
 CSP_DEFAULT_SRC="'none'"
-CSP_SCRIPT_SRC='self' 'unsafe-inline' cdn.optimizely.com https://www.google-analytics.com/analytics.js https://*.shpg.org/ http://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js https://airtable.com
+CSP_SCRIPT_SRC='self' cdn.optimizely.com https://www.google-analytics.com/analytics.js https://*.shpg.org/ http://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js https://airtable.com
 CSP_STYLE_SRC='self' 'unsafe-inline' code.cdn.mozilla.net fonts.googleapis.com
 CSP_IMG_SRC=* data:
 CSP_FONT_SRC='self' fonts.gstatic.com fonts.googleapis.com code.cdn.mozilla.net

--- a/network-api/networkapi/buyersguide/static/js/check-polyfill.js
+++ b/network-api/networkapi/buyersguide/static/js/check-polyfill.js
@@ -1,0 +1,12 @@
+var modernBrowser = (
+  'fetch' in window &&
+  'assign' in Object
+);
+
+if ( !modernBrowser ) {
+  var scriptElement = document.createElement('script');
+
+  scriptElement.async = false;
+  scriptElement.src = '/_js/polyfills.compiled.js';
+  document.head.appendChild(scriptElement);
+}

--- a/network-api/networkapi/buyersguide/templates/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/bg_base.html
@@ -1,4 +1,4 @@
-{% load bg_nav_tags %}
+{% load static bg_nav_tags %}
 
 <!DOCTYPE html>
 <html>
@@ -23,20 +23,7 @@
     <link rel="icon" type="image/png" sizes="196x196" href="/_images/favicons/favicon-196x196@2x.png">
     <link rel="shortcut icon" href="/_images/favicons/favicon.ico">
     <title>{% if pageTitle %}{{ pageTitle }}{% else %}Mozilla - *privacy not included{% endif %}</title>
-    <script>
-      var modernBrowser = (
-        'fetch' in window &&
-        'assign' in Object
-      );
-
-      if ( !modernBrowser ) {
-        var scriptElement = document.createElement('script');
-
-        scriptElement.async = false;
-        scriptElement.src = '/_js/polyfills.compiled.js';
-        document.head.appendChild(scriptElement);
-      }
-    </script>
+    <script src="{% static "js/check-polyfill.js" %}"></script>
   </head>
   <body class="pni" id="pni-{% block body-id %}{% endblock %}">
     <script src="/_js/bg-main.compiled.js" async defer></script>


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/1099 by removing the `unsafe-inline` CSP keyword for scripts. Wagtail itself already removed reliance on that, and so the only thing I could find that violated it was our polyshim check in the buyers guide base template, which was trivially moved to its own static file and src-linked rather than inlined.

### EDIT

turns out there is some script injection for the language picker code that we added to the CMS, so this PR is still WIP.