### PR TITLE
Mobile category nav

### DIFF
--- a/network-api/networkapi/buyersguide/templates/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/bg_base.html
@@ -78,12 +78,14 @@
   </div>
 
   {% block hero %}{% endblock %}
-  <nav class="category-nav text-center" title="{% trans "site navigation" context "Tooltip on menu items" %}">
+
+  {% include "partials/multipage_nav_mobile.html" with pni_category_nav=True wrapper_classes="mt-0" %}
+  <nav id="multipage-nav" class="pni-category-nav text-center d-none d-md-block" title="{% trans "site navigation" context "Tooltip on menu items" %}">
     <div class="container">
       <div class="row">
         <div class="col">
           {% url 'buyersguide-home' as home_url %}
-          <a class="{% bg_active_nav request.get_full_path home_url %}" href="{{ home_url }}">{% trans "All" %}</a>
+          <a class="multipage-link {% bg_active_nav request.get_full_path home_url %}" href="{{ home_url }}">{% trans "All" %}</a>
           {% category_nav request.get_full_path category categories %}
         </div>
       </div>

--- a/network-api/networkapi/buyersguide/templates/category_nav_links.html
+++ b/network-api/networkapi/buyersguide/templates/category_nav_links.html
@@ -4,7 +4,7 @@
 {% if cat.hidden == False %}
 {% if cat.published_product_count > 0 %}
 {% url 'category-view' cat.slug as cat_url %}
-<a class="{% check_active_category current_category cat %}{% if cat.featured is True %} featured{% endif %}" href="{{ cat_url }}" data-name="{{ cat.name }}">{{ cat.name }}</a>
+<a class="multipage-link {% check_active_category current_category cat %}{% if cat.featured is True %} featured{% endif %}" href="{{ cat_url }}" data-name="{{ cat.name }}">{{ cat.name }}</a>
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/network-api/networkapi/templates/partials/multipage_nav_mobile.html
+++ b/network-api/networkapi/templates/partials/multipage_nav_mobile.html
@@ -1,7 +1,7 @@
 {% if singleton_page == False or always_show_mobile_nav == True or pni_category_nav == True %}
 <div class="d-md-none {{wrapper_classes}}" id="multipage-nav-mobile">
-  <div class="container{% if pni_category_nav == True %}-fluid{% endif %}">
-    <div class="row px-3">
+  <div class="container">
+    <div class="row px-3 {% if pni_category_nav == True %}px-sm-0{% endif %}">
       <div class="col-12"></div>
     </div>
   </div>

--- a/network-api/networkapi/templates/partials/multipage_nav_mobile.html
+++ b/network-api/networkapi/templates/partials/multipage_nav_mobile.html
@@ -1,6 +1,6 @@
 {% if singleton_page == False or always_show_mobile_nav == True or pni_category_nav == True %}
 <div class="d-md-none {{wrapper_classes}}" id="multipage-nav-mobile">
-  <div class="container">
+  <div class="container{% if pni_category_nav == True %}-fluid{% endif %}">
     <div class="row px-3">
       <div class="col-12"></div>
     </div>

--- a/network-api/networkapi/templates/partials/multipage_nav_mobile.html
+++ b/network-api/networkapi/templates/partials/multipage_nav_mobile.html
@@ -1,4 +1,4 @@
-{% if singleton_page == False or always_show_mobile_nav == True %}
+{% if singleton_page == False or always_show_mobile_nav == True or pni_category_nav == True %}
 <div class="d-md-none {{wrapper_classes}}" id="multipage-nav-mobile">
   <div class="container">
     <div class="row px-3">

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -9,6 +9,7 @@ import {
 } from "../common";
 
 import { injectReactComponents, bindEventHandlers } from "./index";
+import injectMultipageNav from "../foundation/inject-react/multipage-nav.js";
 
 import primaryNav from "../primary-nav.js";
 
