### PR TITLE
initial rewrite for one-week dismissals

### DIFF
--- a/source/js/donate-modal/donate-modal.jsx
+++ b/source/js/donate-modal/donate-modal.jsx
@@ -11,8 +11,8 @@ class DonateModal extends React.Component {
   constructor(props) {
     super(props);
 
-    const INITIAL_DELAY = parseInt(this.props.delay) || 10 * MILLISECONDS; // 10 seconds, in ms
-    const DISMISSAL_DELAY = parseInt(this.props.hideFor) || 7; // one week, in days
+    const INITIAL_DELAY_IN_MILLISECONDS = parseInt(this.props.delay) || 10 * MILLISECONDS; // 10 seconds, in ms
+    const DISMISSAL_DELAY_IN_DAYS = parseInt(this.props.hideFor) || 7; // one week, in days
 
     // Don't treat the modal as dismissed if:
     // 1. the user never dismissed it before, or
@@ -21,13 +21,13 @@ class DonateModal extends React.Component {
     let lastLoad = localStorage[DISMISSED_CHECK_KEY];
     if (lastLoad) {
       var diff = (Date.now() - parseInt(lastLoad, 10)) / DAY;
-      if (diff < DISMISSAL_DELAY) {
+      if (diff < DISMISSAL_DELAY_IN_DAYS) {
         dismissed = true;
       }
     }
 
     this.state = {
-      delay: INITIAL_DELAY,
+      delay: INITIAL_DELAY_IN_MILLISECONDS,
       visible: false,
       dismissed
     };

--- a/source/js/donate-modal/donate-modal.jsx
+++ b/source/js/donate-modal/donate-modal.jsx
@@ -11,7 +11,8 @@ class DonateModal extends React.Component {
   constructor(props) {
     super(props);
 
-    const INITIAL_DELAY_IN_MILLISECONDS = parseInt(this.props.delay) || 10 * MILLISECONDS; // 10 seconds, in ms
+    const INITIAL_DELAY_IN_MILLISECONDS =
+      parseInt(this.props.delay) || 10 * MILLISECONDS; // 10 seconds, in ms
     const DISMISSAL_DELAY_IN_DAYS = parseInt(this.props.hideFor) || 7; // one week, in days
 
     // Don't treat the modal as dismissed if:

--- a/source/js/donate-modal/donate-modal.jsx
+++ b/source/js/donate-modal/donate-modal.jsx
@@ -2,56 +2,45 @@ import React from "react";
 import ReactDOM from "react-dom";
 import ReactGA from "../react-ga-proxy.js";
 
-const KEY_STATE = `donate modal state`;
-const KEY_TIMER = `donate modal timer`;
-const DELAY = 10000; // in ms
-const TIMER_INCREMENT = 1000; // in ms
+const DISMISSED_CHECK_KEY = "fundraising-banner";
+const MILLISECONDS = 1000;
+const DAY = 24 * 3600 * MILLISECONDS;
+const localStorage = typeof window === "undefined" ? {} : window.localStorage;
 
 class DonateModal extends React.Component {
   constructor(props) {
     super(props);
 
-    let dismissed = !!sessionStorage.getItem(KEY_STATE) || false;
-    let prevTimer = this.getPrevTimer();
+    const INITIAL_DELAY = parseInt(this.props.delay) || 10 * MILLISECONDS; // 10 seconds, in ms
+    const DISMISSAL_DELAY = parseInt(this.props.hideFor) || 7; // one week, in days
+
+    // Don't treat the modal as dismissed if:
+    // 1. the user never dismissed it before, or
+    // 2. it's been longer than a week since they dismissed
+    let dismissed = false;
+    let lastLoad = localStorage[DISMISSED_CHECK_KEY];
+    if (lastLoad) {
+      var diff = (Date.now() - parseInt(lastLoad, 10)) / DAY;
+      if (diff < DISMISSAL_DELAY) {
+        dismissed = true;
+      }
+    }
 
     this.state = {
-      delay: DELAY - prevTimer,
+      delay: INITIAL_DELAY,
       visible: false,
       dismissed
     };
-
-    this.timer = prevTimer;
-    this.runTimer;
-  }
-
-  getPrevTimer() {
-    let prevTimer = parseInt(sessionStorage.getItem(KEY_TIMER), 10);
-
-    if (isNaN(prevTimer)) {
-      prevTimer = 0;
-    }
-
-    return prevTimer;
   }
 
   componentDidMount() {
     if (!this.state.dismissed) {
-      this.startTimer();
-
       // show modal after delay. If delay is a negative value, show modal immediately
-      setTimeout(
+      this.runTimer = setTimeout(
         () => this.setState({ visible: true }),
-        Math.max(this.state.delay, 0)
+        this.state.delay
       );
     }
-  }
-
-  startTimer() {
-    this.runTimer = setInterval(() => {
-      this.timer += TIMER_INCREMENT;
-
-      sessionStorage.setItem(KEY_TIMER, this.timer);
-    }, TIMER_INCREMENT);
   }
 
   handleBtnClick() {
@@ -63,17 +52,9 @@ class DonateModal extends React.Component {
   }
 
   dismiss() {
-    sessionStorage.setItem(KEY_STATE, `dismissed`);
-    sessionStorage.removeItem(KEY_TIMER);
-
-    this.setState(
-      {
-        dismissed: true
-      },
-      () => {
-        clearInterval(this.runTimer);
-      }
-    );
+    clearInterval(this.runTimer);
+    localStorage[DISMISSED_CHECK_KEY] = Date.now();
+    this.setState({ dismissed: true });
   }
 
   render() {

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -12,6 +12,8 @@ import MultipageNavMobile from "./components/multipage-nav-mobile/multipage-nav-
 import News from "./components/news/news.jsx";
 import PulseProjectList from "./components/pulse-project-list/pulse-project-list.jsx";
 
+import injectDonateModal from "./donate-modal/donate-modal.jsx";
+
 import primaryNav from "./primary-nav.js";
 
 const SHOW_MEMBER_NOTICE = false;
@@ -442,40 +444,35 @@ let main = {
       bindProfileCardAnalytics(profileCards);
     });
 
-    /*
-      The following code has been disabled for
-      https://github.com/mozilla/foundation.mozilla.org/issues/2630,
-      but we want to keep this code around for when we need to
-      re-enable this functionality
+    // Load up a fundraising banner
+    let donationModal = document.querySelector(`.donate-modal-wrapper`);
 
-      ---
-      import injectDonateModal from './donate-modal/donate-modal.jsx';
-      ...
-      let donationModal = document.querySelector(`.donate-modal-wrapper`);
+    if (donationModal) {
+      let modalOptions = {
+        title: `Big corporations try to restrict how we access the web.`,
+        subheading: `Misinformation makes it harder for us to find the truth. Web-connected devices go to market without basic security standards.`,
+        cta: {
+          title: [
+            `The non-profit Mozilla Foundation fights for a healthier internet.`,
+            ` `,
+            <strong>Will you donate today?</strong>
+          ],
+          text: `Support Mozilla`
+        },
+        utm: {
+          medium: `foundation`,
+          campaign: `mainsite`,
+          content: `popupbutton`
+        },
+        ga: {
+          category: `site`,
+          action: `donate tap`,
+          label: `donate popup on foundation site`
+        }
+      };
 
-      if (donationModal) {
-        let modalOptions = {
-          title: `We all love the web. Join Mozilla in defending it!`,
-          subheading: `Let's protect the world's largest resource for future generations. A few times a year, the Mozilla Foundation asks for donations.`,
-          cta: {
-            title: `Chip in to help us keep the web healthy, wonderful, and welcoming to all.`,
-            text: `Support Mozilla`
-          },
-          utm: {
-            medium: `foundation`,
-            campaign: `mainsite`,
-            content: `popupbutton`
-          },
-          ga: {
-            category: `site`,
-            action: `donate tap`,
-            label: `donate popup on foundation site`
-          }
-        };
-
-        injectDonateModal(donationModal, modalOptions);
-      }
-    */
+      injectDonateModal(donationModal, modalOptions);
+    }
   }
 };
 


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3324

This switches the donate modal to one that can be dismissed for a week at a time. It will pop up after 10 seconds, and will keep popping up until dismissed. Once dismissed, the time of dismissal is stored in localStorage, and once a week has passed, the modal will start popping up again until dismissed again.