### PR TITLE
Fix dark-theme dropdown option's text color

### DIFF
--- a/source/sass/components/select-dropdown.scss
+++ b/source/sass/components/select-dropdown.scss
@@ -26,10 +26,11 @@ select {
       border: 1px solid $white;
       color: $white;
 
-      // target Edge broswser to explictly set background color to black
-      // otherwise on Edge the dropdown options won't show (white text on Edge's default white background)
-      @supports (-ms-ime-align: auto) {
-        background-color: $black;
+      // Explicitly setting <option>'s color to black.
+      // Otherwise, certain browsers would inherit the text color we set for <select>, and
+      // we would end up having white text on white background in the dropdown.
+      option {
+        color: $black;
       }
     }
   }


### PR DESCRIPTION
Closes #4230 

I've verified that this change looks good on all major browsers on Mac, Windows, Android, and iOS. Dropdown menu list all appears as black text on light background (browser's default background colour for dropdown).
