### PR TITLE
Remove forced coloring of blog links

### DIFF
--- a/network-api/networkapi/utility/faker/streamfield_provider.py
+++ b/network-api/networkapi/utility/faker/streamfield_provider.py
@@ -24,6 +24,7 @@ def generate_field(field_type, value):
 
 def generate_paragraph_field():
     paragraphs = (
+        f'<p>'
         f'<h3>{fake.sentence()}</h3>',
         f'<p>{fake.text(max_nb_chars=200)} <b>This sentence is in bold text.</b> {fake.text(max_nb_chars=200)} '
         f'<a href="{fake.url(schemes=["https"])}">This is a link to a fake url!</a> '
@@ -32,7 +33,8 @@ def generate_paragraph_field():
         f'<ul>',
         ''.join([f'<li>{fake.word()}</li>' for i in range(10)]),
         f'</ul><br />',
-        f'<a href="{fake.url(schemes=["https"])}">This is a link to a fake url!</a>'
+        f'<a href="{fake.url(schemes=["https"])}">This is a link to a fake url!</a>',
+        f'</p>'
     )
 
     return generate_field('paragraph', ''.join(paragraphs))

--- a/network-api/networkapi/utility/faker/streamfield_provider.py
+++ b/network-api/networkapi/utility/faker/streamfield_provider.py
@@ -24,17 +24,15 @@ def generate_field(field_type, value):
 
 def generate_paragraph_field():
     paragraphs = (
-        f'<p>'
         f'<h3>{fake.sentence()}</h3>',
-        f'<p>{fake.text(max_nb_chars=200)} <b>This sentence is in bold text.</b> {fake.text(max_nb_chars=200)} '
-        f'<a href="{fake.url(schemes=["https"])}">This is a link to a fake url!</a> '
+        f'<p>{fake.text(max_nb_chars=200)} <b>This sentence is in bold text.</b> {fake.text(max_nb_chars=200)} ',
+        f'<a href="{fake.url(schemes=["https"])}">This is a link to a fake url!</a> ',
         f'{fake.paragraph(nb_sentences=20, variable_nb_sentences=True)}</p>',
-        f'<p>{fake.paragraph(nb_sentences=20, variable_nb_sentences=True)}',
+        f'<p>{fake.paragraph(nb_sentences=20, variable_nb_sentences=True)}</p>',
         f'<ul>',
         ''.join([f'<li>{fake.word()}</li>' for i in range(10)]),
         f'</ul><br />',
-        f'<a href="{fake.url(schemes=["https"])}">This is a link to a fake url!</a>',
-        f'</p>'
+        f'<p><a href="{fake.url(schemes=["https"])}">This is a link to a fake url!</a></p>',
     )
 
     return generate_field('paragraph', ''.join(paragraphs))

--- a/source/sass/wagtail.scss
+++ b/source/sass/wagtail.scss
@@ -74,8 +74,7 @@
     .block-paragraph {
       p,
       ul,
-      ol,
-      a {
+      ol {
         @extend .body-large;
       }
     }


### PR DESCRIPTION
Since links are always inside `p` elements, we don’t need to explicitly set the color.

Closes #3127