### PR TITLE
rename an inv task + add switching branch command

### DIFF
--- a/docs/local_development_with_docker.md
+++ b/docs/local_development_with_docker.md
@@ -28,9 +28,10 @@ The general workflow is:
   docker-manage                      Shorthand to manage.py. inv docker.manage "[COMMAND] [ARG]"
   docker-migrate                     Updates database schema
   docker-npm                         Shorthand to npm. inv docker.npm "[COMMAND] [ARG]"
-  docker-nuke-db                     Delete your database and create a new one with fake data
+  docker-new-db                      Delete your database and create a new one with fake data
   docker-pipenv                      Shorthand to pipenv. inv docker.pipenv "[COMMAND] [ARG]"
   docker-setup                       Prepare your dev environment after a fresh git clone
+  docker_switching_branch            Get a new database with fake data and rebuild images
   docker-test-node                   Run node tests
   docker-test-python                 Run python tests
 ```

--- a/tasks.py
+++ b/tasks.py
@@ -204,7 +204,27 @@ def docker_test_node(ctx):
 
 
 @task
-def docker_nuke_db(ctx):
+def docker_switching_branch(ctx):
+    """Get a new database with fake data and rebuild images"""
+    print("Stopping services first")
+    ctx.run("docker-compose down")
+    print("Deleting database")
+    ctx.run("docker volume rm foundationmozillaorg_postgres_data")
+    print("Rebuilding images and install dependencies")
+    ctx.run("docker-compose build")
+    print("Applying database migrations.")
+    docker_migrate(ctx)
+    print("Creating fake data")
+    docker_manage(ctx, "load_fake_data")
+    print("Updating localizable fields")
+    docker_l10n_sync(ctx)
+    docker_l10n_update(ctx)
+    print("Updating block information")
+    docker_manage(ctx, "block_inventory")
+
+
+@task
+def docker_new_db(ctx):
     """Delete your database and create a new one with fake data"""
     print("Stopping services first")
     ctx.run("docker-compose down")


### PR DESCRIPTION
- Rename `nuke_db` to `new_db` for clarity: use this command if you broke your DB and want a new DB with fake data,
- Add a `inv docker-switching-branch` command: deletes the previous DB, creates a new one with fake data and rebuilds the images (install dependencies). The goal is to make switching from branches to branches easier by preventing using an old DB incompatible with your current code.

**Documentation:**
- [x] Is my code documented?
- [x] Did I update the READMEs or wagtail documentation?
