### PR TITLE
make newsletter wrapped d-none until needed

### DIFF
--- a/network-api/networkapi/templates/partials/primary_nav.html
+++ b/network-api/networkapi/templates/partials/primary_nav.html
@@ -75,7 +75,7 @@
 </div>
 
 
-<div id="nav-newsletter-form-wrapper">
+<div id="nav-newsletter-form-wrapper" class="d-none">
   <div class="container dark-theme">
     <div class="row">
       <div class="col-12">

--- a/source/js/nav-newsletter.js
+++ b/source/js/nav-newsletter.js
@@ -42,8 +42,13 @@ class NavNewsletter {
   // remove the global 'closeFormClickHandler' click event handler
   // and reset the form
   closeDesktopNewsletter(event) {
-    elements.container.classList.remove("expanded");
+    const wrapper = elements.container;
+    wrapper.classList.remove("expanded");
     elements.buttonDesktop.classList.remove("active");
+    setTimeout(() => {
+      if (wrapper.classList.contains("expanded")) return;
+      wrapper.classList.add("d-none");
+    }, 500);
     // Make sure we don't leak event listeners
     document.removeEventListener("click", this.closeFormClickHandler);
     document.removeEventListener("scroll", this.closeFormClickHandler);
@@ -54,8 +59,10 @@ class NavNewsletter {
   // For desktop+ version:
   // transition newsletter section to its expanded state
   expandDesktopNewsletter(event) {
-    elements.container.style.top = `${elements.primaryNav.offsetHeight}px`;
-    elements.container.classList.add("expanded");
+    const wrapper = elements.container;
+    wrapper.classList.remove("d-none");
+    wrapper.style.top = `${elements.primaryNav.offsetHeight}px`;
+    wrapper.classList.add("expanded");
     elements.buttonDesktop.classList.add("active");
     document.addEventListener(`click`, this.closeFormClickHandler);
     document.addEventListener(`scroll`, this.closeFormClickHandler, {
@@ -69,8 +76,13 @@ class NavNewsletter {
   // remove the global 'closeFormClickHandler' click event handler,
   // and reset the form
   closeMobileNewsletter() {
+    const wrapper = elements.container;
     elements.narrowMenuContainer.classList.remove("d-none");
-    elements.container.classList.remove("faded-in");
+    wrapper.classList.remove("faded-in");
+    setTimeout(() => {
+      if (wrapper.classList.contains("expanded")) return;
+      wrapper.classList.add("d-none");
+    }, 500);
     this.resetForm();
     this.isShown = false;
   }
@@ -78,8 +90,10 @@ class NavNewsletter {
   // For mobile version:
   // transition section to its expanded state
   expandMobileNewsletter() {
+    const wrapper = elements.container;
     elements.narrowMenuContainer.classList.add(`d-none`);
-    elements.container.classList.add("faded-in");
+    wrapper.classList.remove("d-none");
+    wrapper.classList.add("faded-in");
     this.isShown = true;
   }
 

--- a/source/js/nav-newsletter.js
+++ b/source/js/nav-newsletter.js
@@ -45,6 +45,8 @@ class NavNewsletter {
     const wrapper = elements.container;
     wrapper.classList.remove("expanded");
     elements.buttonDesktop.classList.remove("active");
+    // Schedule a "display:none" to happen after the `expanded` animation finishes.
+    // See `#nav-newsletter-form-wrapper` transition in ./source/sass/components/primary-nav.scss 
     setTimeout(() => {
       if (wrapper.classList.contains("expanded")) return;
       wrapper.classList.add("d-none");

--- a/source/js/nav-newsletter.js
+++ b/source/js/nav-newsletter.js
@@ -46,7 +46,7 @@ class NavNewsletter {
     wrapper.classList.remove("expanded");
     elements.buttonDesktop.classList.remove("active");
     // Schedule a "display:none" to happen after the `expanded` animation finishes.
-    // See `#nav-newsletter-form-wrapper` transition in ./source/sass/components/primary-nav.scss 
+    // See `#nav-newsletter-form-wrapper` transition in ./source/sass/components/primary-nav.scss
     setTimeout(() => {
       if (wrapper.classList.contains("expanded")) return;
       wrapper.classList.add("d-none");
@@ -82,7 +82,7 @@ class NavNewsletter {
     elements.narrowMenuContainer.classList.remove("d-none");
     wrapper.classList.remove("faded-in");
     // Schedule a "display:none" to happen after the `expanded` animation finishes.
-    // See `#nav-newsletter-form-wrapper` transition in ./source/sass/components/primary-nav.scss 
+    // See `#nav-newsletter-form-wrapper` transition in ./source/sass/components/primary-nav.scss
     setTimeout(() => {
       if (wrapper.classList.contains("expanded")) return;
       wrapper.classList.add("d-none");

--- a/source/js/nav-newsletter.js
+++ b/source/js/nav-newsletter.js
@@ -79,6 +79,8 @@ class NavNewsletter {
     const wrapper = elements.container;
     elements.narrowMenuContainer.classList.remove("d-none");
     wrapper.classList.remove("faded-in");
+    // Schedule a "display:none" to happen after the `expanded` animation finishes.
+    // See `#nav-newsletter-form-wrapper` transition in ./source/sass/components/primary-nav.scss 
     setTimeout(() => {
       if (wrapper.classList.contains("expanded")) return;
       wrapper.classList.add("d-none");


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4638 such that the newsletter container is set to `d-none` by default, meaning it is not part of the DOM as far as tabbing through indexed elements is concerned. This means that tabbing will now go from the "newsletter" button in the header to the nav bar, rather than invisible tabbing into the newsletter content.

