### PR TITLE
only show products reviewed in the last year

### DIFF
--- a/network-api/networkapi/buyersguide/models.py
+++ b/network-api/networkapi/buyersguide/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from cloudinary import uploader
 from cloudinary.models import CloudinaryField
 
@@ -133,6 +135,13 @@ class Product(ClusterableModel):
     review_date = models.DateField(
         help_text='Review date of this product',
     )
+
+    @property
+    def is_current(self):
+        d = self.review_date
+        review = datetime(d.year, d.month, d.day)
+        cutoff = datetime.now() - timedelta(days=365)
+        return cutoff < review
 
     name = models.CharField(
         max_length=100,
@@ -576,8 +585,9 @@ class Product(ClusterableModel):
         model_dict['numeric_reading_grade'] = self.numeric_reading_grade
         model_dict['reading_grade'] = self.reading_grade
 
-        # model_to_dict does NOT capture related fields!
+        # model_to_dict does NOT capture related fields or @properties!
         model_dict['privacy_policy_links'] = list(self.privacy_policy_links.all())
+        model_dict['is_current'] = self.is_current
 
         return model_dict
 

--- a/network-api/networkapi/buyersguide/models.py
+++ b/network-api/networkapi/buyersguide/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from cloudinary import uploader
 from cloudinary.models import CloudinaryField

--- a/network-api/networkapi/buyersguide/models.py
+++ b/network-api/networkapi/buyersguide/models.py
@@ -140,7 +140,7 @@ class Product(ClusterableModel):
     def is_current(self):
         d = self.review_date
         review = datetime(d.year, d.month, d.day)
-        cutoff = datetime.now() - timedelta(days=365)
+        cutoff = datetime(2019, 6, 1)
         return cutoff < review
 
     name = models.CharField(

--- a/network-api/networkapi/buyersguide/templates/buyersguide_home.html
+++ b/network-api/networkapi/buyersguide/templates/buyersguide_home.html
@@ -1,7 +1,6 @@
 {% extends "./bg_base.html" %}
 
-{% load env %}
-{% load cloudinary %}
+{% load env cloudinary %}
 
 {% block body_id %}home{% endblock %}
 
@@ -32,8 +31,6 @@
     </div>
 </div>
 
-
-
 <div class="project-list-section">
   <div class="creepiness-slider bg-white text-center">
     <span class="current-creepiness">
@@ -49,37 +46,43 @@
 
   <div class="product-box-list-wrapper">
     <div class="product-box-list d-flex justify-content-center align-items-stretch flex-wrap">
-      {% for product in products %}
-      <figure class="product-box d-flex flex-column justify-content-between{% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}" data-creepiness="{{ product.votes.creepiness.average }}">
-        <div class="top-left-badge-container">
-          {% include "fragments/seal_of_approval.html" with product=product %}
-          {% if product.votes.confidence %}
-          {% if product.votes.confidence.1 > product.votes.confidence.0 %}
-            <div class="d-none recommendation positive"></div>
-          {% else %}
-            <div class="d-none recommendation negative"></div>
-          {% endif %}
-        {% endif %}
-        </div>
-        {% include "fragments/adult_content_badge.html" with product=product %}
 
+      {% for product in products %}
+        {% if product.is_current %}
+        
+        <figure class="product-box d-flex flex-column justify-content-between{% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}" data-creepiness="{{ product.votes.creepiness.average }}">
+        <div class="top-left-badge-container">
+            {% include "fragments/seal_of_approval.html" with product=product %}
+            {% if product.votes.confidence %}
+                {% if product.votes.confidence.1 > product.votes.confidence.0 %}
+                    <div class="d-none recommendation positive"></div>
+                {% else %}
+                    <div class="d-none recommendation negative"></div>
+                {% endif %}
+            {% endif %}
+        </div>
+    
+        {% include "fragments/adult_content_badge.html" with product=product %}
+    
         <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="{% url 'product-view' product.slug %}">
-          {% if USE_CLOUDINARY %}
-          <img
+            {% if USE_CLOUDINARY %}
+            <img
             class="product-thumbnail"
             src="{% cloudinary_url product.cloudinary_image quality=50 fetch_format="auto" crop="fit" width=600 %}"
             alt="link to {{product.name}}"
-          >
-          {% else %}
-          <img class="product-thumbnail" src="{{mediaUrl}}{{"AWS_LOCATION"|env}}/{{product.image }}" alt="link to {{product.name}}">
-          {% endif %}
-          <figcaption class="hidden-sm-down mt-md-2 text-left">
+            >
+            {% else %}
+            <img class="product-thumbnail" src="{{mediaUrl}}{{"AWS_LOCATION"|env}}/{{product.image }}" alt="link to {{product.name}}">
+            {% endif %}
+            <figcaption class="hidden-sm-down mt-md-2 text-left">
             <div class="body-small">{{product.company}}</div>
             <div class="body">{{product.name}}</div>
-          </figcaption>
+            </figcaption>
         </a>
-      </figure>
-      {% endfor %}
+        </figure>
+        {% endif %}
+      {% endfor %}  
+
       <div class="no-matching-products-note bg-gray w-100 pt-5 d-none">
         <div class="d-flex flex-column align-items-center">
           <div>No results.</div>

--- a/network-api/networkapi/buyersguide/templates/category_page.html
+++ b/network-api/networkapi/buyersguide/templates/category_page.html
@@ -18,27 +18,29 @@
 
         <div class="row">
           {% for product in products %}
-          <div class="category-item-container col-6 {% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}">
-            <a href="{% url 'product-view' product.slug %}">
-              <div class="category-image-container">
-                {% include "fragments/seal_of_approval.html" with product=product %}
-                {% include "fragments/adult_content_badge.html" with product=product %}
+            {% if product.is_current %}
+              <div class="category-item-container col-6 {% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}">
+                <a href="{% url 'product-view' product.slug %}">
+                  <div class="category-image-container">
+                    {% include "fragments/seal_of_approval.html" with product=product %}
+                    {% include "fragments/adult_content_badge.html" with product=product %}
 
-                {% if USE_CLOUDINARY %}
-                <img
-                  class="product-thumbnail thumb-border"
-                  width="300"
-                  src="{% cloudinary_url product.cloudinary_image quality=50 fetch_format="auto" crop="fit" width=600 %}"
-                  alt="{{ product.name }}"
-                >
-                {% else %}
-                <img class="product-thumbnail" src="{{ mediaUrl }}{{ "AWS_LOCATION" | env }}/{{ product.image }}">
-                {% endif %}
+                    {% if USE_CLOUDINARY %}
+                    <img
+                      class="product-thumbnail thumb-border"
+                      width="300"
+                      src="{% cloudinary_url product.cloudinary_image quality=50 fetch_format="auto" crop="fit" width=600 %}"
+                      alt="{{ product.name }}"
+                    >
+                    {% else %}
+                    <img class="product-thumbnail" src="{{ mediaUrl }}{{ "AWS_LOCATION" | env }}/{{ product.image }}">
+                    {% endif %}
+                  </div>
+                  <h3 class="mb-1 body-small">{{ product.company }}</h3>
+                  <h3 class="mb-5 h5-heading">{{ product.name }}</h3>
+                </a>
               </div>
-              <h3 class="mb-1 body-small">{{ product.company }}</h3>
-              <h3 class="mb-5 h5-heading">{{ product.name }}</h3>
-            </a>
-          </div>
+            {% endif %}
           {% endfor %}
 
           <p><em>The information provided here is pulled directly from the product website.</em></p>


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3760 by adding an `is_current` property to the Product model that checks whether the review date is less than 365 days old. That's not perfect maths because dates are hard, but we don't need true to-the-day checks here, either.

https://github.com/mozilla/foundation.mozilla.org/pull/3815/files?utf8=%E2%9C%93&diff=unified&w=1 for the sane file view (with indent changes hidden)