### PR TITLE
10. Added categories and routable views to the sitemap

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -537,13 +537,14 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         Add categories and route views to the sitemap for better search indexing.
         """
         sitemap = super().get_sitemap_urls(request)
+        last_modified = self.last_published_at or self.latest_revision_created_at
         # Add all the available Buyers Guide categories to the sitemap
         categories = BuyersGuideProductCategory.objects.filter(hidden=False)
         for category in categories:
             sitemap.append(
                 {
                     "location": self.full_url + self.reverse_subpage("category-view", args=(category.slug,)),
-                    "lastmod": (self.last_published_at or self.latest_revision_created_at),
+                    "lastmod": last_modified,
                 }
             )
 
@@ -557,7 +558,7 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
             sitemap.append(
                 {
                     "location": self.full_url + self.reverse_subpage(about_page),
-                    "lastmod": (self.last_published_at or self.latest_revision_created_at),
+                    "lastmod": last_modified,
                 }
             )
         return sitemap

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -533,9 +533,34 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         })
 
     def get_sitemap_urls(self, request):
-        # TODO add category URLs
-        urls = super().get_sitemap_urls(request)
-        return urls
+        """
+        Add categories and route views to the sitemap for better search indexing.
+        """
+        sitemap = super().get_sitemap_urls(request)
+        # Add all the available Buyers Guide categories to the sitemap
+        categories = BuyersGuideProductCategory.objects.filter(hidden=False)
+        for category in categories:
+            sitemap.append(
+                {
+                    "location": self.full_url + self.reverse_subpage("category-view", args=(category.slug,)),
+                    "lastmod": (self.last_published_at or self.latest_revision_created_at),
+                }
+            )
+
+        # Add all the available "subpages" (routes) to the sitemap, excluding categories and products.
+        # Categories are added above. Products will be their own Wagtail pages and get their own URLs because of that.
+        about_page_views = [
+            'how-to-use-view', 'about-why-view', 'press-view',
+            'contact-view', 'methodology-view', 'min-security-view'
+        ]
+        for about_page in about_page_views:
+            sitemap.append(
+                {
+                    "location": self.full_url + self.reverse_subpage(about_page),
+                    "lastmod": (self.last_published_at or self.latest_revision_created_at),
+                }
+            )
+        return sitemap
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)


### PR DESCRIPTION
Closes #5516 
Related PRs/issues #5489 

> Every BuyersguidePage.route needs a sitemap entry. Every category and product needs its own sitemap entries. 

Criteria:
- [x] Using `get_sitemap()` make sure all the routes are added. 
- [x] Make sure all categories are added (loop through them and add them to the list that `get_sitemap()` returns. 
- [x] Don't worry about adding products to the sitemap, they'll be added when a new page is created

This can be tested by creating a new BuyersGuidePage in the Wagtail admin. Then going to http://localhost:8000/sitemap.xml and searching for /about/ and /categories/ 