### PR TITLE
Update CSP related values so they match what are on production

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "network",
-  "description": "The Mozilla Network site",
+  "name": "Mozilla Foundation site",
+  "description": "Mozilla Foundation site",
   "addons": [
     "heroku-postgresql:hobby-dev"
   ],
@@ -23,15 +23,15 @@
     "USE_S3": "True",
     "PULSE_API_DOMAIN": "https://network-pulse-api-production.herokuapp.com",
     "PULSE_DOMAIN": "www.mozillapulse.org",
-    "CSP_DEFAULT_SRC": "'none'",
-    "CSP_SCRIPT_SRC": "'self' 'unsafe-inline' cdn.optimizely.com https://www.google-analytics.com/analytics.js",
-    "CSP_STYLE_SRC": "'self' 'unsafe-inline' code.cdn.mozilla.net fonts.googleapis.com",
-    "CSP_IMG_SRC": "* data:",
-    "CSP_FONT_SRC": "'self' fonts.gstatic.com fonts.googleapis.com code.cdn.mozilla.net",
+    "CSP_CHILD_SRC": "'self' https://www.youtube.com https://s3.amazonaws.com/ask-mozilla/ https://www.youtube-nocookie.com",
     "CSP_CONNECT_SRC": "*",
+    "CSP_DEFAULT_SRC": "'none'",
+    "CSP_FRAME_ANCESTORS": "'none'",
+    "CSP_FONT_SRC": "'self' https://fonts.gstatic.com https://fonts.googleapis.com https://code.cdn.mozilla.net",
+    "CSP_IMG_SRC": "* data:",
     "CSP_MEDIA_SRC": "'self'",
-    "CSP_CHILD_SRC": "'self'",
-    "CSP_FORM_ACTION": "'self' https://www.mozilla.org/en-US/newsletter/",
+    "CSP_SCRIPT_SRC": "'self' 'unsafe-inline' https://www.google-analytics.com/analytics.js http://*.shpg.org/ https://comments.mozillafoundation.org/ https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com",
+    "CSP_STYLE_SRC": "'self' 'unsafe-inline' https://code.cdn.mozilla.net https://fonts.googleapis.com  https://platform.twitter.com",
     "NPM_CONFIG_PRODUCTION": "true",
     "REVIEW_APP": "True"
   },

--- a/app.json
+++ b/app.json
@@ -23,7 +23,7 @@
     "USE_S3": "True",
     "PULSE_API_DOMAIN": "https://network-pulse-api-production.herokuapp.com",
     "PULSE_DOMAIN": "www.mozillapulse.org",
-    "CSP_CHILD_SRC": "'self' https://www.youtube.com https://s3.amazonaws.com/ask-mozilla/ https://www.youtube-nocookie.com",
+    "CSP_CHILD_SRC": "'self' https://www.youtube.com https://www.youtube-nocookie.com",
     "CSP_CONNECT_SRC": "*",
     "CSP_DEFAULT_SRC": "'none'",
     "CSP_FRAME_ANCESTORS": "'none'",

--- a/env.default
+++ b/env.default
@@ -45,7 +45,7 @@ CRM_PETITION_SQS_QUEUE_URL=
 
 # CSP config
 
-CSP_CHILD_SRC='self' https://www.youtube.com https://s3.amazonaws.com/ask-mozilla/ https://www.youtube-nocookie.com
+CSP_CHILD_SRC='self' https://www.youtube.com https://www.youtube-nocookie.com
 CSP_CONNECT_SRC=*
 CSP_DEFAULT_SRC='none'
 CSP_FONT_SRC='self' https://fonts.gstatic.com https://fonts.googleapis.com https://code.cdn.mozilla.net

--- a/env.default
+++ b/env.default
@@ -45,16 +45,16 @@ CRM_PETITION_SQS_QUEUE_URL=
 
 # CSP config
 
-CSP_DEFAULT_SRC='none'
-CSP_SCRIPT_SRC='self' 'unsafe-inline' cdn.optimizely.com https://www.google-analytics.com/analytics.js https://*.shpg.org/ http://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com
-CSP_STYLE_SRC='self' 'unsafe-inline' code.cdn.mozilla.net fonts.googleapis.com https://platform.twitter.com
-CSP_IMG_SRC=* data:
-CSP_FONT_SRC='self' fonts.gstatic.com fonts.googleapis.com code.cdn.mozilla.net
+CSP_CHILD_SRC='self' https://www.youtube.com https://s3.amazonaws.com/ask-mozilla/ https://www.youtube-nocookie.com
 CSP_CONNECT_SRC=*
+CSP_DEFAULT_SRC='none'
+CSP_FONT_SRC='self' https://fonts.gstatic.com https://fonts.googleapis.com https://code.cdn.mozilla.net
+CSP_FRAME_ANCESTORS='none'
+CSP_FRAME_SRC='self' https://www.youtube.com  https://s3.amazonaws.com/ask-mozilla/ https://auremoser.carto.com https://comments.mozillafoundation.org/ https://airtable.com https://docs.google.com/ https://platform.twitter.com https://public.zenkit.com https://calendar.google.com https://www.youtube-nocookie.com
+CSP_IMG_SRC=* data:
 CSP_MEDIA_SRC='self'
-CSP_CHILD_SRC='self' https://www.youtube.com https://s3.amazonaws.com
-CSP_FORM_ACTION='self' https://www.mozilla.org/en-US/newsletter/
-CSP_FRAME_SRC=https://airtable.com https://platform.twitter.com
+CSP_SCRIPT_SRC='self' 'unsafe-inline' https://www.google-analytics.com/analytics.js http://*.shpg.org/ https://comments.mozillafoundation.org/ https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com
+CSP_STYLE_SRC='self' 'unsafe-inline' https://code.cdn.mozilla.net https://fonts.googleapis.com  https://platform.twitter.com
 
 # TEST ENVIRONMENT VALUES
 

--- a/network-api/networkapi/management/commands/review_app_admin.py
+++ b/network-api/networkapi/management/commands/review_app_admin.py
@@ -41,7 +41,9 @@ class Command(BaseCommand):
                 token = settings.GITHUB_TOKEN
                 org = 'mozilla'
                 repo = 'foundation.mozilla.org'
-                r = requests.get(f'https://api.github.com/repos/{org}/{repo}/pulls/{pr_number}&access_token={token}')
+                headers = {'Authorization': f'token {token}'}
+                r = requests.get(f'https://api.github.com/repos/{org}/{repo}/pulls/{pr_number}', headers=headers)
+                r.raise_for_status()
                 try:
                     pr_title = ': ' + r.json()['title']
                 except KeyError:


### PR DESCRIPTION
Closes #3250 

I updated CSP related keys and values so they match what are on production (+ I sorted them alphabetically).

Few notes:

- I deleted `CSP_FORM_ACTION` from `app.json` and `env.default` since this env isn't being explicitly set on prod.
- I added `CSP_FRAME_ANCESTORS` to `app.json` and `env.default` since this env is explicitly set on prod.
- CSP values in `app.json` and `env.default` now include protocol. 
