### PR TITLE
Caching Cypress binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ cache:
   pip: true
   directories:
     - "$HOME/.npm"
+    # Caching cypress binary
+    - ~/.cache
 branches:
   only:
     - master


### PR DESCRIPTION
Unzipping Cypress takes a few minutes and it slowing everything down. Caching the binary like recommended in Cypress doc: https://docs.cypress.io/guides/guides/continuous-integration.html#Travis