### PR TITLE
order profiles by input ordering

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/profile_by_id.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/profile_by_id.py
@@ -16,8 +16,8 @@ class ProfileById(blocks.StructBlock):
 
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
-        ids = context['block'].value['ids']
-        data = list()
+        ids = context['block'].value['ids'].replace(' ','')
+        profiles = list()
 
         # FIXME: the protocol should be part of the pulse api variable.
         #   see: https://github.com/mozilla/foundation.mozilla.org/issues/1824
@@ -32,11 +32,18 @@ class ProfileById(blocks.StructBlock):
             response_data = response.read()
             data = json.loads(response_data)
 
+            as_dict = {}
+            for profile in data:
+                as_dict[str(profile['profile_id'])] = profile
+
+            profiles = [as_dict[id] for id in ids.split(',')]
+
+
         except (IOError, ValueError) as exception:
             print(str(exception))
             pass
 
-        context['profiles'] = data
+        context['profiles'] = profiles
         return context
 
     class Meta:

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/profile_by_id.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/profile_by_id.py
@@ -16,7 +16,7 @@ class ProfileById(blocks.StructBlock):
 
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
-        ids = context['block'].value['ids'].replace(' ','')
+        ids = context['block'].value['ids'].replace(' ', '')
         profiles = list()
 
         # FIXME: the protocol should be part of the pulse api variable.
@@ -37,7 +37,6 @@ class ProfileById(blocks.StructBlock):
                 as_dict[str(profile['profile_id'])] = profile
 
             profiles = [as_dict[id] for id in ids.split(',')]
-
 
         except (IOError, ValueError) as exception:
             print(str(exception))


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4085

Test by creating a page with a `profile by ids` component with ids `1, 2, 3, 4`, open that in a new tab, then change the ordering to `3,1,4,2` and reload the tab to see the profiles have been reordered accordingly.