### PR TITLE
signup was missing O_o

### DIFF
--- a/network-api/networkapi/wagtailpages/translation.py
+++ b/network-api/networkapi/wagtailpages/translation.py
@@ -15,6 +15,7 @@ from .models import (
 
     CTA,
     Petition,
+    Signup,
 
     # DEPRECATED
     ParticipatePage,
@@ -74,6 +75,12 @@ class CTATR(TranslationOptions):
 
 @register(Petition)
 class PetitionTR(TranslationOptions):
+    fields = (
+    )
+
+
+@register(Signup)
+class SignupTR(TranslationOptions):
     fields = (
     )
 


### PR DESCRIPTION
Discovered as part of https://github.com/mozilla/foundation.mozilla.org/pull/2956

The `Signup` snippet does not have localization enabled, which means it cannot be saved without manually duplicating information across the base fields, as well as the `[EN]` copy fields.

This fixes that: test it by trying to create a new Signup snippet but only filling in the normal fields - you should get a confusing error about fields that cannot be empty, despite not being empty when you try to save. Pull this code change, run `inv catch-up` to make sure it gets applied correctly, and then try to make the same signup snippet with the same "only the base fields" data. Saving should now work fine.
