### PR TITLE
Make cms url more forgiving, add page edit link

### DIFF
--- a/cypress/integration/endpoint-tests.js
+++ b/cypress/integration/endpoint-tests.js
@@ -12,7 +12,7 @@ describe(`Visual regression testing for foundation.mozilla.org`, () => {
     cy.window()
       .its(`main-js:react:finished`)
       .should(`equal`, true);
-    cy.wait(500);
+    cy.wait(1000);
     cy.percySnapshot();
   });
 

--- a/cypress/integration/endpoint-tests.js
+++ b/cypress/integration/endpoint-tests.js
@@ -12,7 +12,7 @@ describe(`Visual regression testing for foundation.mozilla.org`, () => {
     cy.window()
       .its(`main-js:react:finished`)
       .should(`equal`, true);
-    cy.wait(1000);
+    cy.wait(500);
     cy.percySnapshot();
   });
 

--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -18,7 +18,7 @@
 
     {% if user.is_authenticated %}
     <div class="authenticated-page-edit" style="position: fixed; bottom:0; background: teal; padding: 0.25em; z-index:1000">
-      <a style="color: white" href="/cms/pages/{{page.id}}/">Edit</a>
+      <a style="color: white" href="/cms/pages/{{page.id}}/edit/">Edit</a>
     </div>
     {% endif %}
 

--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -16,6 +16,12 @@
   </head>
   <body id="view-{% block bodyID %}{% endblock %}">
 
+    {% if user.is_authenticated %}
+    <div class="authenticated-page-edit" style="position: fixed; bottom:0; background: teal; padding: 0.25em; z-index:1000">
+      <a style="color: white" href="/cms/pages/{{page.id}}/">Edit</a>
+    </div>
+    {% endif %}
+
     {% block donate %}
     <div class="donate-modal-wrapper">
       <!-- this will be populated by main.js if needed -->

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -40,7 +40,7 @@ urlpatterns = list(filter(None, [
         name='how-do-i-wagtail'
     ),
     url(r'^cms/', include(wagtailadmin_urls)),
-    url(r'^en/cms/', RedirectView.as_view(url='/cms')),
+    url(r'^en/cms/', RedirectView.as_view(url='/cms/')),
     url(r'^documents/', include(wagtaildocs_urls)),
     url('^sitemap.xml$', sitemap) if settings.DEBUG else None,
 ]))

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -40,6 +40,7 @@ urlpatterns = list(filter(None, [
         name='how-do-i-wagtail'
     ),
     url(r'^cms/', include(wagtailadmin_urls)),
+    url(r'^en/cms/', RedirectView.as_view(url='/cms')),
     url(r'^documents/', include(wagtaildocs_urls)),
     url('^sitemap.xml$', sitemap) if settings.DEBUG else None,
 ]))


### PR DESCRIPTION
These things were annoying me

`/en/cms` now redirects to `/cms`
When logged in, there's an "edit" button at the bottom of Wagtail pages to view the page in the admin.

I made it a link to the "view page" so that a user still goes somewhere useful if they can't edit the page. I also hardcoded the styles because it's so separate from anything else on the site, it didn't feel like it made sense to embed in the page CSS. The edit button is in the bottom left so it doesn't get in the way of the nav.