### PR TITLE
turned the unassigned var root_name into a real string

### DIFF
--- a/network-api/networkapi/templates/partials/primary_nav.html
+++ b/network-api/networkapi/templates/partials/primary_nav.html
@@ -12,7 +12,7 @@
               <div class="row">
                 <div class="col">
                   <div class="nav-links pt-3">
-                    <div><a class="{% primary_active_nav request menu_root.full_url menu_root.full_url %}" href="{{ menu_root.url }}">{{ root_name }}</a></div>
+                    <div><a class="{% primary_active_nav request menu_root.full_url menu_root.full_url %}" href="{{ menu_root.url }}">Home</a></div>
                     {% include "fragments/nav-links.html" with pre="<div>" post="</div>" %}
                   </div>
                 </div>


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3452 by replacing the unused `root_name` variable in the primary nav template with the word `Home`. The mozfest site uses `root_name` in several places, with the appropriate value set, but for some reason primary nav also had that variable even though it's not assigned a value there, and is used only once.
