### PR TITLE
make docker-setup fall through to docker-new-db

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -273,15 +273,8 @@ def docker_setup(ctx):
                 create_docker_env_file("env.default")
         print("Building Docker images")
         ctx.run("docker-compose build", **PLATFORM_ARG)
-        print("Applying database migrations.")
-        docker_migrate(ctx)
-        print("Updating localizable fields")
-        docker_l10n_sync(ctx)
-        docker_l10n_update(ctx)
-        print("Creating fake data")
-        docker_manage(ctx, "load_fake_data")
-        print("Updating block information")
-        docker_manage(ctx, "block_inventory")
+        print("Setting up a clean database.")
+        docker_new_db(ctx)
 
         # Windows doesn't support pty, skipping this step
         if platform == 'win32':


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3535  by making `inv docker-setup` fall through to the `docker_new_db` task, so that even though postgres is installed from an image, it gets a good wipe before bootstrapping the db (including fake data).

This hopefully also fixes converalls.

Test this by pulling master, running `inv docker-setup` to _verify things go wrong_ then checking out this branch and rerunning `inv docker-setup` and see if it makes it all the way to the end.