### PR TITLE
google fonts should always load on https

### DIFF
--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -30,9 +30,9 @@
 
     {% block stylesheets %}
       <link rel="stylesheet" href="/_css/main.compiled.css">
-      <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Nunito+Sans:400,300,700,300i">
-      <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Zilla+Slab:300,400,600,700,300i">
-      <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,700">
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Nunito+Sans:400,300,700,300i">
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,400,600,700,300i">
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700">
     {% endblock %}
 
     {% block extended_head %}{% endblock %}

--- a/network-api/networkapi/wagtailcustomization/templates/wagtailadmin/404.html
+++ b/network-api/networkapi/wagtailcustomization/templates/wagtailadmin/404.html
@@ -13,9 +13,9 @@
     <!-- our app's additional CSS -->
     <link rel="stylesheet" href="/_css/main.compiled.css">
     <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/404-additionals.css' %}" />
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Nunito+Sans:400,600,300,700">
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Zilla+Slab:300,400">
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,700">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Nunito+Sans:400,600,300,700">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,400">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700">
 {% endblock %}
 
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube_regrets_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube_regrets_page.html
@@ -4,7 +4,7 @@
 {% block body_id %}youtube-regrets{% endblock %}
 
 {% block extended_head %}
-  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Changa" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Changa" rel="stylesheet">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4327