### PR TITLE
node 14.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,8 @@ jobs:
   include:
     - name: Python tests
       before_install:
-        - nvm install --lts=erbium
-        - nvm use --lts=erbium
+        - nvm install 14.4.0
+        - nvm use 14.4.0
       install:
       - "./travis-scripts/python-install.sh"
       - "./travis-scripts/npm-install.sh"
@@ -65,16 +65,16 @@ jobs:
         - coveralls
     - name: npm tests
       before_install:
-        - nvm install --lts=erbium
-        - nvm use --lts=erbium
+        - nvm install 14.4.0
+        - nvm use 14.4.0
       install: "./travis-scripts/npm-install.sh"
       script: npm test
     - name: Percy tests
       before_install:
         # libgconf is required by cypress
         - sudo apt-get install -y libgconf-2-4
-        - nvm install --lts=erbium
-        - nvm use --lts=erbium
+        - nvm install 14.4.0
+        - nvm use 14.4.0
       install:
         - "./travis-scripts/python-install.sh"
         - "./travis-scripts/npm-install.sh"

--- a/dockerfiles/Dockerfile.node
+++ b/dockerfiles/Dockerfile.node
@@ -1,3 +1,3 @@
-FROM node:12.16.2-stretch-slim
+FROM node:14.4.0-stretch-slim
 
 WORKDIR /app/

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "engines": {
-    "node": "12.16.*"
+    "node": "14.4.*"
   },
   "devDependencies": {
     "browserslist": "^4.12.0",


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4728 by updating the references to node for docker and travis to 14.4.0 and our package defition to 14.4.*