### PR TITLE
GA identifier as meta + provisioned for mozfest

### DIFF
--- a/network-api/networkapi/buyersguide/templates/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/bg_base.html
@@ -5,16 +5,19 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:type" content="website" />
-    {% block head-extra %}
-      <meta property="og:title" content="*Privacy Not Included: A Buyer’s Guide for Connected Products" />
+    {% block ga_identifier %}
+    <meta name="ga-identifier" content="UA-87658599-6">
     {% endblock %}
-    <meta property="og:description" content="89 connected products rated on their safety and security" />
-    <meta property="og:image" content="{{request.scheme}}://{{request.get_host}}/_images/buyers-guide/share.jpg" />
-    <meta property="og:image:type" content="image/jpg" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="628" />
-    <meta property="og:url" content="{{request.scheme}}://{{request.get_host}}{{request.path}}" />
+    <meta property="og:type" content="website">
+    {% block head-extra %}
+    <meta property="og:title" content="*Privacy Not Included: A Buyer’s Guide for Connected Products">
+    {% endblock %}
+    <meta property="og:description" content="89 connected products rated on their safety and security">
+    <meta property="og:image" content="{{request.scheme}}://{{request.get_host}}/_images/buyers-guide/share.jpg">
+    <meta property="og:image:type" content="image/jpg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="628">
+    <meta property="og:url" content="{{request.scheme}}://{{request.get_host}}{{request.path}}">
     <link rel="stylesheet" href="/_css/buyers-guide.compiled.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Nunito+Sans:400,300,700,300i">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,400,600,700,300i">

--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -1,6 +1,11 @@
 {% extends "pages/base.html" %}
 {% load wagtailcore_tags wagtailimages_tags homepage_tags card_tags wagtailmetadata_tags multi_image_tags %}
 
+
+{% block ga_identifier %}
+  <meta name="ga-identifier" content="UA-87658599-15">
+{% endblock %}
+
 {% block bodyclass %}mozfest{% endblock %}
 
 {% block pageTitle %}

--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">{% block socialMetadata %}{% endblock %}
     <meta name="google-site-verification" content="D7k-r3fHm-XfJ9E7T1uZ5aqHJG2mx-0uUZFeBUDN2lY">
+    {% block ga_identifier %}
+    <meta name="ga-identifier" content="UA-87658599-6">
+    {% endblock %}
     <meta name="csrf-token" content="{{ csrf_token }}">
     <link rel="stylesheet" href="/_css/main.compiled.css">
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Nunito+Sans:400,300,700,300i">

