### PR TITLE
Make sure petition form placeholder text color stay the same

### DIFF
--- a/source/js/components/petition/petition.scss
+++ b/source/js/components/petition/petition.scss
@@ -47,7 +47,7 @@
   textarea:placeholder-shown,
   textarea:not(:placeholder-shown) {
     &::placeholder {
-      color: transparent;
+      opacity: 0;
     }
   }
 


### PR DESCRIPTION
Make sure petition form placeholder text color stay the same regardless of the field's focus state

Closes #4786

Test page: https://foundation-s-issue-4786-k9oueg.herokuapp.com/en/campaigns/single-page/
