### PR TITLE
Fix featured blog dates

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/featured_blogs.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/featured_blogs.html
@@ -30,7 +30,7 @@
             {% if blog.blog.author %}
               {% blocktrans with author=blog.blog.author %}by {{author}}{% endblocktrans %}
             {% endif %}
-            {% if blog.blog.first_published_at %} {% blocktrans with date=page.first_published_at|date:"DATE_FORMAT" %}on {{date}}{% endblocktrans %}{% else %}not published yet{% endif %}
+            {% if blog.blog.first_published_at %} {% blocktrans with date=blog.blog.first_published_at|date:"DATE_FORMAT" %}on {{date}}{% endblocktrans %}{% else %}not published yet{% endif %}
           </p>
           <p>{{blog.blog.search_description}}</p>
         </div>

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -157,10 +157,18 @@ def get_content_related_by_tag(page, result_count=3):
     # tags" is further sorted such that the most recent post shows
     # up first (note that this is done on the database side, not in python).
 
-    ordered = sorted(
-        list(results),
-        key=lambda p: (p.num_common_tags, p.last_published_at),
-        reverse=True
-    )
+    # FIXME: temporary try/except to figure out a bug in production:
+    # See https://github.com/mozilla/foundation.mozilla.org/issues/4046
 
-    return ordered[:result_count]
+    result_list = list(results)
+
+    try:
+        result_list = sorted(
+            result_list,
+            key=lambda p: (p.num_common_tags, p.last_published_at),
+            reverse=True
+        )
+    except TypeError:
+        pass
+
+    return result_list[:result_count]


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4050 by making sure we render the _blog_ "first published" date, not the _homepage's_