--- a/source/js/analytics.js
+++ b/source/js/analytics.js
@@ -1,26 +1,49 @@
 export default {
-  initialize: function() {
+  initialize: function(gaIdentifier = undefined) {
+    if (!gaIdentifier) {
+      console.warn(`No GA identifier found: skipping bootstrap step`);
+    }
+
     var _dntStatus = navigator.doNotTrack || navigator.msDoNotTrack;
     var fxMatch = navigator.userAgent.match(/Firefox\/(\d+)/);
     var ie10Match = navigator.userAgent.match(/MSIE 10/i);
     var w8Match = navigator.appVersion.match(/Windows NT 6.2/);
 
     if (fxMatch && Number(fxMatch[1]) < 32) {
-      _dntStatus = 'Unspecified';
+      _dntStatus = `Unspecified`;
     } else if (ie10Match && w8Match) {
-      _dntStatus = 'Unspecified';
+      _dntStatus = `Unspecified`;
     } else {
-      _dntStatus = { '0': 'Disabled', '1': 'Enabled' }[_dntStatus] || 'Unspecified';
+      _dntStatus =
+        {
+          "0": `Disabled`,
+          "1": `Enabled`
+        }[_dntStatus] || `Unspecified`;
     }
 
-    if (_dntStatus !== 'Enabled'){
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    if (_dntStatus !== `Enabled`) {
+      (function(i, s, o, g, r, a, m) {
+        i[`GoogleAnalyticsObject`] = r;
+        (i[r] =
+          i[r] ||
+          function() {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(
+        window,
+        document,
+        `script`,
+        `https://www.google-analytics.com/analytics.js`,
+        `ga`
+      );
 
-      ga('create', 'UA-87658599-6', 'auto');
-      ga('send', 'pageview');
+      ga(`create`, gaIdentifier, `auto`);
+      ga(`send`, `pageview`);
     }
   },
 
@@ -28,7 +51,15 @@ export default {
     if (!window.ga) {
       return;
     }
-    window.ga('send', category, 'navigation', action, label);
-    window.ga('send', 'event', 'navigation', 'page footer cta', document.querySelectorAll('.cms h1').length > 0 ? document.querySelectorAll('.cms h1')[0].innerText + ' - footer cta' : '');
+    window.ga(`send`, category, `navigation`, action, label);
+    window.ga(
+      `send`,
+      `event`,
+      `navigation`,
+      `page footer cta`,
+      document.querySelectorAll(`.cms h1`).length > 0
+        ? `${document.querySelectorAll(`.cms h1`)[0].innerText} - footer cta`
+        : ``
+    );
   }
 };

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -33,8 +33,18 @@ let main = {
         networkSiteURL = `https://${env.HEROKU_APP_NAME}.herokuapp.com`;
       }
 
-      ReactGA.initialize(`UA-87658599-6`);
-      ReactGA.pageview(window.location.pathname);
+      // TODO: this should probably tap into the analytics.js file that
+      // we use in main.js so that we only have one place where top level
+      // changes to how analytics works need to be made.
+
+      const gaMeta = document.querySelector(`meta[name="ga-identifier"]`);
+      if (gaMeta) {
+        let gaIdentifier = gaMeta.getAttribute(`content`);
+        ReactGA.initialize(gaIdentifier); // UA-87658599-6 by default
+        ReactGA.pageview(window.location.pathname);
+      } else {
+        console.warn(`No GA identifier found: skipping bootstrap step`);
+      }
 
       this.enableCopyLinks();
       this.injectReactComponents();

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -30,15 +30,19 @@ let main = {
       env = envData;
       networkSiteURL = env.NETWORK_SITE_URL;
 
-      csrfToken = document.querySelector('meta[name="csrf-token"]');
-      csrfToken = csrfToken ? csrfToken.getAttribute("content") : false;
+      csrfToken = document.querySelector(`meta[name="csrf-token"]`);
+      csrfToken = csrfToken ? csrfToken.getAttribute(`content`) : false;
 
       // HEROKU_APP_DOMAIN is used by review apps
       if (!networkSiteURL && env.HEROKU_APP_NAME) {
         networkSiteURL = `https://${env.HEROKU_APP_NAME}.herokuapp.com`;
       }
 
-      Analytics.initialize();
+      const gaMeta = document.querySelector(`meta[name="ga-identifier"]`);
+      if (gaMeta) {
+        let gaIdentifier = gaMeta.getAttribute(`content`);
+        Analytics.initialize(gaIdentifier);
+      }
 
       this.injectReactComponents();
       this.bindGlobalHandlers();
@@ -155,25 +159,27 @@ let main = {
 
     // Extra tracking
 
-    document
-      .getElementById(`donate-header-btn`)
-      .addEventListener(`click`, () => {
+    let donateHeaderBtn = document.getElementById(`donate-header-btn`);
+    if (donateHeaderBtn) {
+      donateHeaderBtn.addEventListener(`click`, () => {
         ReactGA.event({
           category: `donate`,
           action: `donate button tap`,
           label: `${document.title} header`
         });
       });
+    }
 
-    document
-      .getElementById(`donate-footer-btn`)
-      .addEventListener(`click`, () => {
+    let donateFooterBtn = document.getElementById(`donate-footer-btn`);
+    if (donateFooterBtn) {
+      donateFooterBtn.addEventListener(`click`, () => {
         ReactGA.event({
           category: `donate`,
           action: `donate button tap`,
           label: `${document.title} footer`
         });
       });
+    }
   },
 
   bindGAEventTrackers() {
@@ -351,10 +357,10 @@ let main = {
 
     filters.forEach(filter => {
       let year = filter.textContent.trim();
-      filter.addEventListener("click", () => {
+      filter.addEventListener(`click`, () => {
         ReactGA.event({
           category: `profiles`,
-          action: `directory filter"`,
+          action: `directory filter`,
           label: `${document.title} ${year}`
         });
       });


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3203
Related PRs/issues https://github.com/mozilla/foundation.mozilla.org/issues/3160

This moves the ga-identifier to a `<meta>` element so that we don't need to hardcode it javascript, but can specify, per "site" which GA id should be used.
