### PR TITLE
order index page entries by most-recently-created

### DIFF
--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -560,6 +560,7 @@ class IndexPage(FoundationMetadataPageMixin, Page):
         context = super().get_context(request)
         context = set_main_site_nav_information(self, context, 'Homepage')
         context = get_page_tree_information(self, context)
+        context['entries'] = self.get_children().live().order_by('-first_published_at')
         return context
 
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/index_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/index_page.html
@@ -23,7 +23,7 @@
     <div class="row">
       {% block subcontent %}
 
-        {% for entry in page.get_children.live %}
+        {% for entry in entries %}
           {% with type=entry.specific_class.get_verbose_name|lower %}
             {% if type == "blog page" %}
               {% include "./fragments/blog-card.html" with page=entry %}


### PR DESCRIPTION
Closes #3465  by ordering the set of entries by publication data. As we can't do ordering in the template itself, this is now done as part of the template context preprocessing function. Thankfully, that means no migrations are required.