### PR TITLE
put homepage banner text/button in the forefront

### DIFF
--- a/source/sass/mozfest.scss
+++ b/source/sass/mozfest.scss
@@ -5,6 +5,16 @@ body.mozfest {
 
       .banner {
         height: var(--moz_banner_height);
+
+        .homepage-top-content {
+          /*
+            This puts the homepage on-banner text
+            and button in the forefront, so it can
+            be text-selected, and buttons clicked.
+          */
+          position: relative;
+          z-index: 1;
+        }
       }
 
       .cutout {


### PR DESCRIPTION
issue-less, I noticed the content on the mozfest homepage in the banner wasn't interactable, which is a problem if we want people to be able to press the "watch now" button.