### PR TITLE
Removed todo

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
@@ -135,13 +135,9 @@
     {% with quote_image=page.quote_image %}
     {% if quote_image %}
     <div class="col-md-4 col-lg-6 mb-5 mb-md-0">
-      {% comment %}
-        To-do:
-        1) Update picture_ratios.html so image sizes are passed as arguments instead of hard-corded.
-        2) Replace the following "picture" code with {% optimize_images page.quote_image %}
-      {% endcomment %}
       {% with alt_text=quote_image.alt %}
-      <picture class="cms-image {{class_names}}">
+
+      <picture class="cms-image">
           {% image quote_image width-540 as image_large %}
           {% image quote_image width-1080 as image_large_2x %}
           <source media="(min-width: 992px)" srcset="{{ image_large.url }}, {{ image_large_2x.url }} 2x"  alt="{{ alt_text }}">


### PR DESCRIPTION
Closes #4944 
Related PRs/issues #4944 

This was pretty much done already by @mmmavis I believe (thank you!) 

I looked into a few different methods for passing in arguments into the `optimize_images` template tag, but nothing really stood out as "making it easier". It was either backend heavy with some math to autoscale different image sizes or frontend heavy where every include takes ~6 thumbnailing modes, which also doesnt seem very intuitive. 

I've opted to keep this the same for now and remove the todo comment. Should we see this being used in the future for, say, a StreamField, we should put this into it's own include. But for now, I'm happy where it's at. 

Happy to discuss this though! 