### PR TITLE
Add defaults for basket's "lang" and "format" fields

### DIFF
--- a/network-api/networkapi/campaign/views.py
+++ b/network-api/networkapi/campaign/views.py
@@ -86,6 +86,8 @@ def petition_submission_view(request, pk):
 def signup_submission(request, signup):
     data = {
         "email": request.data['email'],
+        "lang": "en",
+        "format": "html",
         "source_url": request.data['source'],
         "newsletters": signup.newsletter,
     }


### PR DESCRIPTION
Adds the "lang" and "format" options for basket to our new signup code, defaulting to `en` and `html` respectively for now (with https://github.com/mozilla/foundation.mozilla.org/issues/2991 files to address this in a more general way)

Related PRs/issues https://github.com/mozmeao/basket/issues/152