### PR TITLE
Issue 5108

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -682,15 +682,21 @@ class Homepage(FoundationMetadataPageMixin, Page):
             PageChooserPanel('cause_statement_link_page'),
           ],
           heading='cause statement',
-          classname='collapsible'
+          classname='collapsible collapsed'
         ),
-        InlinePanel('focus_areas', label='Areas of focus', min_num=3, max_num=3),
+        MultiFieldPanel(
+            [
+                InlinePanel('focus_areas', min_num=3, max_num=3),
+            ],
+            heading='Areas of focus',
+            classname='collapsible collapsed',
+        ),
         MultiFieldPanel(
             [
                 InlinePanel('news_you_can_use', min_num=4, max_num=4),
             ],
             heading='News you can use',
-            classname='collapsible'
+            classname='collapsible collapsed'
         ),
         MultiFieldPanel(
           [
@@ -699,19 +705,7 @@ class Homepage(FoundationMetadataPageMixin, Page):
             InlinePanel('spotlight_posts', label='Posts', min_num=3, max_num=3),
           ],
           heading='spotlight',
-          classname='collapsible'
-        ),
-        MultiFieldPanel(
-          [
-            FieldPanel('partner_heading'),
-            FieldPanel('partner_intro_text'),
-            FieldPanel('partner_page_text'),
-            PageChooserPanel('partner_page'),
-            ImageChooserPanel('partner_background_image'),
-            InlinePanel('partner_logos', label='Partner Logo', max_num=7, min_num=1),
-          ],
-          heading='Partner',
-          classname='collapsible'
+          classname='collapsible collapsed'
         ),
         MultiFieldPanel(
             [
@@ -729,7 +723,19 @@ class Homepage(FoundationMetadataPageMixin, Page):
             FieldPanel('quote_source_job_title'),
           ],
           heading='quote',
-          classname='collapsible',
+          classname='collapsible collapsed',
+        ),
+        MultiFieldPanel(
+          [
+            FieldPanel('partner_heading'),
+            FieldPanel('partner_intro_text'),
+            FieldPanel('partner_page_text'),
+            PageChooserPanel('partner_page'),
+            ImageChooserPanel('partner_background_image'),
+            InlinePanel('partner_logos', label='Partner Logo', max_num=7, min_num=1),
+          ],
+          heading='Partner',
+          classname='collapsible collapsed'
         ),
     ]
 

--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -696,7 +696,7 @@ class Homepage(FoundationMetadataPageMixin, Page):
                 InlinePanel('news_you_can_use', min_num=4, max_num=4),
             ],
             heading='News you can use',
-            classname='collapsible collapsed'
+            classname='collapsible'
         ),
         MultiFieldPanel(
           [
@@ -705,7 +705,7 @@ class Homepage(FoundationMetadataPageMixin, Page):
             InlinePanel('spotlight_posts', label='Posts', min_num=3, max_num=3),
           ],
           heading='spotlight',
-          classname='collapsible collapsed'
+          classname='collapsible'
         ),
         MultiFieldPanel(
             [
@@ -713,7 +713,7 @@ class Homepage(FoundationMetadataPageMixin, Page):
                 InlinePanel('take_action_cards', label='Take Action Cards', max_num=4),
             ],
             heading='Take Action',
-            classname='collapsible collapsed',
+            classname='collapsible',
         ),
         MultiFieldPanel(
           [


### PR DESCRIPTION
Closes #5108 

Reorders the fields as requested, and makes everything past the hero collapsed-by-default so that target edits are easier.