### PR TITLE
Fix "recent blog entries" component

### DIFF
--- a/network-api/networkapi/wagtailpages/customblocks/recent_blog_entries.py
+++ b/network-api/networkapi/wagtailpages/customblocks/recent_blog_entries.py
@@ -70,10 +70,11 @@ class RecentBlogEntries(blocks.StructBlock):
         only choose one filter option.
         '''
         if category:
-            category = slugify(category)
             type = "category"
-            query = category
-            blogpage.extract_category_information(category)
+            query = slugify(category)
+            BlogPageCategory = apps.get_model('wagtailpages.BlogPageCategory')
+            category_object = BlogPageCategory.objects.get(name=category)
+            blogpage.extract_category_information(category_object)
             entries = blogpage.get_entries(context)
 
         # Updates the href for the 'More from our blog' button

--- a/network-api/networkapi/wagtailpages/customblocks/recent_blog_entries.py
+++ b/network-api/networkapi/wagtailpages/customblocks/recent_blog_entries.py
@@ -46,7 +46,7 @@ class RecentBlogEntries(blocks.StructBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
         IndexPage = apps.get_model('wagtailpages.IndexPage')
-        blogpage = IndexPage.objects.get(title__iexact="blog")
+        blogpage = IndexPage.objects.get(title_en__iexact="blog")
 
         tag = value.get("tag_filter", False)
         category = value.get("category_filter", False)


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3894 by resolving the category string to a category object before calling `blogpage.extract_category_information()`

- https://foundation-mofostaging-pr-3895.herokuapp.com/en/internet-health-report/blog/
- https://foundation-mofostaging-pr-3895.herokuapp.com/fr/internet-health-report/blog/

I thought this also closed https://github.com/mozilla/foundation.mozilla.org/issues/3865 but the moment I try the categories in /fr/ it no longer works, so I'll investigate a bit more.

steps for testing: 
- I added a `RedirectingPage` with title `blog` on https://foundation-mofostaging-pr-3895.herokuapp.com/en/opportunity/multi-page/
- clicked the category on https://foundation-mofostaging-pr-3895.herokuapp.com/en/blog/season-need-something-us-focus-heart/ (worked)
- clicked the category on https://foundation-mofostaging-pr-3895.herokuapp.com/fr/blog/season-need-something-us-focus-heart/ (did not work correctly)
