### PR TITLE
Meaningless change to force a deploy trigger, because travis got _horribly_ stuck

### DIFF
--- a/cypress/integration/endpoint-tests.js
+++ b/cypress/integration/endpoint-tests.js
@@ -35,6 +35,8 @@ describe(`Visual regression testing for foundation.mozilla.org`, () => {
     cy.percySnapshot();
   });
 
+  // Blog pages
+
   it(`Blog index page`, function() {
     cy.visit(`/en/blog`);
     cy.window()


### PR DESCRIPTION
Something went wrong on Travis' end and it died trying to build master after trying to run the `npm test` job for 50 minutes.