### PR TITLE
add a note to visual regression testing

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -52,3 +52,7 @@ It's possible to skip CI builds by adding `[skip ci]` or `[ci skip]` in the comm
 ### Visual regression testing
 
 The Travis continuous integration run will also trigger a visual regression testing using [Percy.io](https://percy.io) (based on Cypress output). These tests do not need to pass for a PR to be merged in, but any discrepancies that are flagged by Percy should be reviewed and signed off on during the course of normal PR review.
+
+Note that any changes to model fields, field ordering, or factories, will likely result in charges to our testing data, which will result in Percy flagging changes: the test data is based on Python's pseudo-random number generator, which we seed at various points during test data generation, but between those seed points is based on the exact order in which fields are assigned testing data. If the order of assignments changes, or old fields are added/new fields are removed, then the PRNG sequence will be different, and Percy will likely show that there are visual diffs that require sign-off.
+
+It is possible that a PR has Percy-flagged changes, despite the PR not touching model/factory code nor introducing changes to the front-end code. In this case, please alert the engineering team: we've seen this happen in the past and it is unclear why it happens.


### PR DESCRIPTION
Added two paragraphs to explain when to expect diffs, and when they are unexpected and require actually raising concerns over.

Closes https://github.com/mozilla/foundation.mozilla.org/issues/3923