### PR TITLE
[Review App] fix typo in slack payload

### DIFF
--- a/network-api/networkapi/management/commands/review_app_admin.py
+++ b/network-api/networkapi/management/commands/review_app_admin.py
@@ -98,7 +98,7 @@ class Command(BaseCommand):
                         ]
                     },
                     {
-                        type: "divider",
+                        'type': "divider",
                     }
                 ]
             }

--- a/network-api/networkapi/management/commands/review_app_admin.py
+++ b/network-api/networkapi/management/commands/review_app_admin.py
@@ -82,7 +82,7 @@ class Command(BaseCommand):
                             {
                                 'type': 'button',
                                 'text': {
-                                    'type': "plain_text",
+                                    'type': 'plain_text',
                                     'text': 'View review app'
                                 },
                                 'url': f'https://{reviewapp_name}.herokuapp.com'
@@ -98,7 +98,7 @@ class Command(BaseCommand):
                         ]
                     },
                     {
-                        'type': "divider",
+                        'type': 'divider',
                     }
                 ]
             }


### PR DESCRIPTION
Review apps were created, but a typo in the slack payload prevented the message to be posted.