### PR TITLE
fix scrollbar <= 768px on Windows

### DIFF
--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -214,10 +214,10 @@
         padding-top: 72px;
       }
 
-      height: 100vh;
       top: 0;
-      left: 0;
       right: 0;
+      bottom: 0;
+      left: 0;
       background: white;
       transition: opacity 0.2s, height 0s;
 

--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -217,7 +217,7 @@
       height: 100vh;
       top: 0;
       left: 0;
-      width: 100vw;
+      right: 0;
       background: white;
       transition: opacity 0.2s, height 0s;
 


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/2952 by switching the mobile nav element from using anchoring position+dimensions (`top:0; left: 0; width: 100vw; height: 100vh;`) to using pure anchoring position (`top:0; right: 0; bottom:0; left:0;`, effecting the same full width/height nav without the possibility of running into errors due to using a fixed number of units