### PR TITLE
More SCSS cleanup

### DIFF
--- a/source/images/line-art/play-icon.svg
+++ b/source/images/line-art/play-icon.svg
@@ -1,6 +1,0 @@
-<svg width="67" height="66" xmlns="http://www.w3.org/2000/svg">
-    <g transform="translate(1 1)" stroke="#FFF" stroke-width="2" fill="none" fill-rule="evenodd">
-        <ellipse cx="32.013" cy="32" rx="32.013" ry="32"/>
-        <path stroke-linecap="round" stroke-linejoin="round" d="M49.73 32.36L21 46.717V18z"/>
-    </g>
-</svg>

--- a/source/js/components/fellow-list/directory-filter-bar.scss
+++ b/source/js/components/fellow-list/directory-filter-bar.scss
@@ -15,7 +15,6 @@
     button {
       background: inherit;
       border: none;
-      cursor: pointer;
       font-family: inherit;
       padding: 0.5rem;
       margin: 0;

--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -35,7 +35,6 @@
 
     &:hover {
       color: $dark-blue;
-      cursor: pointer;
     }
   }
 
@@ -114,7 +113,6 @@
     }
 
     .burger {
-      cursor: pointer;
       margin-right: 24px;
       margin-left: -52px;
       border: 0;

--- a/source/sass/global.scss
+++ b/source/sass/global.scss
@@ -1,10 +1,6 @@
 body {
   scroll-behavior: smooth;
 
-  & > .wrapper {
-    background: $white;
-  }
-
   .noselect {
     -webkit-touch-callout: none; /* iOS */
     -webkit-user-select: none; /* Webkit */
@@ -22,6 +18,14 @@ li {
   ol,
   ul {
     margin-top: $list-item-vertical-margin;
+  }
+}
+
+hr {
+  border-color: $gray-20;
+
+  &.intro-and-content-divider {
+    @include intro-and-content-spacing(true);
   }
 }
 
@@ -103,8 +107,4 @@ footer.site-footer {
       }
     }
   }
-}
-
-hr.intro-and-content-divider {
-  @include intro-and-content-spacing(true);
 }

--- a/source/sass/global.scss
+++ b/source/sass/global.scss
@@ -14,10 +14,6 @@ body {
   }
 }
 
-button:hover {
-  cursor: pointer;
-}
-
 li {
   $list-item-vertical-margin: 0.25em;
 

--- a/source/sass/main.scss
+++ b/source/sass/main.scss
@@ -67,9 +67,3 @@ $bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
 // MozFest
 
 @import "./mozfest";
-
-// Bootstrap or mofo-bootstrap overrides
-
-hr {
-  border-color: $gray-20;
-}

--- a/source/sass/mixins.scss
+++ b/source/sass/mixins.scss
@@ -1,3 +1,25 @@
+// Break the constraints of parent container(s) to span the entire viewport width
+@mixin full-bleed {
+  width: 100vw;
+  max-width: none;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+// Mixin to create ".full-bleed-breakpoint" utility classes
+@mixin full-bleed-bp($breakpoint) {
+  @include media-breakpoint-only($breakpoint) {
+    .full-bleed-#{$breakpoint} {
+      @include full-bleed;
+    }
+  }
+}
+
 @mixin heading(
   $font-family,
   $font-weight,

--- a/source/sass/utilities.scss
+++ b/source/sass/utilities.scss
@@ -5,11 +5,6 @@
   margin-top: $spacer;
   margin-bottom: $spacer;
 }
-
-.flex-grow-0 {
-  flex-grow: 0;
-}
-
 .flex-1 {
   flex: 1;
 }
@@ -18,52 +13,11 @@
   position: relative;
 }
 
-.big-section {
-  margin-bottom: 5rem;
-}
-
 .key-item {
   border-bottom: 4px solid $gray-20;
   margin-top: -1.5em;
   background: $white;
   position: relative;
-}
-
-.play-button-wrapper {
-  position: relative;
-}
-
-.play-button-overlay {
-  background-image: url(../_images/line-art/play-icon.svg);
-  position: absolute;
-  top: calc(50% - 3em);
-  left: calc(50% - 3em);
-  width: 6em;
-  height: 6em;
-  background-repeat: no-repeat;
-  background-size: contain;
-}
-
-// Break the constraints of parent container(s) to span the entire viewport width
-
-@mixin full-bleed {
-  width: 100vw;
-  max-width: none;
-  position: relative;
-  left: 50%;
-  right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
-  padding-left: 0;
-  padding-right: 0;
-}
-
-@mixin full-bleed-bp($breakpoint) {
-  @include media-breakpoint-only($breakpoint) {
-    .full-bleed-#{$breakpoint} {
-      @include full-bleed;
-    }
-  }
 }
 
 .full-bleed {


### PR DESCRIPTION
Closes #4546 

This wraps up the Bootstrap cleanup work. @Pomax let me know if you spot anything I missed.

I'm keeping Bootstrap related SCSS code in this `mofo-bootstrap` directory. All colour variables are in `mofo-bootstrap/_color.scss` (including Bootstrap colour variable overrides & our custom colour variables) since we need them to build `mofo-bootstrap.scss` which we eventually import into `main.scss` and `bg-main.scss`
<img width="141" alt="image" src="https://user-images.githubusercontent.com/2896608/80750108-616a0e00-8adc-11ea-808d-6cd7a0147151.png">
