### PR TITLE
catch int() errors

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/index.py
@@ -145,11 +145,17 @@ class IndexPage(FoundationMetadataPageMixin, RoutablePageMixin, Page):
 
         page = 1
         if 'page' in request.GET:
-            page = int(request.GET['page'])
+            try:
+                page = int(request.GET['page'])
+            except ValueError:
+                pass
 
         page_size = self.page_size
         if 'page_size' in request.GET:
-            page_size = int(request.GET['page_size'])
+            try:
+                page_size = int(request.GET['page_size'])
+            except ValueError:
+                pass
 
         start = page * page_size
         end = start + page_size


### PR DESCRIPTION
Closes #5100 

Follow-up: https://github.com/mozilla/foundation.mozilla.org/issues/5104

Base route: https://foundation-s-fix-blog-e-bmmx0c.herokuapp.com/en/blog/entries/ (cms set to 4 results per API page)