### PR TITLE
Add GA event trackings to homepage

### DIFF
--- a/network-api/networkapi/templates/partials/footer.html
+++ b/network-api/networkapi/templates/partials/footer.html
@@ -12,7 +12,7 @@
           <p class="h3-heading mb-0">{% trans "We all love the Web. Join Mozilla in defending it." %}</p>
           <p class="h3-heading mb-4">{% trans "Let’s protect the world’s largest resource for future generations." %}</p>
           <div>
-            <a href="https://donate.mozilla.org/" target="_blank" rel="noopener noreferrer" class="btn btn-secondary dark-theme">{% trans "Donate now" %}</a>
+            <a href="https://donate.mozilla.org/" target="_blank" rel="noopener noreferrer" class="btn btn-secondary dark-theme" id="donate-banner-cta">{% trans "Donate now" %}</a>
           </div>
         </div>
       </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/cause_statement.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/cause_statement.html
@@ -3,7 +3,7 @@
     <div class="section-cause-statement dark-theme p-5 text-center">
       <p class="h4-heading">{{ page.cause_statement }}</p>
       {% if page.cause_statement_link_text and page.cause_statement_link_page %}
-        <a href="{{page.cause_statement_link_page.url}}" class="cta-link">{{page.cause_statement_link_text}}</a>
+        <a href="{{page.cause_statement_link_page.url}}" class="cta-link" id="homepage-cause-statement-cta">{{page.cause_statement_link_text}}</a>
       {% endif %}
     </div>
   </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/news_you_can_use.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/news_you_can_use.html
@@ -4,7 +4,7 @@
   <div class="col-12 d-flex flex-row justify-content-between">
     <h2 class="h4-heading mb-4">{% trans "News you can use" %}</h2>
     {# this should not be a hardcoded route... #}
-    <a href="/blog" class="cta-link d-none d-md-inline-block">{% trans "Read more news" %}</a>
+    <a href="/blog" class="cta-link d-none d-md-inline-block" id="news-you-can-use-cta">{% trans "Read more news" %}</a>
   </div>
 
   <div class="col-12">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/partner.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/partner.html
@@ -12,7 +12,7 @@
             {{ page.partner_intro_text }}
           </p>
         {% endif %}
-        <a href="{{ page.partner_page.url }}" class="text-white cta-link font-weight-bold">
+        <a href="{{ page.partner_page.url }}" class="text-white cta-link font-weight-bold" id="partner-cta">
           {{ page.partner_page_text }}
         </a>
       </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/primary_heroguts.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/primary_heroguts.html
@@ -42,7 +42,7 @@
         <div class="col-12 col-md-9 col-xl-6 mt-3 d-flex flex-column justify-content-end">
           <h1 class="h1-heading">{{ page.hero_headline }}</h1>
           <div>
-            <a href="{{page.hero_button_url}}" class="btn btn-secondary text-wrap">{{page.hero_button_text}}</a>
+            <a href="{{page.hero_button_url}}" class="btn btn-secondary text-wrap" id="homepage-hero-cta">{{page.hero_button_text}}</a>
           </div>
         </div>
       </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/take_action.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/take_action.html
@@ -29,7 +29,7 @@
         <div class="bg-black p-4 dark-theme">
           <div
             class="join-us"
-            data-form-position="header"
+            data-form-position="body"
             data-cta-header="Protect the internet as a global public resource"
             data-cta-description="<p class='mb-3'>Join our <b>Mozilla News</b> email list to take action and stay updated!</p>"
             data-newsletter="{{ cta.newsletter }}">

--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -35,6 +35,7 @@ export default class JoinUs extends React.Component {
       lang: getCurrentLanguage(),
       hideLocaleFields: [
         `header`,
+        `body`,
         `footer`,
         `youtube-regrets-reporter`,
       ].includes(props.formPosition),

--- a/source/js/foundation/template-js-handler/homepage.js
+++ b/source/js/foundation/template-js-handler/homepage.js
@@ -10,7 +10,7 @@ export default () => {
     if (element) {
       element.addEventListener(`click`, () => {
         ReactGA.event({
-          category: `cta read more`,
+          category: `CTA read more`,
           action: eventAction,
           label: `${DOC_TITLE} - ${element.innerText}`,
         });

--- a/source/js/foundation/template-js-handler/homepage.js
+++ b/source/js/foundation/template-js-handler/homepage.js
@@ -1,0 +1,56 @@
+import { ReactGA } from "../../common";
+
+/**
+ * Bind click handler to "#see-more-modular-page" (the "see more" link in ih_cta.html)
+ */
+export default () => {
+  const DOC_TITLE = document.title;
+
+  let bindCtaGA = (element, eventAction) => {
+    if (element) {
+      element.addEventListener(`click`, () => {
+        ReactGA.event({
+          category: `cta read more`,
+          action: eventAction,
+          label: `${DOC_TITLE} - ${element.innerText}`,
+        });
+      });
+    }
+  };
+
+  // Hero CTA button
+  bindCtaGA(
+    document.querySelector(`#homepage-hero-cta`),
+    `read more hero button tap`
+  );
+
+  // Cause Statement CTA link
+  bindCtaGA(
+    document.querySelector(`#homepage-cause-statement-cta`),
+    `more about our work link tap`
+  );
+
+  // News You Can Use CTA link
+  bindCtaGA(
+    document.querySelector(`#news-you-can-use-cta`),
+    `read news link tap`
+  );
+
+  // Partner CTA link
+  bindCtaGA(
+    document.querySelector(`#partner-cta`),
+    `let's work together link tap`
+  );
+
+  // Donate Banner CTA
+  let donateBannerCta = document.querySelector("#donate-banner-cta");
+  if (donateBannerCta) {
+    donateBannerCta.addEventListener(`click`, () => {
+      ReactGA.event({
+        category: `donate`,
+        action: `donate button tap banner`,
+        label: `${DOC_TITLE} banner`,
+      });
+    });
+  }
+};

--- a/source/js/foundation/template-js-handler/index.js
+++ b/source/js/foundation/template-js-handler/index.js
@@ -1,6 +1,7 @@
 import stickyCtaHandler from "./window/sticky-cta";
 import stickyShareButtonGroupHandler from "./window/sticky-share-button-group";
 
+import homepageHandler from "./homepage";
 import internetHealthSeeMoreHandler from "./internet-health-see-more.js";
 import loadMoreEntriesHandler from "./load-more-entries.js";
 import participatePageDonateHandler from "./participate-page-donate.js";
@@ -20,6 +21,7 @@ export const bindWindowEventHandlers = () => {
  * Bind event handlers
  */
 export const bindEventHandlers = () => {
+  homepageHandler();
   internetHealthSeeMoreHandler();
   loadMoreEntriesHandler();
   participatePageDonateHandler();


### PR DESCRIPTION
Closes #5048

https://foundation-s-issue-5048-hirqze.herokuapp.com/en/

I use [Google Analytics Debuggers](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) Chrome plugin to debug. You will need to turn on "persistent log" so you don't lose the log when you are brought to another page (after clicking a link etc).

![Screen Shot 2020-09-14 at 3 09 13 PM](https://user-images.githubusercontent.com/2896608/93143394-b7f77380-f69c-11ea-8894-4417b0b2b1b8.png)
