### PR TITLE
Fix #3907: Make internet health report link under initiatives open in same tab

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/static/initiatives_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/static/initiatives_page.html
@@ -30,7 +30,7 @@
             <a class="multipage-link active" href="./">{% trans "Overview" %}</a>
             <!-- hardcoding nav links as per https://github.com/mozilla/foundation.mozilla.org/issues/2379#issuecomment-449127807  -->
             <a class="multipage-link" href="/advocacy">{% trans "Advocacy" %}</a>
-            <a class="multipage-link" href="https://foundation.mozilla.org/internet-health-report/" target="_blank">{% trans "Internet Health Report" %}</a>
+            <a class="multipage-link" href="https://foundation.mozilla.org/internet-health-report/">{% trans "Internet Health Report" %}</a>
             <a class="multipage-link" href="/fellowships">{% trans "Fellowships" %}</a>
             <a class="multipage-link" href="/awards">{% trans "Awards" %}</a>
             <a class="multipage-link" href="https://mozillafestival.org/" target="_blank">{% trans "MozFest" %}</a>


### PR DESCRIPTION
Closes #3907
Related PRs/issues #3889/#3899