### PR TITLE
Remove 'html-entities' from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5076,11 +5076,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
-    "html-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
-    },
     "html-tags": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "babel-loader": "^8.0.6",
     "classnames": "2.2.6",
     "event-stream": "3.3.4",
-    "html-entities": "^1.2.1",
     "js-cookie": "2.2.1",
     "mofo-bootstrap": "4.1.0",
     "moment": "^2.24.0",


### PR DESCRIPTION
Remove `html-entities` because we [don't need it (see `scripts/build-healthcheck.js`)](https://github.com/mozilla/foundation.mozilla.org/pull/897/files#diff-24f8b02e122f2c2a7aba4636b5fb2377).