### PR TITLE
Run django-modeltranslation tasks after migration task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -193,6 +193,8 @@ def manage(ctx, command):
 def migrate(ctx):
     """Updates database schema"""
     manage(ctx, "migrate --no-input")
+    l10n_sync(ctx)
+    l10n_update(ctx)
 
 
 @task(aliases=["docker-makemigrations"])


### PR DESCRIPTION
 ... to account for data migrations that may have taken place before a model was registered for translation

Closes #5167 