### PR TITLE
remove cypress install since it's not used for local dev

### DIFF
--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -6,7 +6,3 @@ WORKDIR /app/
 COPY package.json package-lock.json ./
 
 RUN npm install
-
-# Install visual testing tools separately with CI true to suppress the hundreds lines of "unziping".
-# Might replace it by a silent flag if this PR gets merged: https://github.com/cypress-io/cypress/pull/2706
-RUN CI=true npm run cypress:install


### PR DESCRIPTION
Closes MozillaFoundation/mofo-devops#678

I'm removing cypress from the Node image: it's not used in local dev and it's taking ages to install every time we have to rebuild the image.