### PR TITLE
better product update CMS

### DIFF
--- a/network-api/networkapi/buyersguide/factory.py
+++ b/network-api/networkapi/buyersguide/factory.py
@@ -15,6 +15,7 @@ from networkapi.utility.faker import ImageProvider, generate_fake_data
 from networkapi.utility.faker.helpers import reseed
 from networkapi.buyersguide.models import (
     Product,
+    Update,
     ProductPrivacyPolicyLink,
     GeneralProduct,
     BuyersGuideProductCategory,
@@ -51,8 +52,18 @@ class ProductPrivacyPolicyLinkFactory(DjangoModelFactory):
     url = Faker('url')
 
 
-class ProductFactory(DjangoModelFactory):
+class ProductUpdateFactory(DjangoModelFactory):
+    class Meta:
+        model = Update
 
+    source = Faker('url')
+    title = Faker('sentence')
+    author = Faker('sentence')
+    featured = Faker('boolean')
+    snippet = Faker('sentence')
+
+
+class ProductFactory(DjangoModelFactory):
     class Meta:
         model = GeneralProduct
         exclude = (
@@ -178,6 +189,11 @@ def generate(seed):
         twitter='@TwitterHandle',
         worst_case='Duplicate work that burns through screenshots'
     )
+
+    reseed(seed)
+
+    print('Generating Buyer\'s Guide product updates')
+    generate_fake_data(ProductUpdateFactory, 15)
 
     reseed(seed)
 

--- a/network-api/networkapi/buyersguide/pagemodels/products/base.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/base.py
@@ -31,7 +31,9 @@ else:
 
 class ProductUpdatesFieldPanel(FieldPanel):
     """
-    ...docs go here...
+    This is a custom field panel for listing product updates in a regular
+    product's admin view - the list is populated by the result from
+    calling BaseProduct.get_product_updates, below.
     """
     def on_form_bound(self):
         instance = self.model
@@ -398,7 +400,10 @@ class Product(ClusterableModel):
 
     def get_product_updates(self):
         """
-        ...docs go here...
+        This function is used by our custom ProductUpdatesFieldPanel, to make sure
+        updates are alphabetically listed. Eventually we want to replace this with
+        "that, but also nothing older than 2 years". We can't do that yet, though,
+        as product updates currently do not record their creation_date.
         """
         return ProductUpdate.objects.all().order_by('title')
 

--- a/network-api/networkapi/buyersguide/pagemodels/products/base.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/base.py
@@ -11,6 +11,7 @@ from django.forms import model_to_dict
 from django.utils.text import slugify
 
 from networkapi.buyersguide.fields import ExtendedYesNoField
+from ..product_update import Update as ProductUpdate
 
 from modelcluster.models import ClusterableModel
 
@@ -26,6 +27,16 @@ if settings.USE_CLOUDINARY:
     image_field = FieldPanel('cloudinary_image')
 else:
     image_field = FieldPanel('image')
+
+
+class ProductUpdatesFieldPanel(FieldPanel):
+    """
+    ...docs go here...
+    """
+    def on_form_bound(self):
+        instance = self.model
+        self.form.fields['updates'].queryset = instance.get_product_updates(instance)
+        super().on_form_bound()
 
 
 class RelatedProductFieldPanel(FieldPanel):
@@ -137,7 +148,7 @@ product_panels = [
         heading='Ways to contact the company',
         classname='collapsible'
     ),
-    FieldPanel('updates'),
+    ProductUpdatesFieldPanel('updates'),
     RelatedProductFieldPanel('related_products'),
 ]
 
@@ -384,6 +395,12 @@ class Product(ClusterableModel):
         related_name='pniproduct',
         blank=True
     )
+
+    def get_product_updates(self):
+        """
+        ...docs go here...
+        """
+        return ProductUpdate.objects.all().order_by('title')
 
     # comments are not a model field, but are "injected" on the product page instead
 


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/5390 by adding some code that sorts product updates alphabetically, with an update to load_fake_data that generates a bunch of fake product updates to populate the update list in the CMS.

This is similar, but subtly different, from the RelatedProductsFieldPanel work that already landed.

**Changes in Models:**
- [x] Did I update or add new fake data?
- [x] [Are my changes backward-compatible]
