### PR TITLE
fix the RSS feed entry selection

### DIFF
--- a/network-api/networkapi/wagtailpages/rss.py
+++ b/network-api/networkapi/wagtailpages/rss.py
@@ -3,7 +3,7 @@ from django.contrib.syndication.views import Feed
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.text import Truncator
 
-from .models import BlogIndexPage
+from .models import IndexPage
 
 
 class RSSFeed(Feed):
@@ -17,14 +17,17 @@ class RSSFeed(Feed):
     description = 'The Mozilla Foundation Blog'
 
     def items(self):
-        # Pull this object specifically using the English page title
-        blog_index = BlogIndexPage.objects.get(title_en__iexact='Blog')
+        # Pull this object specifically using the English page title, as an IndexPage
+        # rather than a BlogIndexPage, to make sure we're not filtering out all the
+        # "featured" posts (which we need to do for site content purposes))
+        index = IndexPage.objects.get(title_en__iexact='Blog')
 
         # If that doesn't yield the blog page, pull using the universal title
-        if blog_index is None:
-            blog_index = BlogIndexPage.objects.get(title__iexact='Blog')
+        if index is None:
+            index = IndexPage.objects.get(title__iexact='Blog')
 
-        blog_pages = blog_index.get_all_entries()
+        blog_pages = index.get_all_entries().order_by('-first_published_at')
+
         return blog_pages[:settings.FEED_LIMIT]
 
     def item_title(self, item):


### PR DESCRIPTION
Closes #5258

Switches the RSS selector from BlogIndexPage to IndexPage, as the BlogIndexPage's `get_all_entries` filters out all featured blog items, which we definitely want for the blog page, but definitely _don't_ want for RSS purposes.

Code-reason why this was going wrong: https://github.com/mozilla/foundation.mozilla.org/blob/e5979d0f00ae9b81415a27f782b4bc236eef0bd3/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py#L61-L70

That L69-L70 should not run for RSS/Atom purposes