### PR TITLE
Hide pre-v4 products

### DIFF
--- a/network-api/networkapi/buyersguide/pagemodels/products/base.py
+++ b/network-api/networkapi/buyersguide/pagemodels/products/base.py
@@ -433,7 +433,7 @@ class Product(ClusterableModel):
     def is_current(self):
         d = self.review_date
         review = datetime(d.year, d.month, d.day)
-        cutoff = datetime(2019, 6, 1)
+        cutoff = datetime(2020, 10, 29)
         return cutoff < review
 
     @property


### PR DESCRIPTION
⚠️ **THIS SHOULD ONLY BE MERGED AND PUSHED WHEN WE ARE READY TO GO LIVE** :warning:

Probably the smallest PR in this entire four sprint period...

Closes https://github.com/mozilla/foundation.mozilla.org/issues/5463 by setting the product filter cutoff from the old July 1st, 2019, to October 29th, 2020.

(note that this cutoff only affects which product end up shown in our listings on the homepage/category pages)
