### PR TITLE
Allow any authenticated user to clear the PNI product cache

### DIFF
--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -399,6 +399,33 @@ class BuyersGuideViewTest(TestCase):
         response = self.client.get(f'/en/privacynotincluded/categories/smart-home/')
         self.assertEqual(response.status_code, 200, 'The category "Smarth Home" should work by slug')
 
+    def test_drive_by_clear_cache(self):
+        """
+        regular users should not be able to trigger clear_cache
+        """
+        authenticated = self.user.is_authenticated
+
+        self.client.logout()
+        response = self.client.post('/api/buyersguide/clear-cache/')
+        self.assertEqual(response.status_code, 403, 'standard user is not permitted to clear BG cache')
+
+        if authenticated is True:
+            self.client.force_login(self.user)
+
+    def test_authenticated_clear_cache(self):
+        """
+        authenticated users can trigger clear_cache
+        """
+        authenticated = self.user.is_authenticated
+
+        self.client.force_login(self.user)
+        response = self.client.post('/api/buyersguide/clear-cache/')
+        self.assertEqual(response.status_code, 302, 'authenticated user is permitted to clear BG cache')
+        self.assertEqual(response.url, '/cms/buyersguide/product/', 'clearing sends users to product page')
+
+        if authenticated is False:
+            self.client.logout()
+
 
 @override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
 class ProductTests(TestCase):

--- a/network-api/networkapi/buyersguide/views.py
+++ b/network-api/networkapi/buyersguide/views.py
@@ -10,7 +10,7 @@ from django.shortcuts import render, get_object_or_404, redirect
 
 from rest_framework.decorators import api_view, parser_classes, throttle_classes, permission_classes
 from rest_framework.parsers import JSONParser
-from rest_framework.permissions import AllowAny, IsAdminUser
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
 from .models import (
@@ -207,7 +207,7 @@ def product_vote(request):
 
 
 @api_view(['POST'])
-@permission_classes((IsAdminUser,))
+@permission_classes((IsAuthenticated,))
 def clear_cache(request):
     cache.clear()
     return redirect('/cms/buyersguide/product/')


### PR DESCRIPTION
Right now only admins have this power, but really any authenticated user should be able to call this route. Ideally, any authenticated user that, according to their session, is on a PNI product page, but that's more work than worth it, really.