### PR TITLE
Add version number to activate build config validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Activate Build Config Validation on Travis
+version: ~> 1.0
+
 dist: xenial
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 version: ~> 1.0
 
 dist: xenial
+os: linux
 language: python
 
 python:
@@ -43,7 +44,7 @@ branches:
   only:
     - master
 
-matrix:
+jobs:
   include:
     - name: Python tests
       install: "./travis-scripts/python-install.sh"


### PR DESCRIPTION
Travis added a [build config validation beta](https://blog.travis-ci.com/2019-10-24-build-config-validation) feature. This PR enable it.

They finally simplified the usage of `matrix` vs `jobs`: `matrix` is getting deprecated and we should now use `jobs` :D

I'll fix this in this PR but I want to see the config warnings first.