### PR TITLE
Fix lang reset

### DIFF
--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -345,6 +345,7 @@ export default class JoinUs extends React.Component {
           <LanguageSelect
             className="w-100"
             handleLangChange={e => this.setLang(e)}
+            selectedLang={this.state.lang}
           />
         </div>
       </div>

--- a/source/js/components/join/language-select.jsx
+++ b/source/js/components/join/language-select.jsx
@@ -36,11 +36,10 @@ export default class LanguageSelect extends React.Component {
   render() {
     let meta_lang = getCurrentLanguage();
     let classes = classNames(`form-control`, this.props.className);
-    let value = event.target.value;
 
     return (
       <select
-        value={value || meta_lang}
+        value={this.props.selectedLang || meta_lang}
         onChange={evt => this.handleChange(evt)}
         className={classes}
       >


### PR DESCRIPTION
Related PRs/issues #3766

Regression Issue from #3766: Snippet language field was being reset after `country` selection. This PR fixes that issue and allows language field to maintain originally selected value.