### PR TITLE
a single block name accidentally got reverted

### DIFF
--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -6,7 +6,7 @@
 <html lang="{{ lang_code }}">
   <head>
     <meta charset="utf-8">
-    <title>{% block pageTitle %}Mozilla Foundation - {% if page.specifics.seo_title %}{{ page.specifics.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}</title>
+    <title>{% block page_title %}Mozilla Foundation - {% if page.specifics.seo_title %}{{ page.specifics.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token }}">


### PR DESCRIPTION
The template's title block accidentally reverted from `page_title` to `pageTitle`. A code scan reveals this is the only block that regressed to `[a-z]+([A-Z][a-z]+)+` format.