### PR TITLE
Instruct Travis-ci to execute builds for the pni-v4-2020 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ cache:
 branches:
   only:
     - master
+    - pni-v4-2020
 
 jobs:
   include:


### PR DESCRIPTION
Closes #5261

This will have travis run CI when we merge into pni-v4-2020 so that work can be verified before a Heroku deploy to the PNI staging environment.