### PR TITLE
Add the mobile nav for subpages

### DIFF
--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest_primary_page.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest_primary_page.html
@@ -4,5 +4,7 @@
 {% block mozfestBodyId %}primary{% endblock %}
 
 {% block secondary_nav %}
+  {% include "partials/multipage-nav-mobile.html" %}
   {% primary_page_menu page %}
 {% endblock %}
+


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3193

We were missing the mobile nav for subpage navigation.