### PR TITLE
remove content cap

### DIFF
--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -17,6 +17,8 @@
       <meta property='wagtail:language' content='{{ lang_code }}'>
     {% endblock %}
 
+    {% block rss_metadata %}{% endblock %}
+
     {% block wagtail_metadata %}
       {% meta_tags %}
     {% endblock %}

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -70,7 +70,7 @@ urlpatterns += i18n_patterns(
     url(r'^privacynotincluded/', include('networkapi.buyersguide.urls')),
 
     # Blog RSS feed
-    path('blog/rss/', RSSFeed()),
+    path('blog/rss/', RSSFeed(), name='rss-feed'),
     path('blog/atom/', AtomFeed()),
 
     # Redirects

--- a/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
+++ b/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
@@ -2,6 +2,7 @@ import re
 from django import template
 from django.utils.text import slugify
 from django.utils.html import strip_tags
+from django.utils.safestring import SafeText
 from wagtail.core.rich_text import RichText
 
 # We don't actually register any tags: the idea is to tap into
@@ -75,8 +76,8 @@ def with_heading_ids(self):
     # component's __html__ serializer function generates plain text
     # HTML source code, that assumption might be invalidated at some
     # point in time, so in order to make sure we can safely perform
-    # text replacement, we need to verify `html` has a string type.
-    if type(html) is not str:
+    # text replacement, we need to verify `html` is an instance of SafeText.
+    if type(html) is not SafeText:
         return html
 
     return re.sub(heading_re, add_id_attribute, html)

--- a/network-api/networkapi/wagtailpages/rss.py
+++ b/network-api/networkapi/wagtailpages/rss.py
@@ -36,8 +36,7 @@ class RSSFeed(Feed):
     def item_description(self, item):
         page = item.specific
         html = str(page.body)
-        text = Truncator(html).chars(1000, html=True)
-        return text
+        return html
 
     def item_pubdate(self, item):
         return item.first_published_at

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_page.html
@@ -4,7 +4,7 @@
 
 
 {% block rss_metadata %}
-  <link rel="alternate" type="application/rss+xml" href="https://foundation.mozilla.org/blog/rss/" />
+  <link rel="alternate" type="application/rss+xml" href="{% url 'rss-feed' %}" />
 {% endblock %}
 
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_page.html
@@ -2,6 +2,12 @@
 
 {% load wagtailcore_tags wagtailimages_tags i18n %}
 
+
+{% block rss_metadata %}
+  <link rel="alternate" type="application/rss+xml" href="https://foundation.mozilla.org/blog/rss/" />
+{% endblock %}
+
+
 {% block featured %}
   {% if not filtered %}
     <div class="row">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
@@ -2,6 +2,11 @@
 {% load wagtailcore_tags wagtailimages_tags homepage_tags card_tags wagtailmetadata_tags multi_image_tags i18n  %}
 
 
+{% block rss_metadata %}
+  <link rel="alternate" type="application/rss+xml" href="https://foundation.mozilla.org/blog/rss/" />
+{% endblock %}
+
+
 {% block body_id %}home{% endblock %}
 
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
@@ -3,7 +3,7 @@
 
 
 {% block rss_metadata %}
-  <link rel="alternate" type="application/rss+xml" href="https://foundation.mozilla.org/blog/rss/" />
+  <link rel="alternate" type="application/rss+xml" href="{% url 'rss-feed' %}" />
 {% endblock %}
 
 


### PR DESCRIPTION
Closes #5232

Removes the text limit on RSS blog entries, so folks can read the blog posts in their RSS readers.

Also adds the RSS link to the homepage, and blog page, so that RSS feed extensions automatically pick up on the fact that there's an RSS feed.
