### PR TITLE
Adjust sticky CTA position for MozFest & tiny SCSS code refactor

### DIFF
--- a/network-api/networkapi/mozfest/factory.py
+++ b/network-api/networkapi/mozfest/factory.py
@@ -12,7 +12,7 @@ from factory import (
     SubFactory,
     LazyAttribute
 )
-from .signup import SignupFactory
+from networkapi.wagtailpages.factory.signup import SignupFactory
 from .models import (
     MozfestHomepage,
     MozfestPrimaryPage

--- a/network-api/networkapi/mozfest/factory.py
+++ b/network-api/networkapi/mozfest/factory.py
@@ -12,6 +12,7 @@ from factory import (
     SubFactory,
     LazyAttribute
 )
+from .signup import SignupFactory
 from .models import (
     MozfestHomepage,
     MozfestPrimaryPage
@@ -53,6 +54,8 @@ class MozfestHomepageFactory(MozfestPrimaryPageFactory):
                          'young people dedicated to creating a better, healthier open internet.')
     banner_video_url = Faker('url')
     banner_heading_text = Faker('sentence', nb_words=6, variable_nb_words=True)
+
+    signup = SubFactory(SignupFactory)
 
 
 def generate(seed):

--- a/source/js/components/petition/petition.scss
+++ b/source/js/components/petition/petition.scss
@@ -1,44 +1,5 @@
 @import "donation-modal.scss";
 
-#cta-anchor {
-  margin-top: -80px;
-  padding-top: 80px;
-}
-
-.cta {
-  .sticky-cta {
-    position: sticky;
-    top: 5rem;
-    z-index: 1029; /* we need a z-index due to the header also being sticky, our header is 1030 (bootstrap) */
-    overflow: hidden;
-  }
-
-  .narrow-sticky-button-container {
-    background: $white;
-    padding: 15px;
-    width: 100%;
-    box-shadow: 0 -1px 3px $border-shadow-color;
-    border-top: 1px solid $gray-20;
-    display: block;
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    transition: margin-bottom 0.3s ease-in-out;
-
-    &.hidden {
-      margin-bottom: -308px;
-      visibility: hidden;
-      pointer-events: auto;
-      transition: margin-bottom 0.3s ease-in-out, visibility 0s ease-in-out 0.3s;
-    }
-
-    @media (min-width: $bp-lg) {
-      display: none;
-    }
-  }
-}
-
 .form-label-group {
   position: relative;
   cursor: text;

--- a/source/sass/main.scss
+++ b/source/sass/main.scss
@@ -52,8 +52,9 @@ $bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
 @import "./cms";
 @import "./wagtail";
 
-// temporary?
-@import "./mozfest";
+// Shared between different views
+
+@import "./views/shared/sticky-cta";
 
 // View specific
 
@@ -67,6 +68,10 @@ $bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
 @import "./views/blog";
 @import "./views/style-guide";
 @import "./views/youtube-regrets";
+
+// MozFest
+
+@import "./mozfest";
 
 // Bootstrap or mofo-bootstrap overrides
 

--- a/source/sass/mixins.scss
+++ b/source/sass/mixins.scss
@@ -89,7 +89,7 @@
   }
 }
 
-@mixin cta-anchor-position($extra-vertical-spacing: 0) {
+@mixin cta-anchor-position($extra-vertical-spacing: 0px) {
   $offset: 80px;
 
   margin-top: -$offset;

--- a/source/sass/mixins.scss
+++ b/source/sass/mixins.scss
@@ -88,3 +88,10 @@
     }
   }
 }
+
+@mixin cta-anchor-position($extra-vertical-spacing: 0) {
+  $offset: 80px;
+
+  margin-top: -$offset;
+  padding-top: calc(#{$offset} + #{$extra-vertical-spacing});
+}

--- a/source/sass/mozfest.scss
+++ b/source/sass/mozfest.scss
@@ -152,6 +152,17 @@ body.mozfest {
         }
       }
     }
+
+    .cta {
+      $sticky-extra-offset: 1.5rem;
+
+      position: relative;
+      top: -$sticky-extra-offset;
+
+      #cta-anchor {
+        @include cta-anchor-position($sticky-extra-offset);
+      }
+    }
   }
 
   #multipage-nav {

--- a/source/sass/views/shared/sticky-cta.scss
+++ b/source/sass/views/shared/sticky-cta.scss
@@ -1,0 +1,37 @@
+#cta-anchor {
+  @include cta-anchor-position();
+}
+
+.cta {
+  .sticky-cta {
+    position: sticky;
+    top: 5rem;
+    z-index: 1029; /* we need a z-index due to the header also being sticky, our header is 1030 (bootstrap) */
+    overflow: hidden;
+  }
+
+  .narrow-sticky-button-container {
+    background: $white;
+    padding: 15px;
+    width: 100%;
+    box-shadow: 0 -1px 3px $border-shadow-color;
+    border-top: 1px solid $gray-20;
+    display: block;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    transition: margin-bottom 0.3s ease-in-out;
+
+    &.hidden {
+      margin-bottom: -308px;
+      visibility: hidden;
+      pointer-events: auto;
+      transition: margin-bottom 0.3s ease-in-out, visibility 0s ease-in-out 0.3s;
+    }
+
+    @media (min-width: $bp-lg) {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
Closes #4304

https://foundation-s-issue-4304-s1nzcf.herokuapp.com/en/mozilla-festival/

Ended up going with a SCSS-only approach as I thought using JS to detect the `sticky` state and dynamically adjust the position of the CTA/form section just for MozFest homepage would be an overkill.