### PR TITLE
"Dev help page" on review apps: fix 500

### DIFF
--- a/network-api/networkapi/templates/reviewapp-help.html
+++ b/network-api/networkapi/templates/reviewapp-help.html
@@ -15,14 +15,14 @@
         <ul>
           <li><a href="/about/">About</a></li>
           <li><a href="/styleguide/">Style guide</a></li>
-          <li><a href="/people/">People</a></li>
           <li><a href="/news/">News</a></li>
           <li><a href="/initiatives/">Initiatives</a></li>
           <li><a href="/campaigns/single-page/">Single page campaign</a></li>
           <li><a href="/campaigns/multi-page/">Multi page campaign</a></li>
           <li><a href="/opportunity/single-page/">Single page opportunity</a></li>
           <li><a href="/opportunity/multi-page/">Multi page opportunity</a></li>
-          <li><a href="/blog/post/">Blog post</a></li>
+          <li><a href="/blog/initial-test-blog-post-with-fixed-title/">Blog post</a></li>
+          <li><a href="/privacynotincluded/">Privacy Not Included</a></li>
         </ul>
       </div>
     </div>

--- a/network-api/networkapi/templates/reviewapp-help.html
+++ b/network-api/networkapi/templates/reviewapp-help.html
@@ -1,5 +1,7 @@
 {% extends "pages/base.html" %} {% load wagtailcore_tags wagtailimages_tags %}
 
+{% block wagtail_metadata %}{% endblock %}
+
 {% block body_id %}reviewapp-help{% endblock%}
 
 {% block content %}


### PR DESCRIPTION
Review apps all have a `DEV HELP` page with a few links to different types of pages (`Multi page campaign`, `Single page opportunity`, etc). It suffered from the same issues as the [Mozfest 404 page](https://github.com/mozilla/foundation.mozilla.org/pull/3541) so this PR makes sure we don't load wagtail-managed metadata, and also update a few broken links. 