### PR TITLE
change mozfest page URLs when using a review app

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/nav-links.html
+++ b/network-api/networkapi/mozfest/templates/fragments/nav-links.html
@@ -1,5 +1,7 @@
 {% load primary_active_nav %}
 
+{# TODO: Dynamically generated Nav links: https://github.com/mozilla/foundation.mozilla.org/issues/3289 #}
+
 {% if HEROKU_APP_NAME %}
 
 {{ pre }}<a class="{% primary_active_nav request '/mozilla-festival/spaces' %}" href="/mozilla-festival/spaces">Spaces</a>{{ post }}

--- a/network-api/networkapi/mozfest/templates/fragments/nav-links.html
+++ b/network-api/networkapi/mozfest/templates/fragments/nav-links.html
@@ -1,8 +1,18 @@
 {% load primary_active_nav %}
 
+{% if HEROKU_APP_NAME %}
+
+{{ pre }}<a class="{% primary_active_nav request '/mozilla-festival/spaces' %}" href="/mozilla-festival/spaces">Spaces</a>{{ post }}
+{{ pre }}<a class="{% primary_active_nav request '/mozilla-festival/team' %}" href="/mozilla-festival/team">Team</a>{{ post }}
+{{ pre }}<a class="{% primary_active_nav request '/mozilla-festival/tickets' %}" href="/mozilla-festival/tickets">Tickets</a>{{ post }}
+{{ pre }}<a class="{% primary_active_nav request '/mozilla-festival/sponsors' %}" href="/mozilla-festival/sponsors">Sponsors</a>{{ post }}
+{% endif %}
+
+{% if not HEROKU_APP_NAME %}
 {{ pre }}<a class="{% primary_active_nav request '/spaces' %}" href="/spaces">Spaces</a>{{ post }}
 {{ pre }}<a class="{% primary_active_nav request '/team' %}" href="/team">Team</a>{{ post }}
 {{ pre }}<a class="{% primary_active_nav request '/tickets' %}" href="/tickets">Tickets</a>{{ post }}
 {{ pre }}<a class="{% primary_active_nav request '/sponsors' %}" href="/sponsors">Sponsors</a>{{ post }}
+{% endif %}
 
 {% if HEROKU_APP_NAME %}{{ pre }}<a href="/help">DEV HELP</a>{{ post }}{% endif %}


### PR DESCRIPTION
The URLs for mozfest site pages are different on review apps, so I modified the nav template fragment so that if `HEROKU_APP_NAME` is set, it will use URLs with `/mozilla-festival/` as the prefix.

I'm open to suggestions if anyone can think of a DRY-er way to achieve this..