### PR TITLE
only allow the django.utils.autoreload logger to log errors

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -530,6 +530,10 @@ LOGGING = {
             'handlers': ['debug-error'],
             'level': 'ERROR'
         },
+        'django.utils.autoreload': {
+            'handlers': ['debug-error'],
+            'level': 'ERROR'
+        }
     }
 }
 DJANGO_LOG_LEVEL = env('DJANGO_LOG_LEVEL')


### PR DESCRIPTION
overrides the default logging config for django.utils.autoreload.