### PR TITLE
added in the same rules we use for narrow content on foundation pages

### DIFF
--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -29,7 +29,7 @@
 
   <div class="container cms">
     <div class="row my-1 d-flex align-items-center">
-      <div class="pb-5 col-12">
+      <div class="pb-5 {% block bootstrap_width %}col-lg-8 offset-lg-2{% endblock %}">
         {% for block in page.body %}
           {% if block.block_type == 'heading' %}
             <h1>{{ block.value }}</h1>

--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest_homepage.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest_homepage.html
@@ -7,6 +7,8 @@
   {% include "partials/primary_heroguts.html" with root=root page=page homepage=True %}
 {% endblock %}
 
+{% block bootstrap_width %}col-lg-12{% endblock %}
+
 {% block prefooter %}
   <div class="prefooter container">
     <div class="row">

--- a/network-api/networkapi/mozfest/templates/partials/primary_heroguts.html
+++ b/network-api/networkapi/mozfest/templates/partials/primary_heroguts.html
@@ -16,7 +16,7 @@
 
   <div class="container">
     <div class="row no-gutters">
-      <div class="cutout col-12 pt-4">
+      <div class="cutout pt-4 col-12 {% if homepage != True %}col-md-8{% endif %}">
         <h1 class="h2-heading mb-0">{% if root.title %}{{ root.title }}{% elif page.header %}{{ page.header }}{% else %}{{ page.title }}{% endif %}</h1>
         {% if page.intro %}
         <p class="body-large mt-3 mb-0">{{ page.intro | richtext }}</p>


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3199
Related PRs/issues https://github.com/mozilla/foundation.mozilla.org/issues/3160

This adds the bootstrapping we use for pages like https://foundation.mozilla.org/en/internet-health/ for all primary pages, with an override for the mozfest homepage so that its content is unrestricted.