### PR TITLE
we pull country from the selector, not via an onChange handler

### DIFF
--- a/source/js/components/petition/country-select.jsx
+++ b/source/js/components/petition/country-select.jsx
@@ -7,10 +7,6 @@ export default class CountrySelect extends React.Component {
     super(props);
   }
 
-  handleChange(event) {
-    this.props.handleCountryChange(event.target.value);
-  }
-
   render() {
     let classes = classNames(
       `country-picker form-control`,
@@ -34,7 +30,6 @@ export default class CountrySelect extends React.Component {
         }}
         onFocus={this.props.onFocus}
         defaultValue={``}
-        onChange={evt => this.handleChange(evt)}
         aria-label="Please select your country"
       >
         <option value="">{this.props.label}</option>


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4070 by observing that we pull the country value via https://github.com/mozilla/foundation.mozilla.org/blob/master/source/js/components/petition/petition.jsx#L150 and so the `onChange` handler in the `CountrySelect` component shouldn't even be there.

My testing was using a `console.log(payload)` in `submitDataToApi`, which shows the correct country code included in the payload when submitting the form after selecting a country.