### PR TITLE
Newsletter data updates

### DIFF
--- a/network-api/networkapi/campaign/views.py
+++ b/network-api/networkapi/campaign/views.py
@@ -4,7 +4,6 @@ from rest_framework.parsers import JSONParser
 from rest_framework import status, permissions
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
-from django.utils import translation
 from datetime import datetime
 import boto3
 import logging
@@ -85,25 +84,17 @@ def petition_submission_view(request, pk):
 
 # handle Salesforce petition data
 def signup_submission(request, signup):
-    language = translation.get_language_from_request(request)
-    print('language is:', language)
     data = {
         "email": request.data['email'],
         "format": "html",
         "source_url": request.data['source'],
         "newsletters": signup.newsletter,
+        "lang": request.data.get('lang', 'en'),
         "country": request.data.get('country', ''),
         # Empty string instead of None due to Basket issues
         "first_name": request.data.get('givenNames', ''),
         "last_name": request.data.get('surname', '')
     }
-
-    if 'lang' in request.data:
-        data["lang"] = request.data['lang']
-    elif language:
-        data["lang"] = language
-    else:
-        data["lang"] = 'en'
 
     message = json.dumps({
         'app': settings.HEROKU_APP_NAME,

--- a/network-api/networkapi/campaign/views.py
+++ b/network-api/networkapi/campaign/views.py
@@ -4,6 +4,7 @@ from rest_framework.parsers import JSONParser
 from rest_framework import status, permissions
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
+from django.utils import translation
 from datetime import datetime
 import boto3
 import logging
@@ -84,17 +85,25 @@ def petition_submission_view(request, pk):
 
 # handle Salesforce petition data
 def signup_submission(request, signup):
+    language = translation.get_language_from_request(request)
+    print('language is:', language)
     data = {
         "email": request.data['email'],
         "format": "html",
         "source_url": request.data['source'],
         "newsletters": signup.newsletter,
-        "lang": request.data['lang'],
         "country": request.data.get('country', ''),
         # Empty string instead of None due to Basket issues
         "first_name": request.data.get('givenNames', ''),
         "last_name": request.data.get('surname', '')
     }
+
+    if 'lang' in request.data:
+        data["lang"] = request.data['lang']
+    elif language:
+        data["lang"] = language
+    else:
+        data["lang"] = 'en'
 
     message = json.dumps({
         'app': settings.HEROKU_APP_NAME,

--- a/network-api/networkapi/campaign/views.py
+++ b/network-api/networkapi/campaign/views.py
@@ -89,8 +89,8 @@ def signup_submission(request, signup):
         "format": "html",
         "source_url": request.data['source'],
         "newsletters": signup.newsletter,
-        "lang": request.data.get('lang', 'en'),
-        "country": request.data.get('country', 'US'),
+        "lang": request.data['lang'],
+        "country": request.data.get('country', ''),
         # Empty string instead of None due to Basket issues
         "first_name": request.data.get('givenNames', ''),
         "last_name": request.data.get('surname', '')

--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom";
 import classNames from "classnames";
 import CountrySelect from "../petition/country-select.jsx";
 import { getText } from "../petition/locales";
+import { getCurrentLanguage } from "../petition/locales";
 import LanguageSelect from "./language-select.jsx";
 
 export default class JoinUs extends React.Component {
@@ -25,7 +26,8 @@ export default class JoinUs extends React.Component {
       apiSubmitted: false,
       apiSuccess: false,
       apiFailed: false,
-      userTriedSubmitting: false
+      userTriedSubmitting: false,
+      lang: getCurrentLanguage()
     };
   }
 

--- a/source/js/components/join/language-select.jsx
+++ b/source/js/components/join/language-select.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import classNames from "classnames";
-import { getCurrentLanguage } from "../petition/locales";
 
 export default class LanguageSelect extends React.Component {
   constructor(props) {
@@ -34,12 +33,11 @@ export default class LanguageSelect extends React.Component {
   }
 
   render() {
-    let meta_lang = getCurrentLanguage();
     let classes = classNames(`form-control`, this.props.className);
 
     return (
       <select
-        value={this.props.selectedLang || meta_lang}
+        value={this.props.selectedLang}
         onChange={evt => this.handleChange(evt)}
         className={classes}
       >


### PR DESCRIPTION
## **Issues Fixed**
- [x] Send page language as `lang` if none is chosen
- [x] Send nothing if a `country` isn't selected
---
### **Summary of Changes**
Instead of sending default `country` if none is chosen, we're sending an empty string. As for `lang`, instead of having a default language preset in `views.py`, we're updating `lang` in `<JoinUs />` component to pull from page locale for its initial state. 

Related #3700, #3771 , #3768, #3766