### PR TITLE
Force image to be 50*50px in image text mini component

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text_mini.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text_mini.html
@@ -2,7 +2,7 @@
 
 <div class="my-5">
   <div class="p-2 p-md-3 col-12 d-flex align-items-center img-txt-mini-container">
-    <div class="mr-3 mr-md-4">
+    <div class="img-txt-mini-img-container mr-2">
       {% image value.image fill-100x100-c100 format-jpeg class="w-100" %}
     </div>
     <div class="img-txt-mini-text">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text_mini.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text_mini.html
@@ -2,7 +2,7 @@
 
 <div class="my-5">
   <div class="p-2 p-md-3 col-12 d-flex align-items-center img-txt-mini-container">
-    <div class="img-txt-mini-img-container mr-2">
+    <div class="img-txt-mini-img-container mr-2 mr-md-3">
       {% image value.image fill-100x100-c100 format-jpeg class="w-100" %}
     </div>
     <div class="img-txt-mini-text">

--- a/source/sass/components/img-txt-mini.scss
+++ b/source/sass/components/img-txt-mini.scss
@@ -2,15 +2,10 @@
   &-container {
     border-top: 1px solid $black;
     border-bottom: 1px solid $black;
+  }
 
-    img {
-      min-width: 30px;
-      max-width: 65px;
-
-      @include media-breakpoint-up(md) {
-        min-width: 50px;
-      }
-    }
+  &-img-container {
+    flex: 0 0 50px;
   }
 
   &-text {


### PR DESCRIPTION
Closes #3076 

Test page: https://foundation-mofostaging-pr-3080.herokuapp.com/en/test-page/

I didn't modify this part but note that padding (purple highlighted area) is set to 16px on medium+ devices and 8px for smaller devices. 
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/2896608/56992292-8edd4e00-6b4e-11e9-924a-492b14a5994a.png">

