### PR TITLE
Upgrade percy/cypress to v2 to fix a known bug about homepage percy test not being taken

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -8,10 +8,13 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
+let percyHealthCheck = require("@percy/cypress/task");
+
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  on("task", percyHealthCheck);
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run build:common && npm run build:js",
     "build-uncompressed": "npm run build:common && npm run build:js-uncompressed",
     "cypress": "run-p --race server cypress:test",
-    "cypress:install": "npm install --no-save cypress@^3.1.5 @percy/cypress@^1.0.2",
+    "cypress:install": "npm install --no-save cypress@^3.1.5 @percy/cypress@^2.0.0",
     "cypress:test": "wait-on tcp:8000 && cypress run",
     "heroku-postbuild": "npm run build",
     "migrate": "pipenv run python network-api/manage.py migrate",


### PR DESCRIPTION
The root cause of homepage Percy test isn't being taken is because of a known Percy v1 bug -- the first snapshot isn't being triggered. Upgrading percy/cypress to v2.0.0 fixes this issue.

Migration guide: https://github.com/percy/percy-cypress/releases/tag/v2.0.0