### PR TITLE
Prevent PG port conflicts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   postgres:
     image: postgres:9.6
     ports:
-      - "5432"
+      - "5439"
     volumes:
       - postgres_data:/var/lib/postgresql/data/
 

--- a/tasks.py
+++ b/tasks.py
@@ -25,7 +25,7 @@ def create_docker_env_file(env_file):
     # remove the double quote for docker-compose and python_dotenv compatibility reasons
     env_vars = env_vars.replace('"', '')
     # update the DATABASE_URL env
-    new_db_url = "DATABASE_URL=postgres://postgres@postgres:5432/postgres"
+    new_db_url = "DATABASE_URL=postgres://postgres@postgres:5439/postgres"
     old_db_url = re.search('DATABASE_URL=.*', env_vars)
     env_vars = env_vars.replace(old_db_url.group(0), new_db_url)
     # update the ALLOWED_HOSTS


### PR DESCRIPTION
This switchies the postgres port to 5439 rather than using the default 5432, so that it does not crash the docker setup process if someone happens to also have postgres installed and running for other work.