### PR TITLE
Force quote image to fill its container width

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/quote.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/quote.html
@@ -23,7 +23,7 @@
         {% image quote_image width-1020 as image_small_2x %}
         <source srcset="{{ image_small.url }}, {{ image_small_2x.url }} 2x" alt="{{ alt_text }}">
 
-        <img src="{{ image_large.url }}" class="wagtail-image" srcset="{{image_small.url}} 510w, {{ image_medium.url }} 210w, {{ image_large.url }} 540w" alt="{{ alt_text }}"/>
+        <img src="{{ image_large.url }}" class="wagtail-image w-100" srcset="{{image_small.url}} 510w, {{ image_medium.url }} 210w, {{ image_large.url }} 540w" alt="{{ alt_text }}"/>
     </picture>
     {% endwith %}
   </div>


### PR DESCRIPTION
Closes #5126 

Undersized images cannot be processed into the dimension we want.  Adding `w-100` class to force those images to fill its container width.

To QA:
Test it with a small image or just use the one I added to the page. View the page using dev tool's responsive design mode tool. Play around with different size and DPR settings. 