### PR TITLE
Rename 'Happening now' to 'Featured stories'

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
@@ -33,7 +33,7 @@
   <div class="row">
     <div class="col mb-4">
       <hr class="hr-emphasis mb-4">
-      <h2 class="h4-heading">{% trans "Happening now" %}</h2>
+      <h2 class="h4-heading">{% trans "Featured stories" %}</h2>
     </div>
   </div>
   <div id="home-highlights-wagtail">


### PR DESCRIPTION
Closes #4468

@taisdesouzalessa you can also see the change on Percy. Scroll down this page and click on "details" 
<img width="703" alt="image" src="https://user-images.githubusercontent.com/2896608/79253592-4dfe4800-7e38-11ea-94c5-cb8c376c9880.png">
