### PR TITLE
rename BaseProduct back to Product

### DIFF
--- a/network-api/networkapi/buyersguide/migrations/0049_auto_20200511_1820.py
+++ b/network-api/networkapi/buyersguide/migrations/0049_auto_20200511_1820.py
@@ -1,0 +1,80 @@
+# [2020-05-11] Custom Django 2.2.12 migration for handling superclass model renaming.
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+from ..utils import AlterModelBases
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('buyersguide', '0048_auto_20200507_1619'),
+    ]
+
+    operations = [
+        # Step 1: rename the parent links in our subclasses to match their future name:
+
+        migrations.RenameField(model_name='generalproduct', old_name='baseproduct_ptr', new_name='product_ptr',),
+        migrations.RenameField(model_name='softwareproduct', old_name='baseproduct_ptr', new_name='product_ptr',),
+
+        # Step 2: then, temporarily set the base model for our subclassses to just `Model`, which makes Django
+        #         think there are no parent links, which mean it won't try to apply crashing logic in step 3.
+
+        AlterModelBases("GeneralProduct", (models.Model,)),
+        AlterModelBases("SoftwareProduct", (models.Model,)),
+
+        # Step 3: Now we can safely rename the superclass without Django trying solve subclass pointers:
+
+        migrations.RenameModel(old_name="BaseProduct", new_name="Product"),
+
+        # Step 4: Which means we can now update the `parent_link` fields for the subclasses. Even though we
+        #         altered the model bases earlier, this step will restore the class hierarchy:
+
+        migrations.AlterField(
+            model_name='generalproduct',
+            name='product_ptr',
+            field=models.OneToOneField(
+                auto_created=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                parent_link=True, primary_key=True,
+                serialize=False,
+                to='buyersguide.Product'
+            ),
+        ),
+        migrations.AlterField(
+            model_name='softwareproduct',
+            name='product_ptr',
+            field=models.OneToOneField(
+                auto_created=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                parent_link=True,
+                primary_key=True,
+                serialize=False,
+                to='buyersguide.Product'
+            ),
+        ),
+
+        # And of course in our case, also make sure the voting models point
+        # to the new Product class instead of the old BaseProduct class.
+        migrations.AlterField(
+            model_name='booleanvote',
+            name='product',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='buyersguide.Product'),
+        ),
+        migrations.AlterField(
+            model_name='booleanproductvote',
+            name='product',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='boolean_product_votes', to='buyersguide.Product'),
+        ),
+        migrations.AlterField(
+            model_name='rangevote',
+            name='product',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='buyersguide.Product'),
+        ),
+        migrations.AlterField(
+            model_name='rangeproductvote',
+            name='product',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='range_product_votes', to='buyersguide.Product'),
+        ),
+    ]

--- a/network-api/networkapi/buyersguide/models.py
+++ b/network-api/networkapi/buyersguide/models.py
@@ -3,15 +3,15 @@ from .pagemodels.get_product_image_upload_path import (
 )
 
 from .pagemodels.base_voting import (
+    BooleanProductVote,
+    BooleanVote,
+    BooleanVoteBreakdown,
     ProductVote,
     RangeProductVote,
-    BooleanProductVote,
-    VoteBreakdown,
-    BooleanVoteBreakdown,
+    RangeVote,
     RangeVoteBreakdown,
     Vote,
-    BooleanVote,
-    RangeVote,
+    VoteBreakdown,
 )
 
 from .pagemodels.cloudinary_image_field import (

--- a/network-api/networkapi/buyersguide/pagemodels/base_voting.py
+++ b/network-api/networkapi/buyersguide/pagemodels/base_voting.py
@@ -6,6 +6,39 @@ from networkapi.buyersguide.validators import ValueListValidator
 from .products.base import Product
 
 
+class Vote(models.Model):
+    product = models.ForeignKey(Product, on_delete=models.deletion.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+
+
+class BooleanVote(Vote):
+    attribute = models.CharField(
+        max_length=100,
+        validators=[
+            ValueListValidator(valid_values=['confidence'])
+        ]
+    )
+    value = models.BooleanField()
+
+
+class RangeVote(Vote):
+    attribute = models.CharField(
+        max_length=100,
+        validators=[
+            ValueListValidator(valid_values=['creepiness'])
+        ]
+    )
+    value = models.IntegerField(
+        validators=[
+            MinValueValidator(1),
+            MaxValueValidator(100)
+        ]
+    )
+
+
 class ProductVote(models.Model):
     votes = models.IntegerField(
         default=0
@@ -13,6 +46,20 @@ class ProductVote(models.Model):
 
     class Meta:
         abstract = True
+
+
+class BooleanProductVote(ProductVote):
+    attribute = models.CharField(
+        max_length=100,
+        validators=[
+            ValueListValidator(valid_values=['confidence'])
+        ]
+    )
+    product = models.ForeignKey(
+        Product,
+        on_delete=models.CASCADE,
+        related_name='boolean_product_votes'
+    )
 
 
 class RangeProductVote(ProductVote):
@@ -32,20 +79,6 @@ class RangeProductVote(ProductVote):
         Product,
         on_delete=models.CASCADE,
         related_name='range_product_votes',
-    )
-
-
-class BooleanProductVote(ProductVote):
-    attribute = models.CharField(
-        max_length=100,
-        validators=[
-            ValueListValidator(valid_values=['confidence'])
-        ]
-    )
-    product = models.ForeignKey(
-        Product,
-        on_delete=models.CASCADE,
-        related_name='boolean_product_votes'
     )
 
 
@@ -82,39 +115,5 @@ class RangeVoteBreakdown(VoteBreakdown):
             ValueListValidator(
                 valid_values=[0, 1, 2, 3, 4]
             )
-        ]
-    )
-
-
-class Vote(models.Model):
-    # This is the only "BaseProduct" left, as "Product" is just a code alias for now.
-    product = models.ForeignKey('BaseProduct', on_delete=models.CASCADE)
-    created_at = models.DateTimeField(auto_now_add=True)
-
-    class Meta:
-        abstract = True
-
-
-class BooleanVote(Vote):
-    attribute = models.CharField(
-        max_length=100,
-        validators=[
-            ValueListValidator(valid_values=['confidence'])
-        ]
-    )
-    value = models.BooleanField()
-
-
-class RangeVote(Vote):
-    attribute = models.CharField(
-        max_length=100,
-        validators=[
-            ValueListValidator(valid_values=['creepiness'])
-        ]
-    )
-    value = models.IntegerField(
-        validators=[
-            MinValueValidator(1),
-            MaxValueValidator(100)
         ]
     )

