### PR TITLE
Replacing merge for squash in mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
       - "status-success=continuous-integration/travis-ci/pr"
     actions:
       merge:
-        method: merge
+        method: squash
         strict_method: rebase
         strict: true
   - name: Automatic merge for PRs labelled "ready to merge"
@@ -18,6 +18,6 @@ pull_request_rules:
       - "label=ready-to-merge"
     actions:
       merge:
-        method: merge
+        method: squash
         strict_method: rebase
         strict: true


### PR DESCRIPTION
Reading diffs before pushing staging is quite a pain. Switching to squash instead of merge.