### PR TITLE
Remove forced redirect to English for PNI

### DIFF
--- a/network-api/networkapi/buyersguide/templates/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/bg_base.html
@@ -93,7 +93,7 @@
       {% block guts %}{% endblock %}
     </div>
 
-    {% include "partials/footer.html" with exclude_language_switcher=True %}
+    {% include "partials/footer.html" %}
   </div>
 
   {% block extra_scripts %}{% endblock %}

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -9,7 +9,7 @@ from django.test import TestCase, RequestFactory
 from datetime import date
 
 from networkapi.buyersguide.factory import ProductFactory
-from networkapi.buyersguide.models import RangeVote, BooleanVote, Product, BuyersGuideProductCategory
+from networkapi.buyersguide.models import RangeVote, BooleanVote, Product
 from networkapi.buyersguide.views import product_view, category_view, buyersguide_home
 from django.core.management import call_command
 
@@ -333,30 +333,6 @@ class BuyersGuideViewTest(TestCase):
         response = self.client.get('/privacynotincluded/')
         self.assertEqual(response.status_code, 302, 'simple locale gets redirected')
 
-    def test_only_en(self):
-        """
-        Test that the homepage redirects away from the other locales the site supports
-        """
-        response = self.client.get('/fr/privacynotincluded', follow=True)
-        self.assertEqual(response.redirect_chain[1][0], '/en/privacynotincluded/', 'redirects /fr/ to /en/')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get('/de/privacynotincluded', follow=True)
-        self.assertEqual(response.redirect_chain[1][0], '/en/privacynotincluded/', 'redirects /de/ to /en/')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get('/pt/privacynotincluded', follow=True)
-        self.assertEqual(response.redirect_chain[1][0], '/en/privacynotincluded/', 'redirects /pt/ to /en/')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get('/es/privacynotincluded', follow=True)
-        self.assertEqual(response.redirect_chain[1][0], '/en/privacynotincluded/', 'redirects /es/ to /en/')
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.get('/pl/privacynotincluded', follow=True)
-        self.assertEqual(response.redirect_chain[1][0], '/en/privacynotincluded/', 'redirects /pl/ to /en/')
-        self.assertEqual(response.status_code, 200)
-
     def test_product_view_404(self):
         """
         Test that the product view raises an Http404 if the product name doesn't exist
@@ -411,39 +387,3 @@ class ProductTests(TestCase):
         p.name = 'name changed'
         p.save()
         self.assertEqual(p.slug, slugify(p.name))
-
-    def test_only_en(self):
-        p = Product.objects.create(name='this should redirect', review_date=date.today())
-        url = f'/fr/privacynotincluded/products/{p.slug}/'
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response['Location'],
-            f'/en/privacynotincluded/products/{p.slug}/',
-            'redirects to /en/privacynotincluded/products/{slug}/'
-        )
-
-
-class CategoryViewTest(TestCase):
-    def test_only_en(self):
-        c = BuyersGuideProductCategory.objects.create(name='testcategory')
-        url = f'/fr/privacynotincluded/categories/{c.name}/'
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response['Location'],
-            f'/en/privacynotincluded/categories/{c.name}/',
-            'redirects to /en/privacynotincluded/categories/{name}/'
-        )
-
-
-class AboutViewTest(TestCase):
-    def test_only_en(self):
-        url = f'/fr/privacynotincluded/about/'
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response['Location'],
-            f'/en/privacynotincluded/about/',
-            'redirects to /en/privacynotincluded/about/'
-        )

--- a/network-api/networkapi/buyersguide/views.py
+++ b/network-api/networkapi/buyersguide/views.py
@@ -41,26 +41,6 @@ def get_average_creepiness(product):
     return 50
 
 
-def path_is_en_prefixed(path):
-    return path.startswith('/en/')
-
-
-def get_en_redirect(path):
-    redirect_path = re.sub(locale_regex, '/en/', path)
-    return redirect(redirect_path, permanent=False)
-
-
-def enforce_en_locale(view_handler):
-    def check_locale(*args, **kwargs):
-        path = args[0].path
-        if not path_is_en_prefixed(path):
-            return get_en_redirect(path)
-
-        return view_handler(*args, **kwargs)
-
-    return check_locale
-
-
 def filter_draft_products(request, products):
     if request.user.is_authenticated:
         return products
@@ -69,7 +49,6 @@ def filter_draft_products(request, products):
 
 
 @redirect_to_default_cms_site
-@enforce_en_locale
 def buyersguide_home(request):
     products = cache.get('sorted_product_dicts')
 
@@ -88,7 +67,6 @@ def buyersguide_home(request):
 
 
 @redirect_to_default_cms_site
-@enforce_en_locale
 def category_view(request, slug):
     key = f'products_category__{slug}'
     products = cache.get(key)
@@ -114,7 +92,6 @@ def category_view(request, slug):
 
 
 @redirect_to_default_cms_site
-@enforce_en_locale
 def product_view(request, slug):
     product = get_object_or_404(Product, slug=slug)
 
@@ -152,7 +129,6 @@ def product_view(request, slug):
 
 def bg_about_page(template_name):
     @redirect_to_default_cms_site
-    @enforce_en_locale
     def render_view(request):
         key = 'categories'
         categories = cache.get(key)


### PR DESCRIPTION
Closes #4379

Removing forced /en/ redirect for PNI and adding back language switcher in footer.

/fr/privacynotincluded should show some translations