### PR TITLE
add track-record value translation tag

### DIFF
--- a/network-api/networkapi/buyersguide/templates/fragments/it_uses.html
+++ b/network-api/networkapi/buyersguide/templates/fragments/it_uses.html
@@ -1,4 +1,4 @@
-{% load yes_no i18n %}
+{% load bg_selector_tags i18n %}
 
 <div class="it-uses d-flex flex-column">
   <div class="title">

--- a/network-api/networkapi/buyersguide/templates/fragments/signup_requirement.html
+++ b/network-api/networkapi/buyersguide/templates/fragments/signup_requirement.html
@@ -1,4 +1,4 @@
-{% load yes_no i18n %}
+{% load bg_selector_tags i18n %}
 
 <div class="signup-requirement d-flex flex-column">
   <div class="title">

--- a/network-api/networkapi/buyersguide/templates/product_page.html
+++ b/network-api/networkapi/buyersguide/templates/product_page.html
@@ -1,6 +1,6 @@
 {% extends "./bg_base.html" %}
 
-{% load yes_no env cloudinary l10n i18n static %}
+{% load bg_selector_tags env cloudinary l10n i18n static %}
 
 {% block head_extra %}
   <meta property="og:title" content="{% blocktrans context "This can be localized. This is a reference to the “*batteries not included” mention on toys." %}privacy not included - {{ product.name }}{% endblocktrans %}" />

--- a/network-api/networkapi/buyersguide/templatetags/bg_selector_tags.py
+++ b/network-api/networkapi/buyersguide/templatetags/bg_selector_tags.py
@@ -37,7 +37,7 @@ def track_record(value):
     about the possible options, and the context in which to apply
     this tag, rather than a generic "localize" tag.
     """
-    lcontext = "This can be localized. This is a rating for a company's history concerning privacy"
+    lcontext = "This is a rating for a company's history concerning privacy"
     if value == 'Great':
         return pgettext(lcontext, 'Great')
     if value == 'Average':

--- a/network-api/networkapi/buyersguide/templatetags/bg_selector_tags.py
+++ b/network-api/networkapi/buyersguide/templatetags/bg_selector_tags.py
@@ -27,3 +27,22 @@ def extended_yes_no(value):
     if value == 'No':
         return gettext('No')
     return value
+
+
+@register.filter
+def track_record(value):
+    """
+    effects localization for company track records. While it might
+    seem easier to just return gettext(value), we want to be explicit
+    about the possible options, and the context in which to apply
+    this tag, rather than a generic "localize" tag.
+    """
+    if value == 'Great':
+        return gettext('Great')
+    if value == 'Average':
+        return gettext('Average')
+    if value == 'Needs Improvement':
+        return gettext('Needs Improvement')
+    if value == 'Bad':
+        return gettext('Bad')
+    return value

--- a/network-api/networkapi/buyersguide/templatetags/bg_selector_tags.py
+++ b/network-api/networkapi/buyersguide/templatetags/bg_selector_tags.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.translation import gettext
+from django.utils.translation import gettext, pgettext
 
 register = template.Library()
 
@@ -37,12 +37,13 @@ def track_record(value):
     about the possible options, and the context in which to apply
     this tag, rather than a generic "localize" tag.
     """
+    lcontext = "This can be localized. This is a rating for a company's history concerning privacy"
     if value == 'Great':
-        return gettext('Great')
+        return pgettext(lcontext, 'Great')
     if value == 'Average':
-        return gettext('Average')
+        return pgettext(lcontext, 'Average')
     if value == 'Needs Improvement':
-        return gettext('Needs Improvement')
+        return pgettext(lcontext, 'Needs Improvement')
     if value == 'Bad':
-        return gettext('Bad')
+        return pgettext(lcontext, 'Bad')
     return value


### PR DESCRIPTION
Closes #5292
Related PRs/issues #5295

This adds the necessary tag to ensure that company track record values end up properly localized.

/cc @KalobTaulien this should be a minimal change to https://github.com/mozilla/foundation.mozilla.org/pull/5295/files#diff-47a11420d29f9efdcce95f7e166919e3R138, just needing ` | track_record`