### PR TITLE
Do pulse project ordering via the API

### DIFF
--- a/source/js/components/pulse-project-list/pulse-project-list.jsx
+++ b/source/js/components/pulse-project-list/pulse-project-list.jsx
@@ -43,7 +43,7 @@ export default class PulseProjectList extends React.Component {
       page_size: this.props.max ? this.props.max : 12,
       search: this.props.query,
       featured: this.props.featured && `True`,
-      ordering: this.props.reverseChronological ? `-created`, `created`
+      ordering: this.props.reverseChronological ? `-created` : `created`
     };
 
     // Serialize parameters into a query string

--- a/source/js/components/pulse-project-list/pulse-project-list.jsx
+++ b/source/js/components/pulse-project-list/pulse-project-list.jsx
@@ -16,14 +16,6 @@ export default class PulseProjectList extends React.Component {
     projectXHR.addEventListener(`load`, () => {
       let projects = JSON.parse(projectXHR.response);
 
-      projects.results = projects.results.sort((a, b) => {
-        if (this.props.reverseChronological) {
-          return Date.parse(a.created) < Date.parse(b.created) ? 1 : -1;
-        } else {
-          return Date.parse(a.created) > Date.parse(b.created) ? 1 : -1;
-        }
-      });
-
       this.setState(
         {
           projects: this.props.max
@@ -50,7 +42,8 @@ export default class PulseProjectList extends React.Component {
           : null,
       page_size: this.props.max ? this.props.max : 12,
       search: this.props.query,
-      featured: this.props.featured && `True`
+      featured: this.props.featured && `True`,
+      ordering: this.props.reverseChronological ? `-created`, `created`
     };
 
     // Serialize parameters into a query string


### PR DESCRIPTION
Fix #3419 

This PR fixes an ordering issue with loading pulse projects on the foundation site. It basically changes the way we order projects by offloading that logic to the API vs. doing it on the front-end. See the ticket for why.

Assigning to @alanmoo and @mmmavis...whoever gets to it first.
