### PR TITLE
Newsletter form CSS fixes

### DIFF
--- a/source/js/components/join/join.scss
+++ b/source/js/components/join/join.scss
@@ -38,7 +38,7 @@
   }
 
   .form-control {
-    font-family: "Nunito Sans";
+    font-family: "Nunito Sans", sans-serif;
     font-weight: 400;
     color: $black;
   }

--- a/source/sass/buyers-guide/bg-main.scss
+++ b/source/sass/buyers-guide/bg-main.scss
@@ -45,6 +45,7 @@ $bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
 @import "./components/future-non-react-component";
 @import "../components/nav";
 @import "../components/multipage-nav";
+@import "../components/select-dropdown";
 
 // Misc
 

--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -285,7 +285,7 @@
 
   &.expanded {
     opacity: 1;
-    height: 240px;
+    height: 280px;
   }
 
   &.faded-in {

--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -285,7 +285,7 @@
 
   &.expanded {
     opacity: 1;
-    height: 280px;
+    height: 300px;
   }
 
   &.faded-in {

--- a/source/sass/components/select-dropdown.scss
+++ b/source/sass/components/select-dropdown.scss
@@ -1,0 +1,35 @@
+select {
+  &.form-control {
+    $background-size: 24px;
+    $padding-x: 12px;
+    $padding-right: $padding-x * 2 + $background-size;
+
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    background-image: url("../_images/glyphs/down-chevron.svg");
+    background-repeat: no-repeat;
+    background-position: right $padding-x top 50%;
+    background-size: $background-size $background-size;
+    border-radius: 0;
+    border: 1px solid $gray-20;
+    padding: 5px $padding-right 5px $padding-x;
+    color: $black;
+
+    &-lg {
+      padding: $padding-x $padding-right $padding-x $padding-x;
+    }
+
+    @at-root .dark-theme & {
+      background-image: url("../_images/glyphs/down-chevron-dark-theme.svg");
+      background-color: transparent;
+      border: 1px solid $white;
+      color: $white;
+
+      // target Edge broswser to explictly set background color to black
+      // otherwise on Edge the dropdown options won't show (white text on Edge's default white background)
+      @supports (-ms-ime-align: auto) {
+        background-color: $black;
+      }
+    }
+  }
+}

--- a/source/sass/components/select-dropdown.scss
+++ b/source/sass/components/select-dropdown.scss
@@ -14,6 +14,7 @@ select {
     border: 1px solid $gray-20;
     padding: 5px $padding-right 5px $padding-x;
     color: $black;
+    font-family: "Nunito Sans", sans-serif;
 
     &-lg {
       padding: $padding-x $padding-right $padding-x $padding-x;

--- a/source/sass/main.scss
+++ b/source/sass/main.scss
@@ -40,6 +40,7 @@ $bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
 @import "./components/card";
 @import "./components/airtable-block";
 @import "./components/image-text-mini";
+@import "./components/select-dropdown";
 
 // Misc
 
@@ -71,40 +72,4 @@ $bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
 
 hr {
   border-color: $gray-20;
-}
-
-select {
-  &.form-control {
-    $background-size: 24px;
-    $padding-x: 12px;
-    $padding-right: $padding-x * 2 + $background-size;
-
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    background-image: url("../_images/glyphs/down-chevron.svg");
-    background-repeat: no-repeat;
-    background-position: right $padding-x top 50%;
-    background-size: $background-size $background-size;
-    border-radius: 0;
-    border: 1px solid $gray-20;
-    padding: 5px $padding-right 5px $padding-x;
-    color: $black;
-
-    &-lg {
-      padding: $padding-x $padding-right $padding-x $padding-x;
-    }
-
-    @at-root .dark-theme & {
-      background-image: url("../_images/glyphs/down-chevron-dark-theme.svg");
-      background-color: transparent;
-      border: 1px solid $white;
-      color: $white;
-
-      // target Edge broswser to explictly set background color to black
-      // otherwise on Edge the dropdown options won't show (white text on Edge's default white background)
-      @supports (-ms-ime-align: auto) {
-        background-color: $black;
-      }
-    }
-  }
 }


### PR DESCRIPTION
Fixes #3770
Related Issue #3759

Dropdowns are not styled in PNI
![Screenshot_2019-10-12  Privacy Not Included A Buyer’s Guide for Connected Products](https://user-images.githubusercontent.com/1294206/66746271-41913680-ee79-11e9-9304-6d77147a25ed.png)


`Please check this box if you want to proceed` and privacy notice box are cut-out in non-EN languages with errors displayed
![Screenshot_2019-10-12 Fondation Mozilla](https://user-images.githubusercontent.com/1294206/66746287-4950db00-ee79-11e9-81ee-45d24fdea7fe.png)


Select options are using `serif` font instead of `sans-serif`
<img width="478" alt="Capture d’écran 2019-10-14 à 11 54 35" src="https://user-images.githubusercontent.com/1294206/66746339-6edde480-ee79-11e9-963d-16d18667a006.png">
