### PR TITLE
added software product and cypress route

### DIFF
--- a/cypress/integration/endpoint-tests.js
+++ b/cypress/integration/endpoint-tests.js
@@ -147,8 +147,15 @@ describe(`Visual regression testing for foundation.mozilla.org`, () => {
     cy.percySnapshot();
   });
 
-  it(`PNI product page`, function () {
+  it(`PNI general product page`, function () {
     cy.visit(`/en/privacynotincluded/products/percy-cypress/`);
+    cy.window().its(`bg-main-js:react:finished`).should(`equal`, true);
+    cy.wait(500);
+    cy.percySnapshot();
+  });
+
+  it(`PNI software product page`, function () {
+    cy.visit(`/en/privacynotincluded/products/percy-cypress-app/`);
     cy.window().its(`bg-main-js:react:finished`).should(`equal`, true);
     cy.wait(500);
     cy.percySnapshot();

--- a/network-api/networkapi/buyersguide/factory.py
+++ b/network-api/networkapi/buyersguide/factory.py
@@ -117,6 +117,10 @@ class ProductFactory(DjangoModelFactory):
     signup_requires_third_party_account = LazyFunction(get_extended_yes_no_value)
     signup_requirement_explanation = Faker('sentence')
 
+    how_does_it_use_data_collected = Faker('sentence')
+    data_collection_policy_is_bad = Faker('boolean')
+    user_friendly_privacy_policy = LazyFunction(get_extended_yes_no_value)
+
     meets_minimum_security_standards = Faker('boolean')
     show_ding_for_minimum_security_standards = Faker('boolean')
     uses_encryption = LazyFunction(get_extended_yes_no_value)
@@ -159,8 +163,6 @@ class GeneralProductFactory(ProductFactory):
     biometric_data_collected = Faker('sentence')
     social_data_collected = Faker('sentence')
 
-    how_does_it_use_data_collected = Faker('sentence')
-    data_collection_policy_is_bad = Faker('boolean')
     how_can_you_control_your_data = Faker('sentence')
     data_control_policy_is_bad = Faker('boolean')
 

--- a/network-api/networkapi/buyersguide/factory.py
+++ b/network-api/networkapi/buyersguide/factory.py
@@ -18,6 +18,7 @@ from networkapi.buyersguide.models import (
     Update,
     ProductPrivacyPolicyLink,
     GeneralProduct,
+    SoftwareProduct,
     BuyersGuideProductCategory,
     RangeVote,
     BooleanVote,
@@ -111,33 +112,10 @@ class ProductFactory(DjangoModelFactory):
 
     worst_case = Faker('sentence')
 
-    camera_app = LazyFunction(get_extended_yes_no_value)
-    camera_device = LazyFunction(get_extended_yes_no_value)
-    microphone_app = LazyFunction(get_extended_yes_no_value)
-    microphone_device = LazyFunction(get_extended_yes_no_value)
-    location_app = LazyFunction(get_extended_yes_no_value)
-    location_device = LazyFunction(get_extended_yes_no_value)
-
     signup_requires_email = LazyFunction(get_extended_yes_no_value)
     signup_requires_phone = LazyFunction(get_extended_yes_no_value)
     signup_requires_third_party_account = LazyFunction(get_extended_yes_no_value)
     signup_requirement_explanation = Faker('sentence')
-
-    personal_data_collected = Faker('sentence')
-    biometric_data_collected = Faker('sentence')
-    social_data_collected = Faker('sentence')
-
-    how_does_it_use_data_collected = Faker('sentence')
-    data_collection_policy_is_bad = Faker('boolean')
-    how_can_you_control_your_data = Faker('sentence')
-    data_control_policy_is_bad = Faker('boolean')
-
-    company_track_record = get_random_option(['Great', 'Average', 'Needs Improvement', 'Bad'])
-    track_record_is_bad = Faker('boolean')
-    track_record_details = Faker('sentence')
-
-    offline_capable = LazyFunction(get_extended_yes_no_value)
-    offline_use_description = Faker('sentence')
 
     meets_minimum_security_standards = Faker('boolean')
     show_ding_for_minimum_security_standards = Faker('boolean')
@@ -156,11 +134,6 @@ class ProductFactory(DjangoModelFactory):
     def set_privacy_policy_link(self, create, extracted, **kwargs):
         ProductPrivacyPolicyLinkFactory.create(product=self)
 
-    uses_ai = LazyFunction(get_extended_yes_no_value)
-    ai_uses_personal_data = LazyFunction(get_extended_yes_no_value)
-    ai_is_transparent = LazyFunction(get_extended_yes_no_value)
-    ai_helptext = Faker('sentence')
-
     phone_number = Faker('phone_number')
     live_chat = Faker('url')
     email = Faker('email')
@@ -171,17 +144,84 @@ class ProductFactory(DjangoModelFactory):
     # updates...
 
 
+class GeneralProductFactory(ProductFactory):
+    class Meta:
+        model = GeneralProduct
+
+    camera_app = LazyFunction(get_extended_yes_no_value)
+    camera_device = LazyFunction(get_extended_yes_no_value)
+    microphone_app = LazyFunction(get_extended_yes_no_value)
+    microphone_device = LazyFunction(get_extended_yes_no_value)
+    location_app = LazyFunction(get_extended_yes_no_value)
+    location_device = LazyFunction(get_extended_yes_no_value)
+
+    personal_data_collected = Faker('sentence')
+    biometric_data_collected = Faker('sentence')
+    social_data_collected = Faker('sentence')
+
+    how_does_it_use_data_collected = Faker('sentence')
+    data_collection_policy_is_bad = Faker('boolean')
+    how_can_you_control_your_data = Faker('sentence')
+    data_control_policy_is_bad = Faker('boolean')
+
+    company_track_record = get_random_option(['Great', 'Average', 'Needs Improvement', 'Bad'])
+    track_record_is_bad = Faker('boolean')
+    track_record_details = Faker('sentence')
+
+    offline_capable = LazyFunction(get_extended_yes_no_value)
+    offline_use_description = Faker('sentence')
+
+    @post_generation
+    def set_privacy_policy_link(self, create, extracted, **kwargs):
+        ProductPrivacyPolicyLinkFactory.create(product=self)
+
+    uses_ai = LazyFunction(get_extended_yes_no_value)
+    ai_uses_personal_data = LazyFunction(get_extended_yes_no_value)
+    ai_is_transparent = LazyFunction(get_extended_yes_no_value)
+    ai_helptext = Faker('sentence')
+
+
+class SoftwareProductFactory(ProductFactory):
+    class Meta:
+        model = SoftwareProduct
+
+    handles_recordings_how = Faker('sentence')
+    recording_alert = LazyFunction(get_extended_yes_no_value)
+    recording_alert_helptext = Faker('sentence')
+    medical_privacy_compliant = Faker('boolean')
+    medical_privacy_compliant_helptext = Faker('sentence')
+    host_controls = Faker('sentence')
+    easy_to_learn_and_use = Faker('boolean')
+    easy_to_learn_and_use_helptext = Faker('sentence')
+
+
 def generate(seed):
     reseed(seed)
 
-    print('Generating fixed Buyer\'s Guide Product for visual regression testing')
-    ProductFactory.create(
+    print('Generating fixed Buyer\'s Guide GeneralProduct for visual regression testing')
+    GeneralProductFactory.create(
         blurb='Visual Regression Testing',
         company='Percy',
         draft=False,
         email='percy@example.com',
         live_chat='https://example.com/percy/chat',
         name='percy cypress',
+        phone_number='1-555-555-5555',
+        price=350,
+        product_words=['Percy', 'Cypress'],
+        url='https://example.com/percy',
+        twitter='@TwitterHandle',
+        worst_case='Duplicate work that burns through screenshots'
+    )
+
+    print('Generating fixed Buyer\'s Guide SoftwareProduct for visual regression testing')
+    SoftwareProductFactory.create(
+        blurb='Visual Regression Testing',
+        company='Percy',
+        draft=False,
+        email='percy@example.com',
+        live_chat='https://example.com/percy/chat',
+        name='percy cypress app',
         phone_number='1-555-555-5555',
         price=350,
         product_words=['Percy', 'Cypress'],
@@ -198,7 +238,7 @@ def generate(seed):
     reseed(seed)
 
     print('Generating Buyer\'s Guide Products')
-    generate_fake_data(ProductFactory, 70)
+    generate_fake_data(GeneralProductFactory, 70)
 
     reseed(seed)
 

--- a/network-api/networkapi/buyersguide/factory.py
+++ b/network-api/networkapi/buyersguide/factory.py
@@ -223,7 +223,7 @@ def generate(seed):
         live_chat='https://example.com/percy/chat',
         name='percy cypress app',
         phone_number='1-555-555-5555',
-        price=350,
+        price='| Free',
         product_words=['Percy', 'Cypress'],
         url='https://example.com/percy',
         twitter='@TwitterHandle',


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/5387 by introducing a new software product in addition to the general product in load_fake_data, with an endpoint cypress test that can be picked up and checked by Percy