### PR TITLE
Reorder the PNI product fields in the CMS to match the on-page presentation of those fields.

### DIFF
--- a/network-api/networkapi/buyersguide/pagemodels/products/base.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/base.py
@@ -34,6 +34,8 @@ product_panels = [
         heading="Publication status",
         classname="collapsible"
     ),
+
+    # core information
     MultiFieldPanel(
         [
             FieldPanel('adult_content'),
@@ -50,6 +52,8 @@ product_panels = [
         heading="General Product Details",
         classname="collapsible"
     ),
+
+    # minimum security standard
     MultiFieldPanel(
         [
             FieldPanel('uses_encryption'),
@@ -66,20 +70,14 @@ product_panels = [
         heading="Minimum Security Standards for general products",
         classname="collapsible"
     ),
+    # Data sharing
     MultiFieldPanel(
         [
             FieldPanel('share_data'),
             FieldPanel('share_data_helptext'),
-        ],
-        heading="Minimum Security Standards",
-        classname="collapsible"
-    ),
-    MultiFieldPanel(
-        [
             FieldPanel('how_does_it_share'),
-            FieldPanel('worst_case'),
         ],
-        heading="How does it handle privacy",
+        heading="How does it handle data sharing",
         classname="collapsible"
     ),
     MultiFieldPanel(
@@ -92,6 +90,13 @@ product_panels = [
             ),
         ],
         heading="Privacy policy links",
+        classname="collapsible"
+    ),
+    MultiFieldPanel(
+        [
+            FieldPanel('worst_case'),
+        ],
+        heading="What's the worst that could happen",
         classname="collapsible"
     ),
     MultiFieldPanel(

--- a/network-api/networkapi/buyersguide/pagemodels/products/general.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/general.py
@@ -5,6 +5,8 @@ from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from .base import BaseProduct, register_product_type
 from ...utils import tri_to_quad
 
+from networkapi.wagtailpages.utils import insert_panels_after
+
 
 class GeneralProduct(BaseProduct):
     """
@@ -70,36 +72,47 @@ class GeneralProduct(BaseProduct):
 
     # administrative panels
 
-    # TODO: make these fit in the right place
-    panels = BaseProduct.panels + [
-        MultiFieldPanel(
-            [
-                FieldPanel('camera_device'),
-                FieldPanel('camera_app'),
-                FieldPanel('microphone_device'),
-                FieldPanel('microphone_app'),
-                FieldPanel('location_device'),
-                FieldPanel('location_app'),
-            ],
-            heading='Can it snoop?',
-            classname='collapsible'
-        ),
-        MultiFieldPanel(
-            [
-                FieldPanel('delete_data'),
-                FieldPanel('delete_data_helptext'),
-                FieldPanel('parental_controls'),
-                FieldPanel('collects_biometrics'),
-                FieldPanel('collects_biometrics_helptext'),
-                FieldPanel('user_friendly_privacy_policy'),
-                FieldPanel('user_friendly_privacy_policy_helptext'),
-            ],
-            heading='How does it handle privacy (general products)',
-            classname='collapsible'
-        ),
-    ]
+    panels = BaseProduct.panels.copy()
 
-    # todict function
+    panels = insert_panels_after(
+        panels,
+        [
+            MultiFieldPanel(
+                [
+                    FieldPanel('camera_device'),
+                    FieldPanel('camera_app'),
+                    FieldPanel('microphone_device'),
+                    FieldPanel('microphone_app'),
+                    FieldPanel('location_device'),
+                    FieldPanel('location_app'),
+                ],
+                heading='Can it snoop?',
+                classname='collapsible'
+            ),
+        ],
+        'Minimum Security Standards for general products'
+    )
+
+    panels = insert_panels_after(
+        panels,
+        [
+            MultiFieldPanel(
+                [
+                    FieldPanel('delete_data'),
+                    FieldPanel('delete_data_helptext'),
+                    FieldPanel('parental_controls'),
+                    FieldPanel('collects_biometrics'),
+                    FieldPanel('collects_biometrics_helptext'),
+                    FieldPanel('user_friendly_privacy_policy'),
+                    FieldPanel('user_friendly_privacy_policy_helptext'),
+                ],
+                heading='How does it handle privacy',
+                classname='collapsible'
+            ),
+        ],
+        'How does it handle data sharing'
+    )
+
     def to_dict(self):
         model_dict = super().to_dict()
         model_dict['delete_data'] = tri_to_quad(self.delete_data)

--- a/network-api/networkapi/buyersguide/pagemodels/products/general.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/general.py
@@ -76,6 +76,7 @@ class GeneralProduct(BaseProduct):
 
     panels = insert_panels_after(
         panels,
+        'Minimum Security Standards for general products',
         [
             MultiFieldPanel(
                 [
@@ -90,11 +91,11 @@ class GeneralProduct(BaseProduct):
                 classname='collapsible'
             ),
         ],
-        'Minimum Security Standards for general products'
     )
 
     panels = insert_panels_after(
         panels,
+        'How does it handle data sharing',
         [
             MultiFieldPanel(
                 [
@@ -110,7 +111,6 @@ class GeneralProduct(BaseProduct):
                 classname='collapsible'
             ),
         ],
-        'How does it handle data sharing'
     )
 
     def to_dict(self):

--- a/network-api/networkapi/buyersguide/pagemodels/products/software.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/software.py
@@ -4,6 +4,8 @@ from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
 from networkapi.buyersguide.fields import ExtendedYesNoField
 from .base import BaseProduct, register_product_type
 
+from networkapi.wagtailpages.utils import insert_panels_after
+
 
 class SoftwareProduct(BaseProduct):
     """
@@ -76,35 +78,61 @@ class SoftwareProduct(BaseProduct):
         blank=True
     )
 
-    # TODO: make these fit in the right place
-    panels = BaseProduct.panels + [
-        MultiFieldPanel(
-            [
-                FieldPanel('handles_recordings_how'),
-                FieldPanel('recording_alert'),
-                FieldPanel('recording_alert_helptext'),
-                FieldPanel('signup_with_email'),
-                FieldPanel('signup_with_phone'),
-                FieldPanel('signup_with_third_party'),
-                FieldPanel('signup_methods_helptext'),
-                FieldPanel('medical_privacy_compliant'),
-                FieldPanel('medical_privacy_compliant_helptext'),
-            ],
-            heading='how does it handle privacy?',
-            classname='collapsible'
-        ),
-        MultiFieldPanel(
-            [
-                FieldPanel('host_controls'),
-                FieldPanel('easy_to_learn_and_use'),
-                FieldPanel('easy_to_learn_and_use_helptext'),
-            ],
-            heading='can I control it',
-            classname='collapsible'
-        ),
-    ]
+    # administrative panels
 
-    # todict function
+    panels = BaseProduct.panels.copy()
+
+    panels = insert_panels_after(
+        panels,
+        [
+             MultiFieldPanel(
+                [
+                    FieldPanel('signup_with_email'),
+                    FieldPanel('signup_with_phone'),
+                    FieldPanel('signup_with_third_party'),
+                    FieldPanel('signup_methods_helptext'),
+                ],
+                heading='How does it handle signup?',
+                classname='collapsible'
+             ),
+        ],
+        'Minimum Security Standards for general products'
+    )
+
+    panels = insert_panels_after(
+        panels,
+        [
+            MultiFieldPanel(
+                [
+                    FieldPanel('handles_recordings_how'),
+                    FieldPanel('recording_alert'),
+                    FieldPanel('recording_alert_helptext'),
+                    FieldPanel('medical_privacy_compliant'),
+                    FieldPanel('medical_privacy_compliant_helptext'),
+                ],
+                heading='How does it handle privacy?',
+                classname='collapsible'
+            ),
+        ],
+        'How does it handle data sharing'
+    )
+
+    panels = insert_panels_after(
+        panels,
+        [
+            MultiFieldPanel(
+                [
+                    FieldPanel('host_controls'),
+                    FieldPanel('easy_to_learn_and_use'),
+                    FieldPanel('easy_to_learn_and_use_helptext'),
+                ],
+                heading='Can I control it',
+                classname='collapsible'
+            ),
+        ],
+        'How does it handle privacy?'
+    )
+
     def to_dict(self):
         model_dict = super().to_dict()
         model_dict['product_type'] = 'software'

--- a/network-api/networkapi/buyersguide/pagemodels/products/software.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/software.py
@@ -84,6 +84,7 @@ class SoftwareProduct(BaseProduct):
 
     panels = insert_panels_after(
         panels,
+        'Minimum Security Standards for general products',
         [
              MultiFieldPanel(
                 [
@@ -96,11 +97,11 @@ class SoftwareProduct(BaseProduct):
                 classname='collapsible'
              ),
         ],
-        'Minimum Security Standards for general products'
     )
 
     panels = insert_panels_after(
         panels,
+        'How does it handle data sharing',
         [
             MultiFieldPanel(
                 [
@@ -114,11 +115,11 @@ class SoftwareProduct(BaseProduct):
                 classname='collapsible'
             ),
         ],
-        'How does it handle data sharing'
     )
 
     panels = insert_panels_after(
         panels,
+        'How does it handle privacy?',
         [
             MultiFieldPanel(
                 [
@@ -130,7 +131,6 @@ class SoftwareProduct(BaseProduct):
                 classname='collapsible'
             ),
         ],
-        'How does it handle privacy?'
     )
 
     def to_dict(self):

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -190,7 +190,7 @@ def get_content_related_by_tag(page, result_count=3):
     return result_list[:result_count]
 
 
-def insert_panels_after(panels, more, after_label):
+def insert_panels_after(panels, after_label, additional_panels):
     """
     Insert wagtail panels somewhere in another set of panels
     """
@@ -200,10 +200,9 @@ def insert_panels_after(panels, more, after_label):
     )
 
     if position is not None:
-        for entry in more:
-            position = position + 1
-            panels.insert(position, entry)
+        cut = position + 2
+        panels = panels[0:cut] + additional_panels + panels[cut:]
     else:
-        panels = panels + more
+        raise ValueError(f'No panel with heading "{after_label}" in panel list')
 
     return panels

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -188,3 +188,22 @@ def get_content_related_by_tag(page, result_count=3):
         capture_exception(err)
 
     return result_list[:result_count]
+
+
+def insert_panels_after(panels, more, after_label):
+    """
+    Insert wagtail panels somewhere in another set of panels
+    """
+    position = next(
+        (i for i, item in enumerate(panels) if item.heading == after_label),
+        None
+    )
+
+    if position is not None:
+        for entry in more:
+            position = position + 1
+            panels.insert(position, entry)
+    else:
+        panels = panels + more
+
+    return panels


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4512 by introducing a helper function that lets us inject (lists of) panels based on "the previous section's heading", with the general and software products both using that to inject their fields in the right spots.

