### PR TITLE
Fix formatting of CSP_FRAME_SRC variable in env.default

### DIFF
--- a/env.default
+++ b/env.default
@@ -54,7 +54,7 @@ CSP_CONNECT_SRC=*
 CSP_MEDIA_SRC="'self'"
 CSP_CHILD_SRC='self' https://www.youtube.com/ https://s3.amazonaws.com/
 CSP_FORM_ACTION='self' https://www.mozilla.org/en-US/newsletter/
-CSP_FRAME_SRC = https://airtable.com
+CSP_FRAME_SRC=https://airtable.com
 
 # TEST ENVIRONMENT VALUES
 


### PR DESCRIPTION
Closes: No related issue

There should not be whitespace in an env file, between the variable name, the equal sign, and the variable's value.

## Checklist

**Tests**
- No test changes required 

**Changes in Models:**
- No Model changes

**Documentation:**
- No Documentation changes required