### PR TITLE
fix the percy test case for blog post by title

### DIFF
--- a/cypress/integration/endpoint-tests.js
+++ b/cypress/integration/endpoint-tests.js
@@ -35,7 +35,7 @@ describe(`Visual regression testing for foundation.mozilla.org`, () => {
   });
 
   it(`Blog page`, function() {
-    cy.visit(`/en/blog/post`);
+    cy.visit(`/en/blog/initial-test-blog-post-with-fixed-title`);
     cy.window()
       .its(`main-js:react:finished`)
       .should(`equal`, true);

--- a/network-api/networkapi/wagtailpages/factory/blog.py
+++ b/network-api/networkapi/wagtailpages/factory/blog.py
@@ -57,7 +57,14 @@ def generate(seed):
         )
 
     print('Generating blog posts under namespace')
-    for i in range(7):
+    title = 'Initial test blog post with fixed title'
+
+    try:
+        BlogPage.objects.get(title=title)
+    except BlogPage.DoesNotExist:
+        BlogPageFactory.create(parent=blog_namespace, title=title)
+
+    for i in range(6):
         title = Faker('sentence', nb_words=6, variable_nb_words=False)
         try:
             BlogPage.objects.get(title=title)


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/foundation.mozilla.org/pull/3469 which forgot to update the associated Percy test - it was hitting the `/en/blog/post` URL, which we changed the title for.