### PR TITLE
Prototyping a Typeform block

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/base_fields.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base_fields.py
@@ -31,4 +31,5 @@ base_fields = [
     ('profile_directory', customblocks.ProfileDirectory()),
     ('recent_blog_entries', customblocks.RecentBlogEntries()),
     ('airtable', customblocks.AirTableBlock()),
+    ('typeform', customblocks.TypeFormBlock()),
 ]

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/__init__.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/__init__.py
@@ -12,6 +12,7 @@ from .profile_by_id import ProfileById
 from .profile_directory import ProfileDirectory
 from .pulse_project_list import PulseProjectList
 from .recent_blog_entries import RecentBlogEntries
+from .typeform_block import TypeFormBlock
 from .quote_block import QuoteBlock
 from .video_block import VideoBlock
 from .youtube_regret_block import YoutubeRegretBlock
@@ -33,6 +34,7 @@ __all__ = [
     PulseProjectList,
     QuoteBlock,
     RecentBlogEntries,
+    TypeFormBlock,
     VideoBlock,
     YoutubeRegretBlock,
 ]

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/typeform_block.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/typeform_block.py
@@ -1,0 +1,16 @@
+from wagtail.core import blocks
+
+
+class TypeFormBlock(blocks.StructBlock):
+    url = blocks.URLBlock(
+        help_text="The URL of the published typeform"
+    )
+
+    height = blocks.IntegerBlock(
+        default=500,
+        help_text="The height of the view on a desktop"
+    )
+
+    class Meta:
+        icon = 'placeholder'
+        template = 'wagtailpages/blocks/typeform_block.html'

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/typeform_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/typeform_block.html
@@ -1,0 +1,21 @@
+<script
+  src="https://embed.typeform.com/embed.js"
+  type="text/javascript"
+></script>
+
+<div
+  id="typeform-embed"
+  class="typeform-embed"
+  style="height: {{ value.height }}px;"
+></div>
+
+<script type="text/javascript">
+  window.addEventListener("DOMContentLoaded", () => {
+    let el = document.querySelector("div#typeform-embed");
+    window.typeformEmbed.makeWidget(el, "{{ value.url }}", {
+      hideFooter: true,
+      hideHeader: true,
+      opacity: 0
+    });
+  });
+</script>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/typeform_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/typeform_block.html
@@ -1,7 +1,4 @@
-<script
-  src="https://embed.typeform.com/embed.js"
-  type="text/javascript"
-></script>
+<script src="https://embed.typeform.com/embed.js" ></script>
 
 <div
   id="typeform-embed"
@@ -9,13 +6,4 @@
   style="height: {{ value.height }}px;"
 ></div>
 
-<script type="text/javascript">
-  window.addEventListener("DOMContentLoaded", () => {
-    let el = document.querySelector("div#typeform-embed");
-    window.typeformEmbed.makeWidget(el, "{{ value.url }}", {
-      hideFooter: true,
-      hideHeader: true,
-      opacity: 0
-    });
-  });
-</script>
+<meta name="typeform-formurl" content="{{ value.url }}">

--- a/source/js/embed-tf.js
+++ b/source/js/embed-tf.js
@@ -1,0 +1,23 @@
+let EmbedTF = {
+  init: function() {
+    document.addEventListener("DOMContentLoaded", () => EmbedTF.setup());
+  },
+  setup: function() {
+    let formMeta = document.querySelector('meta[name=typeform-formurl]');
+
+    if (!formMeta) {
+      return;
+    }
+
+
+    let formElement = document.querySelector("div#typeform-embed");
+
+    window.typeformEmbed.makeWidget(formElement, formMeta.getAttribute('content'), {
+      hideFooter: true,
+      hideHeader: true,
+      opacity: 0
+    });
+  }
+};
+
+export default EmbedTF;

--- a/source/js/embed-tf.js
+++ b/source/js/embed-tf.js
@@ -3,20 +3,23 @@ let EmbedTF = {
     document.addEventListener("DOMContentLoaded", () => EmbedTF.setup());
   },
   setup: function() {
-    let formMeta = document.querySelector('meta[name=typeform-formurl]');
+    let formMeta = document.querySelector("meta[name=typeform-formurl]");
 
     if (!formMeta) {
       return;
     }
 
-
     let formElement = document.querySelector("div#typeform-embed");
 
-    window.typeformEmbed.makeWidget(formElement, formMeta.getAttribute('content'), {
-      hideFooter: true,
-      hideHeader: true,
-      opacity: 0
-    });
+    window.typeformEmbed.makeWidget(
+      formElement,
+      formMeta.getAttribute("content"),
+      {
+        hideFooter: true,
+        hideHeader: true,
+        opacity: 0
+      }
+    );
   }
 };
 

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -16,6 +16,7 @@ import {
 } from "./foundation";
 
 import primaryNav from "./primary-nav.js";
+import EmbedTF from "./embed-tf.js";
 import initializeSentry from "./common/sentry-config.js";
 
 // Initializing component a11y browser console logging
@@ -39,6 +40,7 @@ const apps = [];
 let main = {
   init() {
     GoogleAnalytics.init();
+    EmbedTF.init();
 
     this.fetchEnv(envData => {
       env = envData;

--- a/source/sass/components/typeform-block.scss
+++ b/source/sass/components/typeform-block.scss
@@ -1,3 +1,3 @@
 .typeform-embed {
-    box-sizing: content-box;
+  box-sizing: content-box;
 }

--- a/source/sass/components/typeform-block.scss
+++ b/source/sass/components/typeform-block.scss
@@ -1,0 +1,3 @@
+.typeform-embed {
+    box-sizing: content-box;
+}

--- a/source/sass/main.scss
+++ b/source/sass/main.scss
@@ -41,6 +41,7 @@ $bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
 @import "./components/commitment";
 @import "./components/card";
 @import "./components/airtable-block";
+@import "./components/typeform-block";
 @import "./components/image-text-mini";
 @import "./components/select-dropdown";
 


### PR DESCRIPTION
Kinda works, but also kinda janky.

Height as a block attribute is a poor way to control the element, but I borrowed that from the airtable block.

When in responsive design mode, emulating an S9+, the Typeform frame goes full-screen until completion, which was not quite what I expected, but probably makes sense. However, the height attribute looks pretty silly on mobile, so maybe a responsive CSS rule could make it less janky?