### PR TITLE
Replaced all /en Links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For more information on how to run the project with Docker, check the [local dev
 
 ## Mozilla Festival
 
-The fake data generator can generate a site structure for the Mozilla Festival that can be served under it's own domain, or in the case of review apps on Heroku, where we're limited to a single domain, as a sub-directory of the main foundation site, at `{review_app_host}/en/mozilla-festival`.
+The fake data generator can generate a site structure for the Mozilla Festival that can be served under it's own domain, or in the case of review apps on Heroku, where we're limited to a single domain, as a sub-directory of the main foundation site, at `{review_app_host}/mozilla-festival`.
 
 In order to access the Mozilla Festival site locally on a different domain than the main Foundation site, you'll need to edit your hosts file (`/etc/hosts` on *nix systems, `C:\Windows\System32\Drivers\etc\hosts` on Windows) to allow you to access the site at `mozillafestival.localhost:8000`. To enable this, add the following line to your hosts file: `127.0.0.1 mozillafestival.localhost`
 

--- a/network-api/networkapi/buyersguide/templates/buyersguide_home.html
+++ b/network-api/networkapi/buyersguide/templates/buyersguide_home.html
@@ -62,7 +62,7 @@
           {% endif %}
         {% endif %}
 
-        <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="privacynotincluded/products/{{ product.slug }}">
+        <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="/privacynotincluded/products/{{ product.slug }}">
           {% if USE_CLOUDINARY %}
           <img
             class="product-thumbnail"

--- a/network-api/networkapi/buyersguide/templates/buyersguide_home.html
+++ b/network-api/networkapi/buyersguide/templates/buyersguide_home.html
@@ -62,7 +62,7 @@
           {% endif %}
         {% endif %}
 
-        <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="/en/privacynotincluded/products/{{ product.slug }}">
+        <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="privacynotincluded/products/{{ product.slug }}">
           {% if USE_CLOUDINARY %}
           <img
             class="product-thumbnail"

--- a/network-api/networkapi/buyersguide/templates/category_page.html
+++ b/network-api/networkapi/buyersguide/templates/category_page.html
@@ -19,7 +19,7 @@
         <div class="row">
           {% for product in products %}
           <div class="category-item-container col-6 {% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}">
-            <a href="/en/privacynotincluded/products/{{ product.slug }}">
+            <a href="/privacynotincluded/products/{{ product.slug }}">
               <div class="category-image-container">
                 {% include "fragments/seal-of-approval.html" with product=product %}
                 {% include "fragments/adult-content-badge.html" with product=product %}

--- a/network-api/networkapi/buyersguide/templates/primary_nav.html
+++ b/network-api/networkapi/buyersguide/templates/primary_nav.html
@@ -30,7 +30,7 @@
                   <div class="d-flex align-items-center py-3 logo-section">
                     <a href="/" class="moz-logo mb-0 mr-3"><span class="sr-only">Mozilla</span></a>
                     <p class="mb-0 h3-heading flex-wrap">
-                      <a class="link-back" href="/en/privacynotincluded">*privacy not included</a>
+                      <a class="link-back" href="/privacynotincluded">*privacy not included</a>
                     </p>
                   </div>
                   {% include "./social.html" %}

--- a/network-api/networkapi/buyersguide/templates/product_page.html
+++ b/network-api/networkapi/buyersguide/templates/product_page.html
@@ -59,7 +59,7 @@
       <div id="product-research" class="mt-5">
         <div class="mb-5 d-flex flex-column flex-sm-row align-items-sm-center">
           <h3 class="h5-heading d-inline-block mb-2 mb-sm-0 mr-3">Our Research</h3>
-          <a href="/en/privacynotincluded/about" class="info-help">How to use this guide</a>
+          <a href="/privacynotincluded/about" class="info-help">How to use this guide</a>
         </div>
 
         <h3 class="h3-heading">Can it spy on me</h3>
@@ -158,7 +158,7 @@
           <div class="row">
             {% for product in product.related_products %}
             <div class="related-product col-6 col-md-3 mb-3 mb-md-0">
-              <a class="d-block{% if product.adult_content %} adult-content{% endif %}" href="/en/privacynotincluded/products/{{ product.slug }}">
+              <a class="d-block{% if product.adult_content %} adult-content{% endif %}" href="/privacynotincluded/products/{{ product.slug }}">
                 {% if USE_CLOUDINARY %}
                   <img class="product-thumbnail thumb-border"
                   width="300"

--- a/network-api/networkapi/mozfest/templates/mozfest/404.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/404.html
@@ -22,14 +22,14 @@ Mozilla Festival 2019 - Page Not Found
                             <div class="row">
                                 <div class="col">
                                     <div class="nav-links pt-3">
-                                        <div><a class="active" href="https://www.mozillafestival.org/en/">Home</a></div>
-                                        <div><a class="" href="https://www.mozillafestival.org/en/spaces/">Spaces</a>
+                                        <div><a class="active" href="https://www.mozillafestival.org/">Home</a></div>
+                                        <div><a class="" href="https://www.mozillafestival.org/spaces/">Spaces</a>
                                         </div>
-                                        <div><a class="" href="https://www.mozillafestival.org/en/team/">Team</a></div>
-                                        <div><a class="" href="https://www.mozillafestival.org/en/tickets/">Tickets</a>
+                                        <div><a class="" href="https://www.mozillafestival.org/team/">Team</a></div>
+                                        <div><a class="" href="https://www.mozillafestival.org/tickets/">Tickets</a>
                                         </div>
                                         <div><a class=""
-                                                href="https://www.mozillafestival.org/en/sponsors/">Sponsors</a></div>
+                                                href="https://www.mozillafestival.org/sponsors/">Sponsors</a></div>
                                     </div>
                                 </div>
                             </div>
@@ -48,13 +48,13 @@ Mozilla Festival 2019 - Page Not Found
                                         <div class="burger-bar burger-bar-middle"></div>
                                         <div class="burger-bar burger-bar-bottom"></div>
                                     </button>
-                                    <a class="logo text-hide" href="https://www.mozillafestival.org/en/">Home</a>
+                                    <a class="logo text-hide" href="https://www.mozillafestival.org/">Home</a>
                                     <div class="wide-screen-menu">
                                         <div class="nav-links d-none d-lg-block">
-                                            <a class="" href="https://www.mozillafestival.org/en/spaces/">Spaces</a>
-                                            <a class="" href="https://www.mozillafestival.org/en/team/">Team</a>
-                                            <a class="" href="https://www.mozillafestival.org/en/tickets/">Tickets</a>
-                                            <a class="" href="https://www.mozillafestival.org/en/sponsors/">Sponsors</a>
+                                            <a class="" href="https://www.mozillafestival.org/spaces/">Spaces</a>
+                                            <a class="" href="https://www.mozillafestival.org/team/">Team</a>
+                                            <a class="" href="https://www.mozillafestival.org/tickets/">Tickets</a>
+                                            <a class="" href="https://www.mozillafestival.org/sponsors/">Sponsors</a>
                                         </div>
                                     </div>
                                 </div>

--- a/network-api/networkapi/utility/middleware.py
+++ b/network-api/networkapi/utility/middleware.py
@@ -37,7 +37,7 @@ class TargetDomainRedirectMiddleware:
                     redirect_url = '{protocol}://{hostname}{path}'.format(
                         protocol=protocol,
                         hostname=hostnames[0],
-                        path='/en/mozfest/'
+                        path='/mozfest/'
                     )
 
                     return HttpResponseTemporaryRedirect(redirect_url)


### PR DESCRIPTION
Closes #3475
Removes all /en links except en-US