### PR TITLE
fix banner title alignment in webkit

### DIFF
--- a/source/sass/global.scss
+++ b/source/sass/global.scss
@@ -96,7 +96,7 @@ hr {
       }
 
       .banner-content {
-        align-self: end;
+        align-self: flex-end;
         margin-bottom: 72px;
 
         @media screen and (min-width: $bp-md) {


### PR DESCRIPTION
No issue - fixes a title alignment issue for webkit based browsers due to using the "wrong" end keyword