### PR TITLE
remove ask.moz, fix docker problems with .env

### DIFF
--- a/env.default
+++ b/env.default
@@ -42,16 +42,16 @@ CRM_PETITION_SQS_QUEUE_URL=
 
 # CSP config
 
-CSP_CHILD_SRC='self' https://www.youtube.com https://www.youtube-nocookie.com
-CSP_CONNECT_SRC=*
-CSP_DEFAULT_SRC='none'
-CSP_FONT_SRC='self' https://fonts.gstatic.com https://fonts.googleapis.com https://code.cdn.mozilla.net
-CSP_FRAME_ANCESTORS='none'
-CSP_FRAME_SRC='self' https://www.youtube.com  https://s3.amazonaws.com/ask-mozilla/ https://comments.mozillafoundation.org/ https://airtable.com https://docs.google.com/ https://platform.twitter.com https://public.zenkit.com https://calendar.google.com https://www.youtube-nocookie.com https://devopstypeform.typeform.com
-CSP_IMG_SRC=* data:
-CSP_MEDIA_SRC='self' https://s3.amazonaws.com/mofo-assets/foundation/video/
-CSP_SCRIPT_SRC='self' 'unsafe-inline' https://www.google-analytics.com/analytics.js http://*.shpg.org/ https://comments.mozillafoundation.org/ https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com https://embed.typeform.com
-CSP_STYLE_SRC='self' 'unsafe-inline' https://code.cdn.mozilla.net https://fonts.googleapis.com  https://platform.twitter.com
+CSP_CHILD_SRC="'self' https://www.youtube.com https://www.youtube-nocookie.com"
+CSP_CONNECT_SRC="*"
+CSP_DEFAULT_SRC="'none'"
+CSP_FONT_SRC="'self' https://fonts.gstatic.com https://fonts.googleapis.com https://code.cdn.mozilla.net"
+CSP_FRAME_ANCESTORS="'none'"
+CSP_FRAME_SRC="'self' https://www.youtube.com https://comments.mozillafoundation.org/ https://airtable.com https://docs.google.com/ https://platform.twitter.com https://public.zenkit.com https://calendar.google.com https://www.youtube-nocookie.com https://devopstypeform.typeform.com"
+CSP_IMG_SRC="* data:"
+CSP_MEDIA_SRC="'self' https://s3.amazonaws.com/mofo-assets/foundation/video/"
+CSP_SCRIPT_SRC="'self' 'unsafe-inline' https://www.google-analytics.com/analytics.js http://*.shpg.org/ https://comments.mozillafoundation.org/ https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com https://embed.typeform.com"
+CSP_STYLE_SRC="'self' 'unsafe-inline' https://code.cdn.mozilla.net https://fonts.googleapis.com  https://platform.twitter.com"
 
 # TEST ENVIRONMENT VALUES
 


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/5026 and also fixes those damn env errors in docker by double-quoting all CSP strings.