### PR TITLE
remove index-page as subpage

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -536,7 +536,6 @@ class Homepage(FoundationMetadataPageMixin, Page):
 
     subpage_types = [
         'BanneredCampaignPage',
-        'IndexPage',
         'BlogIndexPage',
         'CampaignIndexPage',
         'InitiativesPage',


### PR DESCRIPTION
Partial fulfillment for https://github.com/mozilla/foundation.mozilla.org/issues/4232, this initial PR removes the base "IndexPage" as a selectable option on the homepage. Only BlogIndexPage and CampaignPage are now allowed.