### PR TITLE
Pull subscription status from pni home url

### DIFF
--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import ReactGA from "../react-ga-proxy.js";
+import Storage from "../storage.js";
 
 import primaryNav from "./components/primary-nav/primary-nav.js";
 import navNewsletter from "../nav-newsletter.js";
@@ -28,6 +29,17 @@ let main = {
 
       csrfToken = document.querySelector('meta[name="csrf-token"]');
       csrfToken = csrfToken ? csrfToken.getAttribute("content") : false;
+      
+      // Checking newsletter subscription status
+      const sessionStorage = Storage.sessionStorage;
+
+      let queryString = new URLSearchParams(window.location.search);
+      let subscribedValue = queryString.get("subscribed");
+
+      if (subscribedValue) {
+        let subscribed = subscribedValue === "1";
+        sessionStorage.setItem("subscribed", subscribed);
+      }
 
       // HEROKU_APP_DOMAIN is used by review apps
       if (!networkSiteURL && env.HEROKU_APP_NAME) {

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -29,7 +29,7 @@ let main = {
 
       csrfToken = document.querySelector('meta[name="csrf-token"]');
       csrfToken = csrfToken ? csrfToken.getAttribute("content") : false;
-      
+
       // Checking newsletter subscription status
       const sessionStorage = Storage.sessionStorage;
 

--- a/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
+++ b/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
@@ -34,7 +34,6 @@ export default class CreepVote extends React.Component {
 
     let confidence = votes.confidence;
 
-
     let subscribed = sessionStorage.subscribed === "true";
     let voteCount = parseInt(sessionStorage.getItem(`voteCount`) || 0);
 

--- a/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
+++ b/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
@@ -8,9 +8,6 @@ import JoinUs from "../../../components/join/join.jsx";
 import { getText } from "../../../components/petition/locales";
 
 import CREEPINESS_LABELS from "../creepiness-labels.js";
-import Storage from "../../../storage";
-
-const sessionStorage = Storage.sessionStorage;
 
 export default class CreepVote extends React.Component {
   constructor(props) {
@@ -37,16 +34,11 @@ export default class CreepVote extends React.Component {
 
     let confidence = votes.confidence;
 
-    let queryString = new URLSearchParams(window.location.search);
-    let subscribedValue = queryString.get("subscribed");
-    let subscribed = subscribedValue === "1";
 
-    let sessionSubscription = sessionStorage.getItem("subscribed") === "true";
+    let subscribed = sessionStorage.subscribed === "true";
     let voteCount = parseInt(sessionStorage.getItem(`voteCount`) || 0);
 
-    if (sessionSubscription) {
-      subscribed = sessionSubscription;
-    } else if (voteCount >= 3) {
+    if (voteCount >= 3) {
       subscribed = true;
     }
 


### PR DESCRIPTION
Previously we were searching if `subscribed=1` was coming form a product page url and this pr fixes that issue and instead looks at the pni home url `subscribed` param.

https://foundation-mofostaging-pr-3946.herokuapp.com/en/privacynotincluded/
https://foundation-mofostaging-pr-3946.herokuapp.com/en/privacynotincluded/?subscribed=1