### PR TITLE
Updated MozFest 'submit proposal' link on nav

### DIFF
--- a/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
+++ b/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
@@ -39,9 +39,7 @@
                   </div>
                 </div>
               </div>
-              <div class="submit-btn-wrapper">
-                <a id="submit-header-btn" class="btn btn-secondary submit-header" href="#tobedetermined" target="_blank" rel="noopener noreferrer">Submit proposal</a>
-              </div>
+              <a class="btn btn-secondary" href="/proposals">Submit proposal</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #3256 

Updated MozFest 'submit proposal' link on nav & deleted extra `id`,`class`, and wrapper `div`.

https://foundation-mofostaging-pr-3265.herokuapp.com/