### PR TITLE
ensures sorting in the page chooser modal

### DIFF
--- a/network-api/networkapi/wagtailpages/wagtail_hooks.py
+++ b/network-api/networkapi/wagtailpages/wagtail_hooks.py
@@ -6,7 +6,7 @@ import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler
 from wagtail.core import hooks
 
-# 1. Use the register_rich_text_features hook.
+# Extended rich text features for our site
 @hooks.register('register_rich_text_features')
 def register_large_feature(features):
     """
@@ -65,3 +65,13 @@ def register_large_feature(features):
     # 6. (optional) Add the feature to the default features list to make it available
     # on rich text fields that do not specify an explicit 'features' list
     features.default_features.append('large')
+
+# Ensure that pages in the PageChooserPanel listings are ordered on most-recent-ness
+@hooks.register('construct_page_chooser_queryset')
+def order_pages_in_chooser(pages, request):
+    # Change listings in the "page chooser" modal:
+    if "choose-page" in request.path:
+        return pages.order_by('-first_published_at')
+
+    # Don't change search results (shown in ./admin/pages/search)
+    return pages


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/3714 by making sure pages are always sorted newest-first