### PR TITLE
Wrapping one MozFest string for localization

### DIFF
--- a/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
+++ b/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
@@ -1,6 +1,7 @@
-{% load primary_active_nav %}
+{% load i18n primary_active_nav %}
 
-{% with root_name="Home" %}
+{% trans "Home" as translated_root_name %}
+{% with root_name=translated_root_name %}
 <div id="primary-nav-container">
   <div class="wrapper-burger">
     <div class="menu-container">


### PR DESCRIPTION
Fixes #5298

Translating `root_name` (Home) on MozFest since it appears in the mobile menu and is used as a11y label for the logo
<img width="447" alt="Capture d’écran 2020-09-24 à 14 25 24" src="https://user-images.githubusercontent.com/1294206/94144911-a87ce500-fe69-11ea-9352-2fca77a3ce94.png">