@@ -108,6 +109,7 @@ let main = {
   injectReactComponents() {
     injectCommonReactComponents(apps, networkSiteURL, csrfToken);
     injectReactComponents(apps, networkSiteURL, csrfToken);
+    injectMultipageNav(apps);
   },
 
   initPageSpecificScript() {

--- a/source/sass/buyers-guide/bg-main.scss
+++ b/source/sass/buyers-guide/bg-main.scss
@@ -28,6 +28,7 @@ html {
 
 @import "../../js/buyers-guide/components/creepometer/creepometer";
 @import "../../js/buyers-guide/components/creep-vote/creep-vote";
+@import "../../js/components/multipage-nav-mobile/multipage-nav-mobile";
 
 // Primary navigation extends from the base nav, but with tweaks
 @import "../components/primary-nav";

--- a/source/sass/buyers-guide/components/header.scss
+++ b/source/sass/buyers-guide/components/header.scss
@@ -1,14 +1,23 @@
 $category-nav-border-bottom-thickness: 4px;
 
-.category-nav {
-  background: $white;
-  overflow-x: auto;
-  white-space: nowrap;
+@mixin set-category-border-bottom-style() {
   border-bottom: 1px solid $gray-20;
+}
+
+.pni-category-nav,
+#multipage-nav-mobile {
   position: sticky;
   position: -webkit-sticky;
   top: 0;
-  z-index: 10;
+  z-index: calc(#{$zindex-sticky} - 1);
+}
+
+.pni-category-nav {
+  background: $white;
+  overflow-x: auto;
+  white-space: nowrap;
+
+  @include set-category-border-bottom-style();
 
   a {
     display: inline-block;
@@ -41,5 +50,15 @@ $category-nav-border-bottom-thickness: 4px;
         "../_images/buyers-guide/icon-video-app.svg"
       );
     }
+  }
+}
+
+#multipage-nav-mobile {
+  @include set-category-border-bottom-style();
+
+  background: $white;
+
+  .col-12 {
+    border: none;
   }
 }

--- a/source/sass/buyers-guide/views/catalog.scss
+++ b/source/sass/buyers-guide/views/catalog.scss
@@ -70,7 +70,9 @@ body.catalog {
 
     @media (min-width: $bp-sm) {
       --container-padding: 0.5em;
-      --initial-width: calc(2 * var(--container-padding) + var(--search-icon-size-desktop));
+      --initial-width: calc(
+        2 * var(--container-padding) + var(--search-icon-size-desktop)
+      );
       --expanded-width: calc(100% - var(--pni-checkbox-container-width) - 2em);
 
       position: absolute;
@@ -183,7 +185,7 @@ body.catalog {
         background: url(../_images/buyers-guide/filter/checkbox.svg);
 
         @media (min-width: $bp-sm) {
-          vertical-align: calc(-5px - var(--pni-checkbox-size) / 2)
+          vertical-align: calc(-5px - var(--pni-checkbox-size) / 2);
         }
       }
 
@@ -338,7 +340,7 @@ body.catalog {
     z-index: 3;
     position: sticky;
     position: -webkit-sticky;
-    top: 16px;
+    top: 30px;
     padding-top: 40px;
     padding-bottom: 9px;
     height: var(--expanded-sticky-height);

--- a/source/sass/components/multipage-nav.scss
+++ b/source/sass/components/multipage-nav.scss
@@ -9,7 +9,7 @@
 }
 
 #multipage-nav {
-  &:not(.vertical-nav) {
+  &:not(.vertical-nav):not(.pni-category-nav) {
     display: flex;
     flex-direction: row;
     align-items: stretch;


### PR DESCRIPTION
Repurpose foundation's site mobile 'multipage-nav' for PNI & add styling overrides to suit our needs

Closes #5417

https://foundation-s-issue-5417-3huxg6.herokuapp.com/en/privacynotincluded/

----

## Two designy things to mention

### 1. Dropdown items

Because mobile nav involved with complicated JS and HTML/CSS work, I wanted to reuse as much existing code as possible. When our existing mobile secondary nav expands, the nav links start after the first row (where the arrow is located). See https://foundation.mozilla.org/en/who-we-are/  example below:

<img src="https://user-images.githubusercontent.com/2896608/97911395-07067000-1d00-11eb-860b-71c533cd1b99.png" width=280>

Since I'm reusing most of the code with some styling changes for PNI mobile category nav, category nav links will show in a similar matter -- instead of showing links from the orange "All", we show everything after the first row. See below

<img src="https://user-images.githubusercontent.com/2896608/97910880-3ec0e800-1cff-11eb-8028-75b6efd1c341.png" width=280>

This is not exactly what [the design](https://app.abstract.com/projects/fa246750-1c19-11e8-b2bf-9db5acc6ed5d/branches/master/commits/6332c2eba53b5d2906c4ec32d3ff8361276c9ad5/files/DBF82218-05B7-47F9-AD7C-8ABDFD109060/layers/18F86C85-5EF2-4DC8-A145-4D526C5540C5?collectionId=2d92eaf9-cfcb-4aa9-916d-d1a456f6e2cf&collectionLayerId=c1d22a98-9658-4c0f-94b8-a44f6266ca3f&mode=design) is for PNI but I hope we can make some compromise here to reduce code overhead. (Note that I've also reused the existing dropdown arrow icon instead of what was provided in the ticket)

### 2. Tablet category nav looks misaligned?

Because our site primary nav is already not following Bootstrap grid and same with the main PNI body content, the mobile category nav that got sandwiched in between looks kinda misaligned. Would love design feedback on this.

<img width="987" alt="image" src="https://user-images.githubusercontent.com/2896608/97912406-a11ae800-1d01-11eb-8818-0fe12aba0ba4.png">



