### PR TITLE
Install the postgresql-client to the python container

### DIFF
--- a/dockerfiles/Dockerfile.python
+++ b/dockerfiles/Dockerfile.python
@@ -12,7 +12,8 @@ RUN apk add --no-cache \
     build-base \
     jpeg-dev \
     zlib-dev \
-    postgresql-dev
+    postgresql-dev \
+    postgresql-client
 
 # Install pipenv
 RUN pip install pipenv


### PR DESCRIPTION
This PR allows the use of `inv docker-manage dbshell` by installing the postgresql-client package.

To test, just run the command above after rebuilding your container `docker-compose build backend`