### PR TITLE
Make sure dev help page doesn't show up on prod

### DIFF
--- a/app.json
+++ b/app.json
@@ -66,7 +66,8 @@
     "CSP_MEDIA_SRC": "'self'",
     "CSP_CHILD_SRC": "'self'",
     "CSP_FORM_ACTION": "'self' https://www.mozilla.org/en-US/newsletter/",
-    "NPM_CONFIG_PRODUCTION": "true"
+    "NPM_CONFIG_PRODUCTION": "true",
+    "REVIEW_APP": "True"
   },
   "buildpacks": [
     {

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -43,6 +43,9 @@ Opening a PR activates different services:
 
 Opening a PR will automatically create a review app in the `foundation-site` pipeline. It's not possible to use OAuth but you can still access the admin interface with a username and password. The login details for review apps are published in the `mofo-ra-foundation` Slack channel when the app has finished deploying.
 
+Environment variable:
+- `REVIEW_APP`: set to True on review app.
+
 ### Continuous Integration testing
 
 Opening a PR will trigger [Travis](https://travis-ci.org) continuous integration, which should pass before a PR is deemed good to merge.

--- a/network-api/networkapi/buyersguide/models.py
+++ b/network-api/networkapi/buyersguide/models.py
@@ -632,7 +632,7 @@ class ProductPrivacyPolicyLink(Orderable, models.Model):
 @receiver(pre_delete, sender=Product)
 def delete_image(sender, instance, **kwargs):
     # We want to keep our review app placeholders
-    if settings.HEROKU_APP_NAME:
+    if settings.REVIEW_APP:
         pass
     else:
         if instance.cloudinary_image:

--- a/network-api/networkapi/context_processor.py
+++ b/network-api/networkapi/context_processor.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 # Used to export env variable to Django templates
 def review_app(request):
-    return {"REVIEW_APP": settings.REVIEW_APP}
+    return {'REVIEW_APP': settings.REVIEW_APP}
 
 
 # Used in BuyersGuide templates to check if we're using cloudinary

--- a/network-api/networkapi/context_processor.py
+++ b/network-api/networkapi/context_processor.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 # Used to export env variable to Django templates
 def review_app(request):
-    return {'HEROKU_APP_NAME': settings.HEROKU_APP_NAME}
+    return {"REVIEW_APP": settings.REVIEW_APP}
 
 
 # Used in BuyersGuide templates to check if we're using cloudinary

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -79,7 +79,8 @@ env = environ.Env(
     DATA_UPLOAD_MAX_NUMBER_FIELDS=(int, 2500),
     # Sentry
     SENTRY_DSN=(str, None),
-    HEROKU_RELEASE_VERSION=(str, None)
+    HEROKU_RELEASE_VERSION=(str, None),
+    REVIEW_APP=(bool, False),
 )
 
 # Read in the environment
@@ -99,6 +100,9 @@ if SENTRY_DSN:
         integrations=[DjangoIntegration()],
         release=HEROKU_RELEASE_VERSION
     )
+
+# At True when running on a review app
+REVIEW_APP = env("REVIEW_APP", default=False)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = root()

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -102,7 +102,7 @@ if SENTRY_DSN:
     )
 
 # At True when running on a review app
-REVIEW_APP = env("REVIEW_APP", default=False)
+REVIEW_APP = env('REVIEW_APP', default=False)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = root()

--- a/network-api/networkapi/templates/fragments/nav_links.html
+++ b/network-api/networkapi/templates/fragments/nav_links.html
@@ -4,4 +4,4 @@
   {{ pre }}<a class="{% primary_active_nav request menu_root.full_url item.full_url %}" href="{{ item.url }}">{{ item.title }}</a>{{ post }}
 {% endfor %}
 
-{% if HEROKU_APP_NAME %}{{ pre }}<a href="/help">DEV HELP</a>{{ post }}{% endif %}
+{% if HEROKU_APP_NAME and not HEROKU_APP_NAME == 'foundation-mozilla-org' %}{{ pre }}<a href="/help">DEV HELP</a>{{ post }}{% endif %}

--- a/network-api/networkapi/templates/fragments/nav_links.html
+++ b/network-api/networkapi/templates/fragments/nav_links.html
@@ -4,4 +4,4 @@
   {{ pre }}<a class="{% primary_active_nav request menu_root.full_url item.full_url %}" href="{{ item.url }}">{{ item.title }}</a>{{ post }}
 {% endfor %}
 
-{% if HEROKU_APP_NAME and not HEROKU_APP_NAME == 'foundation-mozilla-org' %}{{ pre }}<a href="/help">DEV HELP</a>{{ post }}{% endif %}
+{% if REVIEW_APP %}{{ pre }}<a href="/help">DEV HELP</a>{{ post }}{% endif %}

--- a/network-api/networkapi/views.py
+++ b/network-api/networkapi/views.py
@@ -16,7 +16,7 @@ class EnvVariablesView(View):
 
 def review_app_help_view(request):
     try:
-        if settings.HEROKU_APP_NAME:
+        if settings.REVIEW_APP:
             return render(request, 'reviewapp-help.html')
     except AttributeError:
         raise Http404()


### PR DESCRIPTION
We added dyno metada on Heroku to give more context to errors caught by Sentry, which added `HEROKU_APP_NAME` on prod. Updating the if in the template to make sure that the dev help page doesn't show up on prod.