### PR TITLE
Add socialMetadata block to mozfest base

### DIFF
--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -6,6 +6,12 @@
   <meta name="ga-identifier" content="UA-87658599-15">
 {% endblock %}
 
+{% block socialMetadata %}
+    <meta property='og:type' content='website'>
+    <meta property='og:locale' content='en_US'>
+    {% meta_tags %}
+{% endblock %}
+
 {% block bodyclass %}mozfest{% endblock %}
 
 {% block pageTitle %}


### PR DESCRIPTION
Closes #3261 

To test, look at Mozfest template [homepage](https://foundation-mofostaging-pr-3271.herokuapp.com) and [primary page](https://foundation-mofostaging-pr-3271.herokuapp.com/en/mozfest-primary-page/) and notice that while the primary page doesn't have promote info in the admin, it inherits from the homepage. And they both have OG tags in the source now.