--- a/network-api/networkapi/buyersguide/pagemodels/products/base.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/base.py
@@ -120,7 +120,7 @@ def register_product_type(ModelClass):
     registered_product_types.append(ModelClass)
 
 
-class BaseProduct(ClusterableModel):
+class Product(ClusterableModel):
     """
     A product that may not have privacy included.
     """
@@ -380,11 +380,6 @@ class BaseProduct(ClusterableModel):
         ordering = [
             'id'
         ]
-
-
-# FOR REFACTORING PURPOSES, WE FIRST ALIAS THIS:
-
-Product = BaseProduct
 
 # We want to delete the product image when the product is removed
 @receiver(pre_delete, sender=Product)

--- a/network-api/networkapi/buyersguide/pagemodels/products/general.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/general.py
@@ -120,5 +120,5 @@ class GeneralProduct(Product):
         return model_dict
 
 
-# Register this model class so that BaseProduct can "cast" properly
+# Register this model class so that Product can "cast" properly
 register_product_type(GeneralProduct)

--- a/network-api/networkapi/buyersguide/pagemodels/products/software.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/software.py
@@ -8,6 +8,7 @@ from networkapi.wagtailpages.utils import insert_panels_after
 
 
 class SoftwareProduct(Product):
+
     """
     A thing you can install on your computer and our review of it
     """

--- a/network-api/networkapi/buyersguide/pagemodels/products/software.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/software.py
@@ -8,7 +8,6 @@ from networkapi.wagtailpages.utils import insert_panels_after
 
 
 class SoftwareProduct(Product):
-
     """
     A thing you can install on your computer and our review of it
     """

--- a/network-api/networkapi/buyersguide/utils.py
+++ b/network-api/networkapi/buyersguide/utils.py
@@ -1,3 +1,6 @@
+from django.db.migrations.operations.models import ModelOperation
+
+
 def tri_to_quad(input):
     if input is True:
         return 'Yes'
@@ -12,3 +15,29 @@ def quad_to_tri(input):
     if input == 'No':
         return False
     return None
+
+
+class AlterModelBases(ModelOperation):
+    """
+    See https://stackoverflow.com/a/61723620/740553
+    """
+
+    reduce_to_sql = False
+    reversible = True
+
+    def __init__(self, name, bases):
+        self.bases = bases
+        super().__init__(name)
+
+    def state_forwards(self, app_label, state):
+        state.models[app_label, self.name_lower].bases = self.bases
+        state.reload_model(app_label, self.name_lower)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        pass
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        pass
+
+    def describe(self):
+        return "Update %s bases to %s" % (self.name, self.bases)


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4543 by renaming `BaseProduct` back to `Product`, using a custom Django migration that first "undoes" the model hierarchy as far as Django knows _while migrating_, then renaming the superclass and relinking the subclasses to the new model name.