### PR TITLE
PNI: Fix l10n for track_record tag

### DIFF
--- a/network-api/networkapi/buyersguide/templates/product_page.html
+++ b/network-api/networkapi/buyersguide/templates/product_page.html
@@ -160,7 +160,7 @@
             {% include "fragments/product_criterion.html"  with  label=how_can_you_control_your_data  value=product.how_can_you_control_your_data    ding=product.data_control_policy_is_bad   %}
 
             {% trans "What is the company’s known track record for protecting users’ data?" as company_track_record_label %}
-            {% include "fragments/product_criterion.html"  with  label=company_track_record_label  value=product.company_track_record   help=product.track_record_details  ding=product.track_record_is_bad %}
+            {% include "fragments/product_criterion.html"  with  label=company_track_record_label  value=product.company_track_record|track_record   help=product.track_record_details  ding=product.track_record_is_bad %}
 
             {% trans "Can this product be used offline?" as offline_capable %}
             {% include "fragments/product_criterion.html"  with  label=offline_capable  value=product.offline_capable   help=product.offline_use_description %}

--- a/network-api/networkapi/buyersguide/templatetags/bg_selector_tags.py
+++ b/network-api/networkapi/buyersguide/templatetags/bg_selector_tags.py
@@ -37,13 +37,12 @@ def track_record(value):
     about the possible options, and the context in which to apply
     this tag, rather than a generic "localize" tag.
     """
-    lcontext = "This is a rating for a company's history concerning privacy"
     if value == 'Great':
-        return pgettext(lcontext, 'Great')
+        return pgettext("This is a rating for a company's history concerning privacy", 'Great')
     if value == 'Average':
-        return pgettext(lcontext, 'Average')
+        return pgettext("This is a rating for a company's history concerning privacy", 'Average')
     if value == 'Needs Improvement':
-        return pgettext(lcontext, 'Needs Improvement')
+        return pgettext("This is a rating for a company's history concerning privacy", 'Needs Improvement')
     if value == 'Bad':
-        return pgettext(lcontext, 'Bad')
+        return pgettext("This is a rating for a company's history concerning privacy", 'Bad')
     return value


### PR DESCRIPTION
Closes #5407

Fixes two issues:
- For some reason, the strings are not extracted due to the variable used for the contextual marker. Not sure if it’s a gettext bug, or a Python subtlety, but using a variable doesn’t work.
- Adds the tag to the template

I’ve tested locally with French translations that they correctly appear.

If you want to test:
1. Set up your l10n repo https://github.com/mozilla/foundation.mozilla.org#initial-setup
2. run `inv makemessages`
3. Edit foundation/translations/networkapi/buyersguide/locale/fr/django.po in your local repository with PoEdit
4. run `inv makemessages` once again
5. run `inv compilemessages`
6. check the webpage