### PR TITLE
Add missing closing div

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/index_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/index_page.html
@@ -70,5 +70,6 @@
         {# See main.js for the javascript that hooks into this button #}
       </div>
     </div>
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
The `index_page` template is missing a closing div.