### PR TITLE
pni homepage: un-nest figcaption

### DIFF
--- a/network-api/networkapi/buyersguide/templates/buyersguide_home.html
+++ b/network-api/networkapi/buyersguide/templates/buyersguide_home.html
@@ -56,36 +56,36 @@
       {% for product in products %}
         {% if product.is_current %}
 
-        <figure class="product-box d-flex flex-column justify-content-between{% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}" data-creepiness="{{ product.votes.creepiness.average }}">
-        <div class="top-left-badge-container">
-            {% include "fragments/seal_of_approval.html" with product=product %}
-            {% if product.votes.confidence %}
-                {% if product.votes.confidence.1 > product.votes.confidence.0 %}
-                    <div class="d-none recommendation positive"></div>
-                {% else %}
-                    <div class="d-none recommendation negative"></div>
-                {% endif %}
-            {% endif %}
-        </div>
+        <a class="product-box product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="{% url 'product-view' product.slug %}">
+          <figure class="d-flex flex-column justify-content-between{% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}" data-creepiness="{{ product.votes.creepiness.average }}">
+          <div class="top-left-badge-container">
+              {% include "fragments/seal_of_approval.html" with product=product %}
+              {% if product.votes.confidence %}
+                  {% if product.votes.confidence.1 > product.votes.confidence.0 %}
+                      <div class="d-none recommendation positive"></div>
+                  {% else %}
+                      <div class="d-none recommendation negative"></div>
+                  {% endif %}
+              {% endif %}
+          </div>
 
-        {% include "fragments/adult_content_badge.html" with product=product %}
+          {% include "fragments/adult_content_badge.html" with product=product %}
 
-        <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="{% url 'product-view' product.slug %}">
-            {% if USE_CLOUDINARY %}
-            <img
-            class="product-thumbnail"
-            src="{% cloudinary_url product.cloudinary_image quality=50 fetch_format="auto" crop="fit" width=600 %}"
-            alt="{% blocktrans with product=product.name %}link to {{product}}{% endblocktrans %}"
-            >
-            {% else %}
-            <img class="product-thumbnail" src="{{mediaUrl}}{{"AWS_LOCATION"|env}}/{{product.image }}" alt="{% blocktrans with product_name=product.name %}link to {{product_name}}{% endblocktrans %}">
-            {% endif %}
-            <figcaption class="d-none d-md-block mt-md-2 text-left">
-            <div class="body-small">{{product.company}}</div>
-            <div class="body">{{product.name}}</div>
-            </figcaption>
+              {% if USE_CLOUDINARY %}
+              <img
+              class="product-thumbnail"
+              src="{% cloudinary_url product.cloudinary_image quality=50 fetch_format="auto" crop="fit" width=600 %}"
+              alt="{% blocktrans with product=product.name %}link to {{product}}{% endblocktrans %}"
+              >
+              {% else %}
+              <img class="product-thumbnail" src="{{mediaUrl}}{{"AWS_LOCATION"|env}}/{{product.image }}" alt="{% blocktrans with product_name=product.name %}link to {{product_name}}{% endblocktrans %}">
+              {% endif %}
+              <figcaption class="d-none d-md-block mt-md-2 text-left">
+              <div class="body-small">{{product.company}}</div>
+              <div class="body">{{product.name}}</div>
+              </figcaption>
+          </figure>
         </a>
-        </figure>
         {% endif %}
       {% endfor %}
     </div>

--- a/source/sass/buyers-guide/views/homepage.scss
+++ b/source/sass/buyers-guide/views/homepage.scss
@@ -37,7 +37,7 @@
         margin-left: -$box-margin;
       }
 
-      figure.product-box {
+      a.product-box {
         $padding-x: 12px;
         $padding-y: 12px;
         $seal-of-approval-width: 30px;
@@ -130,6 +130,9 @@
             font-weight: initial;
           }
         }
+      }
+      a.product-box:hover{
+        text-decoration:none;
       }
     }
 

--- a/source/sass/buyers-guide/views/homepage.scss
+++ b/source/sass/buyers-guide/views/homepage.scss
@@ -131,8 +131,8 @@
           }
         }
       }
-      a.product-box:hover{
-        text-decoration:none;
+      a.product-box:hover {
+        text-decoration: none;
       }
     }
 


### PR DESCRIPTION
Closes #4642

I made `<figcaption>` a direct child of `<figure>` by changing the `<a>` tag to be the parent of `<figure>` instead of its child. I then adjusted homepage.scss to account for this change to keep functionality the same.