### PR TITLE
Nav logo fixes

### DIFF
--- a/source/js/buyers-guide/components/primary-nav/primary-nav.scss
+++ b/source/js/buyers-guide/components/primary-nav/primary-nav.scss
@@ -6,7 +6,7 @@ $pni-primary-nav-breakpoint: $bp-sm;
   width: 28px;
   height: 28px;
 
-  @include media-breakpoint-up(md) {
+  @media (min-width: $nav-full-logo-breakpoint) {
     width: 97px;
     background-image: url("../_images/mozilla-on-black.svg");
   }

--- a/source/sass/buyers-guide/bg-main.scss
+++ b/source/sass/buyers-guide/bg-main.scss
@@ -7,13 +7,8 @@ html {
 
 @import "../mofo-bootstrap/mofo-bootstrap";
 
-// Breakpoints (imported from Bootstrap)
-
-$bp-xs: #{map-get($grid-breakpoints, xs)}; // < 576px
-$bp-sm: #{map-get($grid-breakpoints, sm)}; // >= 576px
-$bp-md: #{map-get($grid-breakpoints, md)}; // >= 768px
-$bp-lg: #{map-get($grid-breakpoints, lg)}; // >= 992px
-$bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
+// Custom variables
+@import "../variables";
 
 //Site-wide
 

--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -96,8 +96,6 @@
   }
 
   .wrapper-burger {
-    $full-logo-breakpoint: $bp-sm;
-
     transition: background 200ms ease-in-out;
     background: $white;
     border-bottom: 1px solid $gray-20;
@@ -195,7 +193,7 @@
       position: relative;
       z-index: 1;
 
-      @media (min-width: $full-logo-breakpoint) {
+      @media (min-width: $nav-full-logo-breakpoint) {
         width: 97px;
         background: url(../_images/mozilla-on-black.svg) no-repeat;
       }
@@ -209,7 +207,7 @@
       position: absolute;
       padding-top: 64px;
 
-      @media (min-width: $full-logo-breakpoint) {
+      @media (min-width: $nav-full-logo-breakpoint) {
         padding-top: 72px;
       }
 

--- a/source/sass/main.scss
+++ b/source/sass/main.scss
@@ -2,13 +2,8 @@
 
 @import "./mofo-bootstrap/mofo-bootstrap";
 
-// Breakpoints (imported from Bootstrap)
-
-$bp-xs: #{map-get($grid-breakpoints, xs)}; // < 576px
-$bp-sm: #{map-get($grid-breakpoints, sm)}; // >= 576px
-$bp-md: #{map-get($grid-breakpoints, md)}; // >= 768px
-$bp-lg: #{map-get($grid-breakpoints, lg)}; // >= 992px
-$bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
+// Custom variables
+@import "./variables";
 
 // Site-wide
 @import "./glyphs";

--- a/source/sass/mozfest.scss
+++ b/source/sass/mozfest.scss
@@ -1,8 +1,7 @@
 body.mozfest {
   #primary-nav-container {
     // The following overrides are to make sure
-    // 1) MozFest logo shows up larger than
-    //    the default Mozilla logo that we have on the main site
+    // 1) MozFest logo shows up larger than the default Mozilla logo that we have on the main site
     // 2) MozFest primary nav and main Foundation site's primary nav have the same height
 
     @media (min-width: $nav-full-logo-breakpoint) {

--- a/source/sass/mozfest.scss
+++ b/source/sass/mozfest.scss
@@ -1,18 +1,21 @@
 body.mozfest {
   #primary-nav-container {
-    @media (min-width: $bp-md) {
-      // The following overrides are to make sure
-      // 1) MozFest logo shows up larger than
-      //    the default Mozilla logo that we have on the main site
-      // 2) MozFest primary nav and main Foundation site's primary nav have the same height
-      .menu-container {
-        padding-top: 12px;
-        padding-bottom: 12px;
-      }
+    // The following overrides are to make sure
+    // 1) MozFest logo shows up larger than
+    //    the default Mozilla logo that we have on the main site
+    // 2) MozFest primary nav and main Foundation site's primary nav have the same height
 
+    @media (min-width: $nav-full-logo-breakpoint) {
       .wrapper-burger .logo {
         height: 36px;
         background-image: url(../_images/mozfest/logo.svg);
+      }
+    }
+
+    @media (min-width: $bp-md) {
+      .menu-container {
+        padding-top: 12px;
+        padding-bottom: 12px;
       }
     }
   }

--- a/source/sass/variables.scss
+++ b/source/sass/variables.scss
@@ -1,0 +1,12 @@
+// our own custom SCSS variables
+// for Bootstrap variable overrides use ./mofo-bootstrap/overrides/_variables.scss
+
+// Breakpoints (imported from Bootstrap)
+
+$bp-xs: #{map-get($grid-breakpoints, xs)}; // < 576px
+$bp-sm: #{map-get($grid-breakpoints, sm)}; // >= 576px
+$bp-md: #{map-get($grid-breakpoints, md)}; // >= 768px
+$bp-lg: #{map-get($grid-breakpoints, lg)}; // >= 992px
+$bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
+
+$nav-full-logo-breakpoint: $bp-sm;


### PR DESCRIPTION
Closes #5168 

Show mini Mozilla logo `M` only on extra small screens (<576px). I've also updated PNI so it follows this pattern (got approval from Sabrina).


https://foundation-s-issue-5168-uvmvnd.herokuapp.com/en/mozilla-festival/
https://foundation-s-issue-5168-uvmvnd.herokuapp.com/en/privacynotincluded

### Example: screenshot taken at 575px width (`extra small`)
![Screen Shot 2020-09-17 at 14 33 52](https://user-images.githubusercontent.com/2896608/93530708-e078ab00-f8f2-11ea-8f7a-543b9a6f485c.png)

### Example: screenshot taken at 576px width (`small`)
![Screen Shot 2020-09-17 at 14 36 39](https://user-images.githubusercontent.com/2896608/93530903-38afad00-f8f3-11ea-84d7-cf868ec2f96f.png)
