### PR TITLE
Remove 'color-hex-length' stylelint rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,6 @@
 {
   "plugins": ["stylelint-prettier"],
   "rules": {
-    "prettier/prettier": true,
-    "color-hex-length": "long"
+    "prettier/prettier": true
   }
 }


### PR DESCRIPTION
Closes #4733

Remove 'color-hex-length' stylelint rule since we don't allow colour code in all files other than _colors.scss