### PR TITLE
Updated MozFest site's title meta to add 2019 to the end of it

### DIFF
--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -16,7 +16,7 @@
 {% block bodyclass %}mozfest{% endblock %}
 
 {% block pageTitle %}
-    Mozfest - {% if page.specifics.seo_title %}{{ page.specifics.seo_title }}{% else %}{{ page.title }}{% endif %}
+    Mozilla Festival 2019{% if page.specifics.seo_title %} - {{ page.specifics.seo_title }}{% else %} - {{ page.title }}{% endif %}
 {% endblock %}
 
 {% block bodyID %}mozfest-{% block mozfestBodyId %}home{% endblock %}{% endblock %}

--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -16,7 +16,7 @@
 {% block bodyclass %}mozfest{% endblock %}
 
 {% block pageTitle %}
-    Mozilla Festival - {% if page.specifics.seo_title %}{{ page.specifics.seo_title }}{% else %}{{ page.title }}{% endif %}
+    Mozfest - {% if page.specifics.seo_title %}{{ page.specifics.seo_title }}{% else %}{{ page.title }}{% endif %}
 {% endblock %}
 
 {% block bodyID %}mozfest-{% block mozfestBodyId %}home{% endblock %}{% endblock %}


### PR DESCRIPTION
~Reverts mozilla/foundation.mozilla.org#3264 due to change of specs~

https://foundation-mofostaging-pr-3302.herokuapp.com/

### Review tips

To make main Foundation site pages (or vice versa, MozFest site) show, you have to manually change the setting on Wagtail: 😂 

1. go to /cms on review app
2. go to "Setting" from side menu
3. choose "Sites"
4. click on `foundation-mofostaging-pr-<pr-number>.herokuapp.com`
5. choose "CHOOSE A DIFFERENT ROOT PAGE"
6. select "homepage" (or vice versa, MozFest site)
7. visit review app again