### PR TITLE
Remove title casing enforcement of nav items

### DIFF
--- a/network-api/networkapi/templates/fragments/nav-links.html
+++ b/network-api/networkapi/templates/fragments/nav-links.html
@@ -1,7 +1,7 @@
 {% load primary_active_nav %}
 
 {% for item in menu_items %}
-  {{ pre }}<a class="{% primary_active_nav request menu_root.full_url item.full_url %}" href="{{ item.url }}">{{ item.title|title }}</a>{{ post }}
+  {{ pre }}<a class="{% primary_active_nav request menu_root.full_url item.full_url %}" href="{{ item.url }}">{{ item.title }}</a>{{ post }}
 {% endfor %}
 
 {% if HEROKU_APP_NAME %}{{ pre }}<a href="/help">DEV HELP</a>{{ post }}{% endif %}


### PR DESCRIPTION
In the primary site navigation, "MozFest House" becomes "Mozfest House" and that's not good. Giving the users a little more freedom, with a minor cost (but everything that's in production already will look fine, so I don't think it's a concern.)