### PR TITLE
Make tag/category list show on its own line

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog-card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog-card.html
@@ -14,9 +14,9 @@ each blog page's dominant tag)
 {% block tags %}
   {% if hide_classifiers != True %}
     {% if filtered %}
-      <ul class="tag-list mt-3">
+      <ul class="list-unstyled mt-3 mb-0">
       {% for tag in page.specific.tags.all %}
-        <li class="tag">
+        <li class="d-inline-block text-capitalize">
           <a href="{% routablepageurl root.specific "entries_by_tag" tag.slug %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
         </li>
       {% endfor %}

--- a/source/sass/views/blog.scss
+++ b/source/sass/views/blog.scss
@@ -22,16 +22,4 @@
   .main-tag {
     text-transform: capitalize;
   }
-
-  .tag-list {
-    display: inline-block;
-    list-style: none;
-    padding: 0;
-    margin: 0;
-
-    .tag {
-      display: inline-block;
-      text-transform: capitalize;
-    }
-  }
 }


### PR DESCRIPTION
Closes #3586 

Test page: https://foundation-mofostaging-pr-3635.herokuapp.com/en/blog/tags/mozilla/
Notice that tag list is on its own line even when the title is short.

---

@Pomax I _think_ this shouldn't introduce bad code conflict into Youri's WIP big-ish PR. See [changes in the same file](https://github.com/mozilla/foundation.mozilla.org/pull/3597/files?w=1#diff-a8460b3f099643ea503e5f27dbe62d13) in her PR. We can also wait till that PR is merged first. I'll let you advise what to do.