### PR TITLE
For newsletter signup: exclude query params in 'source url' sent to Basket/Salesforce

### DIFF
--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -97,7 +97,8 @@ export default class JoinUs extends React.Component {
     return new Promise((resolve, reject) => {
       let payload = {
         email: this.email.value,
-        source: window.location.toString()
+        /* Strip query params in source url for newsletter signups: https://github.com/mozilla/foundation.mozilla.org/issues/2994#issuecomment-516997473 */
+        source: window.location.href.split(`?`)[0]
       };
 
       if (this.givenNames) {


### PR DESCRIPTION
Closes #3481
