### PR TITLE
Limit the number child pages that are permitted for the campaigns route

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/campaign_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaign_index.py
@@ -3,21 +3,14 @@ from .index import IndexPage
 
 class CampaignIndexPage(IndexPage):
     """
-    The campaign index is specifically for campaign pages
+    The campaign index is specifically for campaign-related pages
     """
 
-    # Commented off for now, as we'll do the refactor first,
-    # then explicitly set up the permitted page types in
-    # immediate follow-up.
-    #
-    # See issue https://github.com/mozilla/foundation.mozilla.org/issues/4221
-    #
-    # subpage_types = [
-    #     'BlogPage',
-    #     'BanneredCampaignPage',
-    #     'CampaignPage',
-    #     'OpportunityPage',
-    #     'YoutubeRegretsPage',
-    # ]
+    subpage_types = [
+        'BanneredCampaignPage',
+        'CampaignPage',
+        'OpportunityPage',
+        'YoutubeRegretsPage',
+    ]
 
     template = 'wagtailpages/index_page.html'


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4221 by restricting the permitted child page types to only four.

Note that we may need to move the one blog post that lives under `campaigns` right now, in order for this PR to land.

Alternatively I can put the BlogPage back as permitted type, but given that blog pages are lots of special components that assume all blog posts exist under /blog, we probably don't want to keep allowing that as child type.