### PR TITLE
removed the redeclaration of the `extra_scripts` block for PNI

### DIFF
--- a/network-api/networkapi/buyersguide/templates/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/bg_base.html
@@ -96,6 +96,4 @@
 
     {% include "partials/footer.html" %}
   </div>
-
-  {% block extra_scripts %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4633 by removing a duplicated block `extra_scripts` for the PNI pages.