### PR TITLE
Changed line height for .body-large to 1.5

### DIFF
--- a/source/sass/type.scss
+++ b/source/sass/type.scss
@@ -73,7 +73,7 @@ h6,
 .body-large,
 .body-large p {
   @include body-text(null, 300, $black, $white);
-  @include scaleText(18px, 24px, 20px, 28px);
+  @include scaleText(18px, 27px, 20px, 30px);
 }
 
 p,


### PR DESCRIPTION
Closes #3081 

https://foundation-mofostaging-pr-3082.herokuapp.com/en/styleguide/


<img width="953" alt="image" src="https://user-images.githubusercontent.com/2896608/56996671-1da39800-6b5a-11e9-967e-3c9fec01b985.png">

<img width="820" alt="image" src="https://user-images.githubusercontent.com/2896608/56996640-09f83180-6b5a-11e9-8c3d-3d89ec8c9ce7.png">

