### PR TITLE
Wrap 'card' description with appropriate HTML tags

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/card.html
@@ -11,7 +11,11 @@
   <div class="full-bleed-xs d-flex flex-1">
     <div class="key-item mx-2 mx-md-3 p-3 w-100 d-flex flex-column">
       <h5 class="h3-heading mb-2">{{ title }}</h5>
-      <p>{{ description | richtext }}</p>
+      {% if description_is_rich_text %}
+        {{ description|richtext }}
+      {% else %}
+        <p>{{ description }}</p>
+      {% endif %}
       <a class="cta-link mb-2" href="{{ link_url }}">{{ link_label }}</a>
     </div>
   </div>

--- a/network-api/networkapi/wagtailpages/templatetags/card_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/card_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from bs4 import BeautifulSoup
 
 register = template.Library()
 
@@ -9,6 +10,7 @@ def card(image, title, description, link_url, link_label, commitment=None):
         'image': image,
         'title': title,
         'description': description,
+        'description_is_rich_text': BeautifulSoup(description, 'html.parser').p is not None,
         'link_url': link_url,
         'link_label': link_label,
         'commitment': commitment,

--- a/network-api/networkapi/wagtailpages/templatetags/card_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/card_tags.py
@@ -6,11 +6,13 @@ register = template.Library()
 
 @register.inclusion_tag('wagtailpages/tags/card.html')
 def card(image, title, description, link_url, link_label, commitment=None):
+    parsedDescription = BeautifulSoup(description, 'html.parser')
+
     return {
         'image': image,
         'title': title,
         'description': description,
-        'description_is_rich_text': BeautifulSoup(description, 'html.parser').p is not None,
+        'description_is_rich_text': len(parsedDescription.find_all(True)) > 0,
         'link_url': link_url,
         'link_label': link_label,
         'commitment': commitment,


### PR DESCRIPTION
Closes #4287 

Notes: some vertical spacing around the `descrition` also got fixed in this PR as before we had redundant empty `<p>` nodes hanging around. e.g., 
<img width="285" alt="image" src="https://user-images.githubusercontent.com/2896608/76894733-ed391b00-684b-11ea-90c0-30143457a703.png">

Go to the following pages and look for section that looks like
<img width="442" alt="image" src="https://user-images.githubusercontent.com/2896608/76894954-50c34880-684c-11ea-9823-ebd0c66d3a68.png">


## Hompage

https://foundation-s-issue-4287-fjnyxw.herokuapp.com/en/

## Initiatives

https://foundation-s-issue-4287-fjnyxw.herokuapp.com/en/initiatives/

## Participate

https://foundation-s-issue-4287-fjnyxw.herokuapp.com/en/participate/
