### PR TITLE
Mobile product nav

### DIFF
--- a/network-api/networkapi/buyersguide/templates/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/bg_base.html
@@ -85,7 +85,11 @@
       <div class="row">
         <div class="col">
           {% url 'buyersguide-home' as home_url %}
-          <a class="multipage-link {% bg_active_nav request.get_full_path home_url %}" href="{{ home_url }}">{% trans "All" %}</a>
+          {% if pagetype == "product" %}
+            <a class="multipage-link active" href="{{ home_url }}">{% trans "All" %}</a>
+          {% else %}
+            <a class="multipage-link {% bg_active_nav request.get_full_path home_url %}" href="{{ home_url }}">{% trans "All" %}</a>
+          {% endif %}
           {% category_nav request.get_full_path category categories %}
         </div>
       </div>

--- a/network-api/networkapi/buyersguide/views.py
+++ b/network-api/networkapi/buyersguide/views.py
@@ -69,6 +69,7 @@ def buyersguide_home(request):
     products = filter_draft_products(request, products)
 
     return render(request, 'buyersguide_home.html', {
+        'pagetype': 'homepage',
         'categories': BuyersGuideProductCategory.objects.all(),
         'products': products,
         'mediaUrl': MEDIA_URL,
@@ -94,6 +95,7 @@ def category_view(request, slug):
     products = filter_draft_products(request, products)
 
     return render(request, 'category_page.html', {
+        'pagetype': 'category',
         'categories': BuyersGuideProductCategory.objects.all(),
         'category': category,
         'products': products,
@@ -139,6 +141,7 @@ def product_view(request, slug):
     )
 
     return render(request, 'product_page.html', {
+        'pagetype': 'product',
         'categories': BuyersGuideProductCategory.objects.all(),
         'product': product_dict,
         'mediaUrl': MEDIA_URL,

--- a/source/sass/buyers-guide/views/product.scss
+++ b/source/sass/buyers-guide/views/product.scss
@@ -1,5 +1,11 @@
 $pni-product-breakpoint-larger: $bp-md;
 
+#view-product-page {
+  #multipage-nav-mobile {
+    margin-bottom: 0;
+  }
+}
+
 .product-header {
   padding-bottom: 88px;
   position: relative;

--- a/source/sass/buyers-guide/views/product.scss
+++ b/source/sass/buyers-guide/views/product.scss
@@ -3,6 +3,10 @@ $pni-product-breakpoint-larger: $bp-md;
 #view-product-page {
   #multipage-nav-mobile {
     margin-bottom: 0;
+
+    .multipage-link.active {
+      color: $gray-60;
+    }
   }
 }
 

--- a/source/sass/buyers-guide/views/product.scss
+++ b/source/sass/buyers-guide/views/product.scss
@@ -3,9 +3,15 @@ $pni-product-breakpoint-larger: $bp-md;
 #view-product-page {
   #multipage-nav-mobile {
     margin-bottom: 0;
+  }
 
-    .multipage-link.active {
-      color: $gray-60;
+  .multipage-link.active {
+    color: $gray-60;
+    border-bottom: none;
+
+    &:hover {
+      color: $black;
+      border-bottom: 3px solid $black;
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/5583 by making homepage/category page/product page aware of what pagetype they are, so that we can generate the nav normally for homepage/category, but for product always select "all" as default nav selection

Review URL: https://foundation-s-mobile-pro-necxpb.herokuapp.com/privacynotincluded