### PR TITLE
use IndexPage for the blog namespace, and generate 7 blog posts (to verify listing)

### DIFF
--- a/network-api/networkapi/wagtailpages/factory/blog.py
+++ b/network-api/networkapi/wagtailpages/factory/blog.py
@@ -58,7 +58,7 @@ def generate(seed):
 
     print('Generating blog posts under namespace')
     for i in range(7):
-        title = f'post {i}'
+        title = Faker('sentence', nb_words=6, variable_nb_words=False)
         try:
             BlogPage.objects.get(title=title)
         except BlogPage.DoesNotExist:

--- a/network-api/networkapi/wagtailpages/factory/blog.py
+++ b/network-api/networkapi/wagtailpages/factory/blog.py
@@ -12,7 +12,7 @@ from networkapi.utility.faker.helpers import (
     get_homepage,
     reseed
 )
-from .mini_site_namespace import MiniSiteNamespaceFactory
+from .index_page import IndexPageFactory
 
 RANDOM_SEED = settings.RANDOM_SEED
 TESTING = settings.TESTING
@@ -49,15 +49,17 @@ def generate(seed):
         print('blog namespace exists')
     except WagtailPage.DoesNotExist:
         print('Generating a blog namespace')
-        blog_namespace = MiniSiteNamespaceFactory.create(
+        blog_namespace = IndexPageFactory.create(
             parent=home_page,
             title='blog',
-            live=False
+            header='blog',
+            live=True
         )
 
-    try:
-        BlogPage.objects.get(title='post')
-        print('a post page (BlogPage) exists')
-    except BlogPage.DoesNotExist:
-        print('Generating a post page (BlogPage) under namespace')
-        BlogPageFactory.create(parent=blog_namespace, title='post')
+    print('Generating blog posts under namespace')
+    for i in range(7):
+        title = f'post {i}'
+        try:
+            BlogPage.objects.get(title=title)
+        except BlogPage.DoesNotExist:
+            BlogPageFactory.create(parent=blog_namespace, title=title)

--- a/network-api/networkapi/wagtailpages/factory/index_page.py
+++ b/network-api/networkapi/wagtailpages/factory/index_page.py
@@ -1,0 +1,7 @@
+from networkapi.wagtailpages.models import IndexPage
+from wagtail_factories import PageFactory
+
+
+class IndexPageFactory(PageFactory):
+    class Meta:
+        model = IndexPage


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3468

This switches the blog namespace from a minisitenamespace page type to the new indexpage page type, and generates 7 blog posts so that listing can be checked (both in terms of "does it look right?" as well as "is it ordered correctly")

https://foundation-mofostaging-pr-3469.herokuapp.com/en/blog/