### PR TITLE
Remove hamburger menu lg-screen+

### DIFF
--- a/network-api/networkapi/templates/partials/primary_nav.html
+++ b/network-api/networkapi/templates/partials/primary_nav.html
@@ -34,7 +34,7 @@
                 <div class="d-flex align-items-center flex-wrap">
 
                   {% block burger_and_logo %}
-                    <button class="burger {% if page.zen_nav == False or page.zen_nav == null %} hidden-lg-up ml-md-0 {% endif %}" aria-label="{% trans 'Open menu' %}">
+                    <button class="burger {% if page.zen_nav is not True %} hidden-lg-up ml-md-0 {% endif %}" aria-label="{% trans 'Open menu' %}">
                       <div class="burger-bar burger-bar-top"></div>
                       <div class="burger-bar burger-bar-middle"></div>
                       <div class="burger-bar burger-bar-bottom"></div>

--- a/network-api/networkapi/templates/partials/primary_nav.html
+++ b/network-api/networkapi/templates/partials/primary_nav.html
@@ -34,7 +34,7 @@
                 <div class="d-flex align-items-center flex-wrap">
 
                   {% block burger_and_logo %}
-                    <button class="burger {% if page.zen_nav == False or page.zen_nav == undefined %} hidden-lg-up ml-md-0 {% endif %}" aria-label="{% trans 'Open menu' %}">
+                    <button class="burger {% if page.zen_nav == False or page.zen_nav == null %} hidden-lg-up ml-md-0 {% endif %}" aria-label="{% trans 'Open menu' %}">
                       <div class="burger-bar burger-bar-top"></div>
                       <div class="burger-bar burger-bar-middle"></div>
                       <div class="burger-bar burger-bar-bottom"></div>

--- a/network-api/networkapi/templates/partials/primary_nav.html
+++ b/network-api/networkapi/templates/partials/primary_nav.html
@@ -34,7 +34,7 @@
                 <div class="d-flex align-items-center flex-wrap">
 
                   {% block burger_and_logo %}
-                    <button class="burger {% if page.zen_nav == False %} hidden-lg-up ml-md-0 {% endif %}" aria-label="{% trans 'Open menu' %}">
+                    <button class="burger {% if page.zen_nav == False or page.zen_nav == undefined %} hidden-lg-up ml-md-0 {% endif %}" aria-label="{% trans 'Open menu' %}">
                       <div class="burger-bar burger-bar-top"></div>
                       <div class="burger-bar burger-bar-middle"></div>
                       <div class="burger-bar burger-bar-bottom"></div>


### PR DESCRIPTION
Related PRs/issues #4018

The hamburger code was refactored [here](https://github.com/mozilla/foundation.mozilla.org/pull/4018/files#diff-231f11884173d6383dd6469548e82a4dR37) and should've included logic for if `page.zen_nav` is undefined.