### PR TITLE
offer some useful things during copy

### DIFF
--- a/network-api/networkapi/wagtailcustomization/static/wagtailadmin/js/copy-helper.js
+++ b/network-api/networkapi/wagtailcustomization/static/wagtailadmin/js/copy-helper.js
@@ -1,0 +1,40 @@
+// Which locales are we dealing with?
+const main = wagtailModelTranslations.defaultLanguage;
+const languages = wagtailModelTranslations.languages.map((v) =>
+  v.replace(`-`, `_`)
+);
+
+// Which fields are going to be potential deal-breakers?
+const fields = Object.fromEntries(
+  Array.from(
+    document.querySelectorAll(`.content input[type=text]`)
+  ).map((e) => [e.getAttribute(`name`), e])
+);
+
+// 1: Give staff a button that lets them reveal all locale fields, so they can
+// manually edit any field to be any value they want.
+const toggle = document.querySelector(`.locale.helper.button`);
+
+toggle.addEventListener(`click`, () => {
+  document.querySelectorAll(`.locale-picker .locale-toggle`).forEach((btn) => {
+    if (!btn.classList.contains(`showing-locale`)) btn.click();
+  });
+});
+
+// 2: Also give staff a button that lets them just copy whatever is in the
+// [en] field(s) to all the other locales.
+const sync = document.querySelector(`.synchronize.helper.button`);
+
+sync.addEventListener(`click`, () => {
+  Object.values(fields).forEach((field) => {
+    const name = field.getAttribute(`name`);
+    let code = languages.find((v) => name.includes(`_${v}`));
+    if (code === main) return;
+    field.value = fields[name.replace(`_${code}`, `_${main}`)].value;
+  });
+});
+
+// Are there any errors? If so, we need to immediately reveal all fields
+if (document.querySelectorAll(`p.error-message`).length !== 0) {
+  toggle.click();
+}

--- a/network-api/networkapi/wagtailcustomization/static/wagtailadmin/js/copy-helper.js
+++ b/network-api/networkapi/wagtailcustomization/static/wagtailadmin/js/copy-helper.js
@@ -28,7 +28,7 @@ const sync = document.querySelector(`.synchronize.helper.button`);
 sync.addEventListener(`click`, () => {
   Object.values(fields).forEach((field) => {
     const name = field.getAttribute(`name`);
-    let code = languages.find((v) => name.includes(`_${v}`));
+    const code = languages.find((v) => name.includes(`_${v}`));
     if (code === main) return;
     field.value = fields[name.replace(`_${code}`, `_${main}`)].value;
   });

--- a/network-api/networkapi/wagtailcustomization/templates/modeltranslation_copy.html
+++ b/network-api/networkapi/wagtailcustomization/templates/modeltranslation_copy.html
@@ -11,6 +11,11 @@
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}" />
 
+            {% comment %}
+                There is unfortunately no block that we can use to inject content in the right place here,
+                so instead we've copied the entirety of https://github.com/infoportugal/wagtail-modeltranslation's
+                templates/modeltranslation_copy.html so that we can add these buttons for staff to click:
+            {% endcomment %}
             <div>
                 <p><h2>{% trans "Locale synchronization options:" %}</h2></p>
                 <p>

--- a/network-api/networkapi/wagtailcustomization/templates/modeltranslation_copy.html
+++ b/network-api/networkapi/wagtailcustomization/templates/modeltranslation_copy.html
@@ -1,0 +1,37 @@
+{% extends "modeltranslation_copy.html" %}
+
+{% load static i18n %}
+
+{% block content %}
+    {% trans "Copy" as copy_str %}
+    {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
+
+    <div class="nice-padding">
+        <form action="{% url 'wagtailadmin_pages:copy' page.id %}" method="POST" novalidate>
+            {% csrf_token %}
+            <input type="hidden" name="next" value="{{ next }}" />
+
+            <div>
+                <p><h2>{% trans "Locale synchronization options:" %}</h2></p>
+                <p>
+                    <button type="button" class="locale helper button">{% trans "Show all locale fields" %}</button>
+                    <button type="button" class="synchronize helper button">{% trans "Synchronize" %}</button>
+                </p>
+            </div>
+
+            <ul class="fields">
+                {% for field in form.visible_fields %}
+             	    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+             	{% endfor %}
+            </ul>
+
+            <input type="submit" value="{% trans 'Copy this page' %}" class="button">
+        </form>
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+
+    <script src="{% static "wagtailadmin/js/copy-helper.js" %}" async defer></script>
+{% endblock %}


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/4959 

introduces two buttons on the Copy interface:

![image](https://user-images.githubusercontent.com/177243/94625221-127ffa80-026d-11eb-86ad-545cf235462c.png)

The first button expands all fields - this button will _automatically be pressed by the page itself_ if there are any errors on the page (e.g. a user changed the slug for EN and just clicked "COPY" rather than expanding the locale fields to make sure all localized slugs were updated, too).

The second button simply takes the current values in all [EN] fields and copies those over to all corresponding localized fields.

