### PR TITLE
Remove Email CTA Part 1 of 2

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/opportunity_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/opportunity_page.html
@@ -1,12 +1,6 @@
 {% extends "./mini_site_name_space.html" %}
 {% load wagtailcore_tags mini_site_tags %}
 
-{% block signup %}
-	{% if page.cta %}
-    {% cta page %}
-	{% endif %}
-{% endblock %}
-
 {% block subcontent %}
   {% mini_site_sidebar page %}
 


### PR DESCRIPTION
Related PRs/issues #2899 

This pr removes the email cta from the `Opportunity` template as requested [here](https://github.com/mozilla/foundation.mozilla.org/issues/2899#issuecomment-477209814). Part 2 will remove it from models in a separate pr. 

[Test page](https://foundation-mofostaging-pr-2906.herokuapp.com/en/opportunity/no-sign-up-cta/) and/or feel free to check out [Percy](https://percy.io/Mozilla-Foundation/foundation.mozilla.org/builds/1648225?utm_campaign=Mozilla-Foundation&utm_content=foundation.mozilla.org&utm_source=github_status_public).

cc: @kristinashu @alanmoo 
