### PR TITLE
SCSS breakpoint improvements

### DIFF
--- a/network-api/networkapi/buyersguide/templates/primary_nav.html
+++ b/network-api/networkapi/buyersguide/templates/primary_nav.html
@@ -4,7 +4,7 @@
 
 {% block narrow_screen_menu %}
   <div class="narrow-screen-menu-background">
-    <div class="narrow-screen-menu-container">
+    <div class="narrow-screen-menu-container d-md-none">
 
       <div class="container text-center">
         <div class="row">

--- a/source/js/buyers-guide/components/primary-nav/primary-nav.scss
+++ b/source/js/buyers-guide/components/primary-nav/primary-nav.scss
@@ -1,3 +1,5 @@
+$pni-primary-nav-breakpoint: $bp-sm;
+
 .moz-logo {
   background-image: url("../_images/mozilla-m.svg");
   flex-shrink: 0;
@@ -36,7 +38,7 @@
     font-weight: 600;
     max-width: 85px;
 
-    @media (min-width: $bp-sm) {
+    @media (min-width: $pni-primary-nav-breakpoint) {
       font-size: 22px;
       max-width: none;
     }
@@ -52,7 +54,7 @@
   position: absolute;
   padding-top: 62px;
 
-  @media (min-width: $bp-sm) {
+  @media (min-width: $pni-primary-nav-breakpoint) {
     padding-top: 72px;
   }
 
@@ -117,10 +119,6 @@
     background: $white;
     height: 100%;
   }
-
-  @media (min-width: $bp-md) {
-    display: none;
-  }
 }
 
 .btn-donate {
@@ -141,7 +139,7 @@
     display: none;
   }
 
-  @media (min-width: $bp-sm) {
+  @media (min-width: $pni-primary-nav-breakpoint) {
     &.menu-open {
       display: initial;
     }

--- a/source/js/buyers-guide/components/primary-nav/primary-nav.scss
+++ b/source/js/buyers-guide/components/primary-nav/primary-nav.scss
@@ -1,4 +1,4 @@
-$pni-primary-nav-breakpoint-larger: $bp-sm;
+$pni-primary-nav-breakpoint: $bp-sm;
 
 .moz-logo {
   background-image: url("../_images/mozilla-m.svg");
@@ -38,7 +38,7 @@ $pni-primary-nav-breakpoint-larger: $bp-sm;
     font-weight: 600;
     max-width: 85px;
 
-    @media (min-width: $pni-primary-nav-breakpoint-larger) {
+    @media (min-width: $pni-primary-nav-breakpoint) {
       font-size: 22px;
       max-width: none;
     }
@@ -54,7 +54,7 @@ $pni-primary-nav-breakpoint-larger: $bp-sm;
   position: absolute;
   padding-top: 62px;
 
-  @media (min-width: $pni-primary-nav-breakpoint-larger) {
+  @media (min-width: $pni-primary-nav-breakpoint) {
     padding-top: 72px;
   }
 
@@ -139,7 +139,7 @@ $pni-primary-nav-breakpoint-larger: $bp-sm;
     display: none;
   }
 
-  @media (min-width: $pni-primary-nav-breakpoint-larger) {
+  @media (min-width: $pni-primary-nav-breakpoint) {
     &.menu-open {
       display: initial;
     }

--- a/source/js/buyers-guide/components/primary-nav/primary-nav.scss
+++ b/source/js/buyers-guide/components/primary-nav/primary-nav.scss
@@ -1,4 +1,4 @@
-$pni-primary-nav-breakpoint: $bp-sm;
+$pni-primary-nav-breakpoint-larger: $bp-sm;
 
 .moz-logo {
   background-image: url("../_images/mozilla-m.svg");
@@ -38,7 +38,7 @@ $pni-primary-nav-breakpoint: $bp-sm;
     font-weight: 600;
     max-width: 85px;
 
-    @media (min-width: $pni-primary-nav-breakpoint) {
+    @media (min-width: $pni-primary-nav-breakpoint-larger) {
       font-size: 22px;
       max-width: none;
     }
@@ -54,7 +54,7 @@ $pni-primary-nav-breakpoint: $bp-sm;
   position: absolute;
   padding-top: 62px;
 
-  @media (min-width: $pni-primary-nav-breakpoint) {
+  @media (min-width: $pni-primary-nav-breakpoint-larger) {
     padding-top: 72px;
   }
 
@@ -139,7 +139,7 @@ $pni-primary-nav-breakpoint: $bp-sm;
     display: none;
   }
 
-  @media (min-width: $pni-primary-nav-breakpoint) {
+  @media (min-width: $pni-primary-nav-breakpoint-larger) {
     &.menu-open {
       display: initial;
     }

--- a/source/sass/buyers-guide/views/homepage.scss
+++ b/source/sass/buyers-guide/views/homepage.scss
@@ -1,10 +1,12 @@
 #view-home {
+  $breakpoint-larger: $bp-md;
+
   .page-header {
     background: url(../_images/buyers-guide/evergreen-header.jpg) center center /
       cover no-repeat;
     height: 200px;
 
-    @media (min-width: $bp-md) {
+    @media (min-width: $breakpoint-larger) {
       height: 304px;
     }
   }
@@ -18,7 +20,7 @@
       color: $gray-40;
       font-style: italic;
 
-      @media screen and (min-width: 750px) {
+      @media screen and (min-width: $breakpoint-larger) {
         font-size: 20px;
       }
     }
@@ -113,7 +115,7 @@
           img {
             margin: 0 auto;
 
-            @media (min-width: $bp-md) {
+            @media (min-width: $breakpoint-larger) {
               max-width: 78%;
             }
           }
@@ -164,7 +166,7 @@
     padding-top: 40px;
     padding-bottom: 9px;
 
-    @media (min-width: $bp-md) {
+    @media (min-width: $breakpoint-larger) {
       top: 20px;
     }
 
@@ -183,7 +185,7 @@
       position: relative;
       transform: scale($scale-down-ratio);
 
-      @media (min-width: $bp-md) {
+      @media (min-width: $breakpoint-larger) {
         transform: scale(1);
       }
 

--- a/source/sass/buyers-guide/views/homepage.scss
+++ b/source/sass/buyers-guide/views/homepage.scss
@@ -1,12 +1,12 @@
 #view-home {
-  $breakpoint-larger: $bp-md;
+  $breakpoint: $bp-md;
 
   .page-header {
     background: url(../_images/buyers-guide/evergreen-header.jpg) center center /
       cover no-repeat;
     height: 200px;
 
-    @media (min-width: $breakpoint-larger) {
+    @media (min-width: $breakpoint) {
       height: 304px;
     }
   }
@@ -20,7 +20,7 @@
       color: $gray-40;
       font-style: italic;
 
-      @media screen and (min-width: $breakpoint-larger) {
+      @media screen and (min-width: $breakpoint) {
         font-size: 20px;
       }
     }
@@ -115,7 +115,7 @@
           img {
             margin: 0 auto;
 
-            @media (min-width: $breakpoint-larger) {
+            @media (min-width: $breakpoint) {
               max-width: 78%;
             }
           }
@@ -166,7 +166,7 @@
     padding-top: 40px;
     padding-bottom: 9px;
 
-    @media (min-width: $breakpoint-larger) {
+    @media (min-width: $breakpoint) {
       top: 20px;
     }
 
@@ -185,7 +185,7 @@
       position: relative;
       transform: scale($scale-down-ratio);
 
-      @media (min-width: $breakpoint-larger) {
+      @media (min-width: $breakpoint) {
         transform: scale(1);
       }
 

--- a/source/sass/buyers-guide/views/product.scss
+++ b/source/sass/buyers-guide/views/product.scss
@@ -1,7 +1,4 @@
-$product-detail-padding-x: (
-  xs: 18px,
-  md: 5rem
-);
+$pni-product-breakpoint-larger: $bp-md;
 
 .product-header {
   padding-bottom: 88px;
@@ -32,12 +29,12 @@ $product-detail-padding-x: (
 }
 
 .product-section-padding-x {
-  padding-left: map-get($product-detail-padding-x, xs);
-  padding-right: map-get($product-detail-padding-x, xs);
+  padding-left: 18px;
+  padding-right: 18px;
 
-  @media (min-width: $bp-md) {
-    padding-left: map-get($product-detail-padding-x, md);
-    padding-right: map-get($product-detail-padding-x, md);
+  @media (min-width: $pni-product-breakpoint-larger) {
+    padding-left: 5rem;
+    padding-right: 5rem;
   }
 }
 
@@ -67,7 +64,7 @@ $product-detail-padding-x: (
   .copy-link-wrapper {
     order: 4;
 
-    @media (min-width: $bp-md) {
+    @media (min-width: $pni-product-breakpoint-larger) {
       order: unset;
     }
 
@@ -132,7 +129,7 @@ $product-detail-padding-x: (
   .signup-requirement {
     margin-bottom: $spacer;
 
-    @media (min-width: $bp-md) {
+    @media (min-width: $pni-product-breakpoint-larger) {
       margin-bottom: $spacer * 1.5;
     }
 
@@ -153,7 +150,7 @@ $product-detail-padding-x: (
   word-break: break-word;
   margin-bottom: 1rem;
 
-  @media (min-width: $bp-md) {
+  @media (min-width: $pni-product-breakpoint-larger) {
     margin-bottom: 0;
   }
 
@@ -178,7 +175,7 @@ $product-detail-padding-x: (
     position: relative;
     padding-left: calc(#{$badge-width-mobile} + 8px);
 
-    @media (min-width: $bp-md) {
+    @media (min-width: $pni-product-breakpoint-larger) {
       padding-left: calc(#{$badge-width} + 6px);
     }
 
@@ -192,7 +189,7 @@ $product-detail-padding-x: (
       width: $badge-width-mobile;
       height: 100%;
 
-      @media (min-width: $bp-md) {
+      @media (min-width: $pni-product-breakpoint-larger) {
         width: $badge-width;
       }
     }
@@ -320,7 +317,7 @@ $product-detail-padding-x: (
   padding-left: 1rem;
   padding-right: 1rem;
 
-  @media (min-width: $bp-md) {
+  @media (min-width: $pni-product-breakpoint-larger) {
     margin-left: -0.5rem;
     margin-right: -0.5rem;
     padding: 1.5rem 3.75rem;
@@ -345,7 +342,7 @@ $product-detail-padding-x: (
       color: $white;
     }
 
-    @media (min-width: $bp-md) {
+    @media (min-width: $pni-product-breakpoint-larger) {
       left: calc(#{$shadow-width} * -1);
 
       &::before {

--- a/source/sass/components/feature-quote.scss
+++ b/source/sass/components/feature-quote.scss
@@ -1,10 +1,10 @@
 .feature-quote {
-  $breakpoint-larger: $bp-md;
+  $breakpoint: $bp-md;
 
   text-align: center;
   padding: 0;
 
-  @media screen and (min-width: $breakpoint-larger) {
+  @media screen and (min-width: $breakpoint) {
     padding: 0 10%;
   }
 
@@ -24,7 +24,7 @@
     line-height: 1.333333;
     font-style: italic;
 
-    @media screen and (min-width: $breakpoint-larger) {
+    @media screen and (min-width: $breakpoint) {
       font-size: 30px;
     }
   }

--- a/source/sass/components/feature-quote.scss
+++ b/source/sass/components/feature-quote.scss
@@ -1,8 +1,10 @@
 .feature-quote {
+  $breakpoint-larger: $bp-md;
+
   text-align: center;
   padding: 0;
 
-  @media screen and (min-width: $bp-md) {
+  @media screen and (min-width: $breakpoint-larger) {
     padding: 0 10%;
   }
 
@@ -22,7 +24,7 @@
     line-height: 1.333333;
     font-style: italic;
 
-    @media screen and (min-width: $bp-md) {
+    @media screen and (min-width: $breakpoint-larger) {
       font-size: 30px;
     }
   }

--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -96,6 +96,8 @@
   }
 
   .wrapper-burger {
+    $full-logo-breakpoint: $bp-sm;
+
     transition: background 200ms ease-in-out;
     background: $white;
     border-bottom: 1px solid $gray-20;
@@ -193,7 +195,7 @@
       position: relative;
       z-index: 1;
 
-      @media (min-width: $bp-sm) {
+      @media (min-width: $full-logo-breakpoint) {
         width: 97px;
         background: url(../_images/mozilla-on-black.svg) no-repeat;
       }
@@ -207,7 +209,7 @@
       position: absolute;
       padding-top: 64px;
 
-      @media (min-width: $bp-sm) {
+      @media (min-width: $full-logo-breakpoint) {
         padding-top: 72px;
       }
 

--- a/source/sass/mozfest.scss
+++ b/source/sass/mozfest.scss
@@ -19,6 +19,7 @@ body.mozfest {
 
   &#view-mozfest-home {
     #hero {
+      $breakpoint-larger: $bp-md;
       $banner-height-mobile: 400px;
       $banner-height-desktop: 480px;
       $banner-background-z-index: 1;
@@ -31,7 +32,7 @@ body.mozfest {
         width: 100%;
         bottom: 1rem;
 
-        @media screen and (min-width: $bp-md) {
+        @media screen and (min-width: $breakpoint-larger) {
           bottom: calc(#{$cutoff-offset} + 1rem);
         }
 
@@ -76,7 +77,7 @@ body.mozfest {
         flex-direction: column;
         justify-content: center;
 
-        @media screen and (min-width: $bp-md) {
+        @media screen and (min-width: $breakpoint-larger) {
           height: $banner-height-desktop;
         }
       }
@@ -84,11 +85,7 @@ body.mozfest {
       .homepage-banner-content.container {
         z-index: $banner-background-z-index + 3;
 
-        @media screen and (max-width: $bp-sm) {
-          width: 100%;
-        }
-
-        @media screen and (min-width: $bp-md) {
+        @media screen and (min-width: $breakpoint-larger) {
           padding-bottom: $cutoff-offset;
         }
       }
@@ -96,7 +93,7 @@ body.mozfest {
       .cutout {
         z-index: $banner-background-z-index + 2;
         margin-top: 0;
-        @media screen and (min-width: $bp-md) {
+        @media screen and (min-width: $breakpoint-larger) {
           margin-top: -$cutoff-offset;
         }
       }

--- a/source/sass/mozfest.scss
+++ b/source/sass/mozfest.scss
@@ -19,7 +19,7 @@ body.mozfest {
 
   &#view-mozfest-home {
     #hero {
-      $breakpoint-larger: $bp-md;
+      $breakpoint: $bp-md;
       $banner-height-mobile: 400px;
       $banner-height-desktop: 480px;
       $banner-background-z-index: 1;
@@ -32,7 +32,7 @@ body.mozfest {
         width: 100%;
         bottom: 1rem;
 
-        @media screen and (min-width: $breakpoint-larger) {
+        @media screen and (min-width: $breakpoint) {
           bottom: calc(#{$cutoff-offset} + 1rem);
         }
 
@@ -77,7 +77,7 @@ body.mozfest {
         flex-direction: column;
         justify-content: center;
 
-        @media screen and (min-width: $breakpoint-larger) {
+        @media screen and (min-width: $breakpoint) {
           height: $banner-height-desktop;
         }
       }
@@ -85,7 +85,7 @@ body.mozfest {
       .homepage-banner-content.container {
         z-index: $banner-background-z-index + 3;
 
-        @media screen and (min-width: $breakpoint-larger) {
+        @media screen and (min-width: $breakpoint) {
           padding-bottom: $cutoff-offset;
         }
       }
@@ -93,7 +93,7 @@ body.mozfest {
       .cutout {
         z-index: $banner-background-z-index + 2;
         margin-top: 0;
-        @media screen and (min-width: $breakpoint-larger) {
+        @media screen and (min-width: $breakpoint) {
           margin-top: -$cutoff-offset;
         }
       }

--- a/source/sass/views/participate.scss
+++ b/source/sass/views/participate.scss
@@ -4,8 +4,4 @@
     background-position: top center;
     background-size: cover;
   }
-
-  @media (max-width: $bp-sm) {
-    background: none;
-  }
 }

--- a/source/sass/views/youtube-regrets.scss
+++ b/source/sass/views/youtube-regrets.scss
@@ -43,7 +43,7 @@
       height: 100%;
 
       .scene {
-        $breakpoint-larger: $bp-sm;
+        $breakpoint: $bp-sm;
 
         position: absolute;
         left: 0;
@@ -59,7 +59,7 @@
         width: 100vw;
         height: 100vw;
 
-        @media (min-width: $breakpoint-larger) {
+        @media (min-width: $breakpoint) {
           width: 60vw;
           height: 60vw;
         }
@@ -127,7 +127,7 @@
           height: 100%;
           box-shadow: inset 0 0 5px 5px $white;
 
-          @media (min-width: $breakpoint-larger) {
+          @media (min-width: $breakpoint) {
             box-shadow: inset 0 0 10px 15px $white;
           }
 

--- a/source/sass/views/youtube-regrets.scss
+++ b/source/sass/views/youtube-regrets.scss
@@ -43,6 +43,8 @@
       height: 100%;
 
       .scene {
+        $breakpoint-larger: $bp-sm;
+
         position: absolute;
         left: 0;
         right: 0;
@@ -57,7 +59,7 @@
         width: 100vw;
         height: 100vw;
 
-        @media (min-width: $bp-sm) {
+        @media (min-width: $breakpoint-larger) {
           width: 60vw;
           height: 60vw;
         }
@@ -125,7 +127,7 @@
           height: 100%;
           box-shadow: inset 0 0 5px 5px $white;
 
-          @media (min-width: $bp-sm) {
+          @media (min-width: $breakpoint-larger) {
             box-shadow: inset 0 0 10px 15px $white;
           }
 


### PR DESCRIPTION
Closes #4471

Assign "shared" breakpoint used in media query to SCSS variable. Note that I did this SCSS improvement only* to breakpoints that are shared by multiple DOM elements **in a meaningful way**.  There are still many instances of `@media (min-width: $bp-blah)` in the codebase because I couldn't find any correlation between them in order to store `$bp-blah` to a shared SCSS variable.
