### PR TITLE
YouTube mobile newsletter sign up 

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube_regrets_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube_regrets_page.html
@@ -33,6 +33,7 @@
       {% endfor %}
     </div>
     <div class="intro-button-wrapper">
+      <button class="btn btn-primary btn-newsletter hidden-lg-up mx-auto d-none">Join Mozilla</button>
       <button class="btn btn-primary btn-newsletter hidden-md-down mx-auto d-none">Join Mozilla</button>
     </div>
   </div>

--- a/source/js/primary-nav.js
+++ b/source/js/primary-nav.js
@@ -1,104 +1,81 @@
 import ReactGA from "react-ga";
-import utility from "./utility";
 import navNewsletter from "./nav-newsletter.js";
 
-let elements = {
-  elBurger: `.burger`,
-  elWideMenu: `.wide-screen-menu`,
-  elNarrowMenu: `.narrow-screen-menu`,
-  primaryNavContainer: `#primary-nav-container`
-};
+let primaryNav = {
+  init: function() {
+    let elBurger = document.querySelector(`.burger`);
+    let elWideMenu = document.querySelector(`.wide-screen-menu`);
+    let elNarrowMenu = document.querySelector(`.narrow-screen-menu`);
+    let primaryNavContainer = document.getElementById(`primary-nav-container`);
+    let navMode = primaryNavContainer.dataset.navMode;
+    let menuOpen = false;
 
-class PrimaryNav {
-  constructor() {
-    this.navMode = null;
-    this.menuOpen = false;
-  }
-
-  setWideMenuState(openMenu) {
-    if (this.navMode === `zen`) {
-      if (openMenu) {
-        elements.elWideMenu.classList.remove(`hidden`);
-      } else {
-        elements.elWideMenu.classList.add(`hidden`);
+    function setWideMenuState(openMenu) {
+      if (navMode === `zen`) {
+        if (openMenu) {
+          elWideMenu.classList.remove(`hidden`);
+        } else {
+          elWideMenu.classList.add(`hidden`);
+        }
       }
     }
-  }
 
-  setNarrowMenuState(openMenu) {
-    if (openMenu) {
-      elements.elNarrowMenu.classList.remove(`hidden`);
-    } else {
-      elements.elNarrowMenu.classList.add(`hidden`);
-    }
-  }
-
-  setBurgerState(openMenu) {
-    if (openMenu) {
-      elements.elBurger.classList.add(`menu-open`);
-    } else {
-      elements.elBurger.classList.remove(`menu-open`);
-    }
-  }
-
-  trackMenuState(openMenu) {
-    if (openMenu) {
-      ReactGA.event({
-        category: `navigation`,
-        action: `show menu`,
-        label: `Show navigation menu`
-      });
-    } else {
-      ReactGA.event({
-        category: `navigation`,
-        action: `hide menu`,
-        label: `Hide navigation menu`
-      });
-    }
-  }
-
-  setMenuState(openMenu) {
-    this.setWideMenuState(openMenu);
-    this.setNarrowMenuState(openMenu);
-    this.setBurgerState(openMenu);
-    this.trackMenuState(openMenu);
-  }
-
-  init() {
-    if (!utility.checkAndBindDomNodes(elements)) {
-      return;
+    function setNarrowMenuState(openMenu) {
+      if (openMenu) {
+        elNarrowMenu.classList.remove(`hidden`);
+      } else {
+        elNarrowMenu.classList.add(`hidden`);
+      }
     }
 
-    this.navMode = elements.primaryNavContainer.dataset.navMode;
+    function setBurgerState(openMenu) {
+      if (openMenu) {
+        elBurger.classList.add(`menu-open`);
+      } else {
+        elBurger.classList.remove(`menu-open`);
+      }
+    }
 
-    document.addEventListener(`keyup`, event => {
-      this.docKeyupHanlder(event);
+    function trackMenuState(openMenu) {
+      if (openMenu) {
+        ReactGA.event({
+          category: `navigation`,
+          action: `show menu`,
+          label: `Show navigation menu`
+        });
+      } else {
+        ReactGA.event({
+          category: `navigation`,
+          action: `hide menu`,
+          label: `Hide navigation menu`
+        });
+      }
+    }
+
+    function setMenuState(openMenu) {
+      setWideMenuState(openMenu);
+      setNarrowMenuState(openMenu);
+      setBurgerState(openMenu);
+      trackMenuState(openMenu);
+    }
+
+    document.addEventListener(`keyup`, e => {
+      if (e.keyCode === 27) {
+        menuOpen = false;
+        setMenuState(menuOpen);
+      }
     });
-
-    elements.elBurger.addEventListener(`click`, () => {
-      this.elBurgerClickHanlder();
+    elBurger.addEventListener(`click`, () => {
+      if (navNewsletter.getShownState()) {
+        // if newsletter section is open, close just that section
+        // instead of changing the menuOpen state
+        navNewsletter.closeMobileNewsletter();
+      } else {
+        menuOpen = !menuOpen;
+        setMenuState(menuOpen);
+      }
     });
   }
-
-  docKeyupHanlder(event) {
-    if (event.keyCode === 27) {
-      this.menuOpen = false;
-      this.setMenuState(this.menuOpen);
-    }
-  }
-
-  elBurgerClickHanlder() {
-    if (navNewsletter.getShownState()) {
-      // if newsletter section is open, close just that section
-      // instead of changing the menuOpen state
-      navNewsletter.closeMobileNewsletter();
-    } else {
-      this.menuOpen = !this.menuOpen;
-      this.setMenuState(this.menuOpen);
-    }
-  }
-}
-
-const primaryNav = new PrimaryNav();
+};
 
 export default primaryNav;

--- a/source/js/primary-nav.js
+++ b/source/js/primary-nav.js
@@ -1,81 +1,104 @@
 import ReactGA from "react-ga";
+import utility from "./utility";
 import navNewsletter from "./nav-newsletter.js";
 
-let primaryNav = {
-  init: function() {
-    let elBurger = document.querySelector(`.burger`);
-    let elWideMenu = document.querySelector(`.wide-screen-menu`);
-    let elNarrowMenu = document.querySelector(`.narrow-screen-menu`);
-    let primaryNavContainer = document.getElementById(`primary-nav-container`);
-    let navMode = primaryNavContainer.dataset.navMode;
-    let menuOpen = false;
+let elements = {
+  elBurger: `.burger`,
+  elWideMenu: `.wide-screen-menu`,
+  elNarrowMenu: `.narrow-screen-menu`,
+  primaryNavContainer: `#primary-nav-container`
+};
 
-    function setWideMenuState(openMenu) {
-      if (navMode === `zen`) {
-        if (openMenu) {
-          elWideMenu.classList.remove(`hidden`);
-        } else {
-          elWideMenu.classList.add(`hidden`);
-        }
-      }
-    }
+class PrimaryNav {
+  constructor() {
+    this.navMode = null;
+    this.menuOpen = false;
+  }
 
-    function setNarrowMenuState(openMenu) {
+  setWideMenuState(openMenu) {
+    if (this.navMode === `zen`) {
       if (openMenu) {
-        elNarrowMenu.classList.remove(`hidden`);
+        elements.elWideMenu.classList.remove(`hidden`);
       } else {
-        elNarrowMenu.classList.add(`hidden`);
+        elements.elWideMenu.classList.add(`hidden`);
       }
     }
+  }
 
-    function setBurgerState(openMenu) {
-      if (openMenu) {
-        elBurger.classList.add(`menu-open`);
-      } else {
-        elBurger.classList.remove(`menu-open`);
-      }
+  setNarrowMenuState(openMenu) {
+    if (openMenu) {
+      elements.elNarrowMenu.classList.remove(`hidden`);
+    } else {
+      elements.elNarrowMenu.classList.add(`hidden`);
+    }
+  }
+
+  setBurgerState(openMenu) {
+    if (openMenu) {
+      elements.elBurger.classList.add(`menu-open`);
+    } else {
+      elements.elBurger.classList.remove(`menu-open`);
+    }
+  }
+
+  trackMenuState(openMenu) {
+    if (openMenu) {
+      ReactGA.event({
+        category: `navigation`,
+        action: `show menu`,
+        label: `Show navigation menu`
+      });
+    } else {
+      ReactGA.event({
+        category: `navigation`,
+        action: `hide menu`,
+        label: `Hide navigation menu`
+      });
+    }
+  }
+
+  setMenuState(openMenu) {
+    this.setWideMenuState(openMenu);
+    this.setNarrowMenuState(openMenu);
+    this.setBurgerState(openMenu);
+    this.trackMenuState(openMenu);
+  }
+
+  init() {
+    if (!utility.checkAndBindDomNodes(elements)) {
+      return;
     }
 
-    function trackMenuState(openMenu) {
-      if (openMenu) {
-        ReactGA.event({
-          category: `navigation`,
-          action: `show menu`,
-          label: `Show navigation menu`
-        });
-      } else {
-        ReactGA.event({
-          category: `navigation`,
-          action: `hide menu`,
-          label: `Hide navigation menu`
-        });
-      }
-    }
+    this.navMode = elements.primaryNavContainer.dataset.navMode;
 
-    function setMenuState(openMenu) {
-      setWideMenuState(openMenu);
-      setNarrowMenuState(openMenu);
-      setBurgerState(openMenu);
-      trackMenuState(openMenu);
-    }
-
-    document.addEventListener(`keyup`, e => {
-      if (e.keyCode === 27) {
-        menuOpen = false;
-        setMenuState(menuOpen);
-      }
+    document.addEventListener(`keyup`, event => {
+      this.docKeyupHanlder(event);
     });
-    elBurger.addEventListener(`click`, () => {
-      if (navNewsletter.getShownState()) {
-        // if newsletter section is open, close just that section
-        // instead of changing the menuOpen state
-        navNewsletter.closeMobileNewsletter();
-      } else {
-        menuOpen = !menuOpen;
-        setMenuState(menuOpen);
-      }
+
+    elements.elBurger.addEventListener(`click`, () => {
+      this.elBurgerClickHanlder();
     });
   }
-};
+
+  docKeyupHanlder(event) {
+    if (event.keyCode === 27) {
+      this.menuOpen = false;
+      this.setMenuState(this.menuOpen);
+    }
+  }
+
+  elBurgerClickHanlder() {
+    if (navNewsletter.getShownState()) {
+      // if newsletter section is open, close just that section
+      // instead of changing the menuOpen state
+      navNewsletter.closeMobileNewsletter();
+    } else {
+      this.menuOpen = !this.menuOpen;
+      this.setMenuState(this.menuOpen);
+    }
+  }
+}
+
+const primaryNav = new PrimaryNav();
 
 export default primaryNav;

--- a/source/js/youtube-regrets.js
+++ b/source/js/youtube-regrets.js
@@ -16,7 +16,9 @@ let elements = {
   rings: `#view-youtube-regrets .intro-viewport .ring`,
   introText: `#view-youtube-regrets .intro-viewport .intro-text p`,
   scrollHint: `#view-youtube-regrets .intro-viewport .scroll-hint`,
-  newsletterButton: `#view-youtube-regrets .intro-viewport .btn-newsletter`
+  newsletterButtons: `#view-youtube-regrets .intro-viewport .btn-newsletter`,
+  newsletterButtonMobile: `#view-youtube-regrets .intro-viewport .btn-newsletter.hidden-lg-up`,
+  newsletterButtonDesktop: `#view-youtube-regrets .intro-viewport .btn-newsletter.hidden-md-down`
 };
 
 class YouTubeRegretsTunnel {
@@ -63,13 +65,15 @@ class YouTubeRegretsTunnel {
    * Hide it otherwise.
    */
   setNewsletterButtonVisibility(positionTohide) {
-    let button = elements.newsletterButton[0];
+    let buttons = elements.newsletterButtons;
 
-    if (window.pageYOffset >= positionTohide) {
-      button.classList.add(`d-none`);
-    } else {
-      button.classList.remove(`d-none`);
-    }
+    buttons.forEach(button => {
+      if (window.pageYOffset >= positionTohide) {
+        button.classList.add(`d-none`);
+      } else {
+        button.classList.remove(`d-none`);
+      }
+    });
   }
 
   /**
@@ -227,9 +231,17 @@ class YouTubeRegretsTunnel {
       return;
     }
 
-    elements.newsletterButton[0].addEventListener(`click`, event =>
+    elements.newsletterButtonDesktop[0].addEventListener(`click`, event =>
       navNewsletter.buttonDesktopClickHandler(event)
     );
+
+    elements.newsletterButtonMobile[0].addEventListener(`click`, event => {
+      if (navNewsletter.getShownState()) {
+        navNewsletter.closeMobileNewsletter(event);
+      } else {
+        navNewsletter.expandMobileNewsletter(event);
+      }
+    });
 
     this.setSceneDepth();
     this.setObjectsOpacity();

--- a/source/sass/views/youtube-regrets.scss
+++ b/source/sass/views/youtube-regrets.scss
@@ -62,7 +62,6 @@
           height: 60vw;
         }
 
-
         .block {
           position: absolute;
           display: block;

--- a/source/sass/views/youtube-regrets.scss
+++ b/source/sass/views/youtube-regrets.scss
@@ -201,7 +201,6 @@
         opacity: 0;
 
         @include scaleText(30px, 38px, 50px, 56px);
-
       }
     }
 

--- a/source/sass/views/youtube-regrets.scss
+++ b/source/sass/views/youtube-regrets.scss
@@ -62,6 +62,7 @@
           height: 60vw;
         }
 
+
         .block {
           position: absolute;
           display: block;

--- a/source/sass/views/youtube-regrets.scss
+++ b/source/sass/views/youtube-regrets.scss
@@ -12,6 +12,10 @@
     );
   }
 
+  #nav-newsletter-form-wrapper.faded-in {
+    height: 100vh;
+  }
+
   .intro-viewport {
     --scenePerspective: 55;
     --blockZTranslate: 0;
@@ -167,19 +171,19 @@
     bottom: 0;
     display: flex;
     flex-direction: column;
-    justify-content: center;
-
-    @media (min-width: $bp-md) {
-      justify-content: start;
-    }
+    justify-content: start;
 
     .intro-text {
       position: relative;
       width: 100%;
       max-width: 840px;
-      height: 55%;
+      height: 60%;
       margin: 0 auto;
       text-align: center;
+
+      @media (min-width: $bp-md) {
+        height: 55%;
+      }
 
       p {
         font-family: "Changa", sans-serif;
@@ -188,8 +192,7 @@
         position: absolute;
         left: 0;
         right: 0;
-        top: 0;
-        bottom: 0;
+        bottom: 10px;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -199,10 +202,6 @@
 
         @include scaleText(30px, 38px, 50px, 56px);
 
-        @media (min-width: $bp-md) {
-          top: unset;
-          bottom: 10px;
-        }
       }
     }
 


### PR DESCRIPTION
Closes #3756 

Add a`Join Mozilla` button on mobile that serves as a trigger to toggle mobile newsletter sign up section.

https://foundation-mofostaging-pr-3761.herokuapp.com/en/campaigns/youtube-regrets/

### BUT ###
I'm not able to get the burger icon on mobile to chang its look to `X` when the form is expanded by the `Join Mozilla` button (functionality works fine though). It's too risky and time-consuming to modify the existing nav logic just make this one-off version work so I had to go with a workaround with this downside.

If we do find this downside really troublesome, I'll need more engineer support on this one as I don't have the brain power and time to come up with a risk-free solution without changing the existing code drastically. 


### Detailed Reason ###
By design we want the `Join Mozilla` button on mobile to trigger the newsletter sign up form that's hidden as the second screen in the nav menu. We also want the hamburger icon change its look from `(three horizontal lines)` to `X` depending on the newsletter section's open state. 

However, since the hamburger icon was implemented solely as the control to toggle the **mobile nav** (with nav links being the first screen and newsletter form as the second), we have to make quite a bit of code changes to make the `Join Mozilla` button toggle the hidden nav AND jump to the second screen (newsletter signup) directly.

Our existing `<PrimaryNav>` and `<NavNewsletter>` React components have very intertwined logics already to make our regular nav, zen nav, mobile nav, desktop nav, and newsletter sign up section on nav work. I spent quite some time yesterday but couldn't achieve what we want with minor code modification to these two components. I ended up using a workaround but the downside is the hamburger icon doesn't change its look to `X` when the form is expanded by the `Join Mozilla` button (functionality works fine though).





