### PR TITLE
Remove 'color-hex-length' stylelint rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,6 @@
 {
   "plugins": ["stylelint-prettier"],
   "rules": {
-    "prettier/prettier": true,
-    "color-hex-length": "long"
+    "prettier/prettier": true
   }
 }

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/static/initiatives_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/static/initiatives_page.html
@@ -7,7 +7,7 @@
 {% image page.primaryHero fill-2400x700-c100 format-jpeg as big_hero %}
 <div style="background-image: url({{ big_hero.url }}); background-repeat:no-repeat; background-position: top center; background-size: cover; padding-top: 100px;">
 
-  <div class="container p-3 p-sm-5 mx-4 mx-sm-auto mb-4 bg-white">
+  <div class="container p-3 p-sm-5 mx-sm-auto mb-4 bg-white">
     <div class="row align-items-center">
       <div class="col-12 col-lg-4 pr-lg-0 text-lg-right">
         <h1 class="h1-heading">{{ page.header }}</h1>

--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -98,7 +98,6 @@
   .wrapper-burger {
     $full-logo-breakpoint: $bp-sm;
 
-    position: relative;
     transition: background 200ms ease-in-out;
     background: $white;
     border-bottom: 1px solid $gray-20;

--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -98,6 +98,7 @@
   .wrapper-burger {
     $full-logo-breakpoint: $bp-sm;
 
+    position: relative;
     transition: background 200ms ease-in-out;
     background: $white;
     border-bottom: 1px solid $gray-20;
@@ -216,7 +217,7 @@
       height: 100vh;
       top: 0;
       left: 0;
-      width: 100vw;
+      width: 100%;
       transition: opacity 0.2s, height 0s;
 
       &.hidden {

--- a/source/sass/mixins.scss
+++ b/source/sass/mixins.scss
@@ -16,8 +16,8 @@
 // Break the constraints of parent container(s) to span the entire viewport width
 @mixin full-bleed {
   $offset: $grid-gutter-width / 2;
-  width: calc(100% + #{2*$offset});
-  max-width: calc(100% + #{2*$offset});
+  width: calc(100% + #{2 * $offset});
+  max-width: calc(100% + #{2 * $offset});
   position: relative;
   margin-left: -#{$offset};
 }

--- a/source/sass/mixins.scss
+++ b/source/sass/mixins.scss
@@ -15,15 +15,11 @@
 
 // Break the constraints of parent container(s) to span the entire viewport width
 @mixin full-bleed {
-  width: 100vw;
-  max-width: none;
+  $offset: $grid-gutter-width / 2;
+  width: calc(100% + #{2*$offset});
+  max-width: calc(100% + #{2*$offset});
   position: relative;
-  left: 50%;
-  right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
-  padding-left: 0;
-  padding-right: 0;
+  margin-left: -#{$offset};
 }
 
 // Mixin to create ".full-bleed-breakpoint" utility classes


### PR DESCRIPTION
Closes #4733

Remove 'color-hex-length' stylelint rule since we don't allow color code in all files other than _colors.scss