### PR TITLE
fix delete-db not working on a truly clean OS

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -203,12 +203,6 @@ def docker_test_node(ctx):
     ctx.run("docker-compose run --rm watch-static-files npm run test", **PLATFORM_ARG)
 
 
-@task
-def docker_test(ctx):
-    docker_test_python(ctx)
-    docker_test_node(ctx)
-
-
 def docker_shared_database_operations(ctx):
     print("Applying database migrations.")
     docker_migrate(ctx)

--- a/tasks.py
+++ b/tasks.py
@@ -203,6 +203,12 @@ def docker_test_node(ctx):
     ctx.run("docker-compose run --rm watch-static-files npm run test", **PLATFORM_ARG)
 
 
+@task
+def docker_test(ctx):
+    docker_test_python(ctx)
+    docker_test_node(ctx)
+
+
 def docker_shared_database_operations(ctx):
     print("Applying database migrations.")
     docker_migrate(ctx)
@@ -221,7 +227,7 @@ def docker_stop_and_delete_db(ctx):
     print("Deleting database")
     try:
         ctx.run("docker volume rm foundationmozillaorg_postgres_data")
-    except:
+    except:  # noqa: E722 
         pass
 
 
@@ -239,7 +245,6 @@ def docker_new_db(ctx):
     """Delete your database and create a new one with fake data"""
     docker_stop_and_delete_db(ctx)
     docker_shared_database_operations(ctx)
-
 
 
 @task(aliases=["docker-catchup"])

--- a/tasks.py
+++ b/tasks.py
@@ -222,6 +222,14 @@ def docker_stop_and_delete_db(ctx):
     try:
         ctx.run("docker volume rm foundationmozillaorg_postgres_data")
     except:  # noqa: E722 
+        """
+        Removing the postgres data may fail on a clean install that
+        never had docker run before. If that happens, docker will
+        normally generate an error and stop, but not being able to
+        delete data that doesn't exist isn't actually an error in
+        our case, so the task should just keep running.
+        """
+        print("Database did not exist, skipping delete")
         pass
 
 


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3609

@patjouk I wasn't sure if there was a way to properly check for the volume so instead of an `if` I ended up using a `try` with a passing except... would you happen to know if this can be done cleaner?