### PR TITLE
11. Write unit tests for buyersguide page

### DIFF
--- a/network-api/networkapi/buyersguide/management/commands/migrate_products.py
+++ b/network-api/networkapi/buyersguide/management/commands/migrate_products.py
@@ -193,17 +193,18 @@ class Command(BaseCommand):
                 new_product_page.get_or_create_votes()
                 # Use .to_dict() to pull out the old aggregated votes
                 product_dict = product.to_dict()
-                votes = product_dict['votes']['creepiness']['vote_breakdown']
-                values = [x for x in votes.values()]
-                new_product_page.set_votes(values)
-                new_product_page.current_vote_count = product_dict['votes']['total']
+                if hasattr(product_dict, 'votes'):
+                    votes = product_dict['votes']['creepiness']['vote_breakdown']
+                    values = [x for x in votes.values()]
+                    product_total = product_dict['votes']['total']
+                else:
+                    # Default vote "bin"
+                    values = [0, 0, 0, 0, 0]
+                    product_total = 0
 
-            # Save and/or publish the final page.
+            new_product_page.votes.set_votes(values)
+            new_product_page.current_vote_count = product_total
             new_product_page.save()
-            if not product.draft:
-                new_product_page.save_revision().publish()
-            else:
-                new_product_page.save_revision()
 
             # Always good to fresh from db when using Django Treebeard.
             buyersguide_page.refresh_from_db()

--- a/network-api/networkapi/buyersguide/management/commands/migrate_products.py
+++ b/network-api/networkapi/buyersguide/management/commands/migrate_products.py
@@ -1,4 +1,5 @@
 import ntpath
+import time
 
 from django.conf import settings
 from django.core.files.images import ImageFile
@@ -207,6 +208,8 @@ class Command(BaseCommand):
             # Always good to fresh from db when using Django Treebeard.
             buyersguide_page.refresh_from_db()
 
+        time.sleep(1)
+
         # Once all the ProductPages are added, add related_products
         # By writing a secondary for loop we can avoid attaching a legacy_product
         # to each ProductPage because they'll have slugs in common.
@@ -215,7 +218,11 @@ class Command(BaseCommand):
         # Loop through every ProductPage we now have.
         for product_page in ProductPage.objects.all():
             # Fetch the PNI Product that this page was created from.
-            product = Product.objects.get(slug=product_page.slug)
+            try:
+                product = Product.objects.get(slug=product_page.slug)
+            except Product.DoesNotExist:
+                self.debug_print(f"Skipping {product_page} because a ProductPage.slug={product_page.slug} was not found")  # noqa
+                continue
             # Loop through all the Product.related_products
             for related_product in product.related_products.all():
                 try:

--- a/network-api/networkapi/buyersguide/management/commands/migrate_products.py
+++ b/network-api/networkapi/buyersguide/management/commands/migrate_products.py
@@ -50,6 +50,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         products = Product.objects.all()
         buyersguide_page = self.get_or_create_buyers_guide()
+
         for product in products:
             # 1. Create ProductPage out of this product
             product = product.specific  # Get the specific class
@@ -154,10 +155,7 @@ class Command(BaseCommand):
 
             # Save revision and/or publish so we can add Orderables to this page.
             new_product_page.save()
-            if not product.draft:
-                new_product_page.save_revision().publish()
-            else:
-                new_product_page.save_revision()
+            new_product_page.save_revision()
 
             self.debug_print("\tCreated", new_product_page)
 
@@ -205,6 +203,11 @@ class Command(BaseCommand):
             new_product_page.votes.set_votes(values)
             new_product_page.current_vote_count = product_total
             new_product_page.save()
+            if not product.draft:
+                new_product_page.live = True
+                new_product_page.save_revision().publish()
+            else:
+                new_product_page.save_revision()
 
             # Always good to fresh from db when using Django Treebeard.
             buyersguide_page.refresh_from_db()

--- a/network-api/networkapi/buyersguide/management/commands/migrate_products.py
+++ b/network-api/networkapi/buyersguide/management/commands/migrate_products.py
@@ -201,7 +201,7 @@ class Command(BaseCommand):
                     product_total = 0
 
             new_product_page.votes.set_votes(values)
-            new_product_page.current_vote_count = product_total
+            new_product_page.creepiness_value = product_total
             new_product_page.save()
             if not product.draft:
                 new_product_page.live = True

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -814,6 +814,7 @@ class TestProductPage(BuyersGuideTestMixin):
         self.assertTrue(hasattr(self.product_page.votes, 'set_votes'))
 
 
+@override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
 class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestMixin):
 
     def test_successful_vote(self):

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -621,21 +621,21 @@ class TestBuyersGuidePage(BuyersGuideTestMixin):
         category = BuyersGuideProductCategory.objects.first()
         url = self.bg.url + self.bg.reverse_subpage('category-view', args=(category.slug,))
 
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context['products']), 0)
-
-        # Add BuyersGuideProductCategory
-        category_orderable = ProductPageCategory(
-            product=self.product_page,
-            category=category,
-        )
-        category_orderable.save()
-        self.product_page.product_categories.add(category_orderable)
-        self.product_page.save_revision().publish()
-
         # Need to set dummy cache
         with self.settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}}):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.context['products']), 0)
+
+            # Add BuyersGuideProductCategory
+            category_orderable = ProductPageCategory(
+                product=self.product_page,
+                category=category,
+            )
+            category_orderable.save()
+            self.product_page.product_categories.add(category_orderable)
+            self.product_page.save_revision().publish()
+
             response = self.client.get(url)
             self.assertEqual(len(response.context['products']), 1)
 

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -823,7 +823,6 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestMixin):
 
         response = self.client.post(self.product_page.url, {
             'value': 25,
-            'productID': self.product_page.id
         }, format='json')
         self.assertEqual(response.status_code, 200)
 
@@ -836,7 +835,6 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestMixin):
 
         response = self.client.post(self.product_page.url, {
             'value': 100,
-            'productID': self.product_page.id
         }, format='json')
         self.assertEqual(response.status_code, 200)
 
@@ -847,40 +845,17 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestMixin):
         self.assertEqual(self.product_page.current_tally, 2)
         self.assertEqual(self.product_page.creepiness_value, 125)
 
-    def test_vote_values_as_strings(self):
-        # Reset votes
-        response = self.client.post(self.product_page.url, {
-            'value': 25,
-            'productID': "string as an id"
-        }, format='json')
-        self.assertEqual(response.status_code, 405)
-
-        response = self.client.post(self.product_page.url, {
-            'value': "twenty five",
-            'productID': self.product_page.id
-        }, format='json')
-        self.assertEqual(response.status_code, 405)
-
     def test_bad_vote_value(self):
         # vote = 500
         response = self.client.post(self.product_page.url, {
             'value': -1,
-            'productID': self.product_page.id
         }, format='json')
         self.assertEqual(response.status_code, 405)
 
         response = self.client.post(self.product_page.url, {
             'value': 101,
-            'productID': self.product_page.id
         }, format='json')
         self.assertEqual(response.status_code, 405)
-
-    def test_missing_product_vote(self):
-        response = self.client.post(self.product_page.url, {
-            'value': 25,
-            'productID': 9999
-        }, format='json')
-        self.assertEqual(response.status_code, 404)
 
     def test_vote_on_draft_page(self):
         self.product_page.live = False

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -833,7 +833,7 @@ class TestProductPage(BuyersGuideTestMixin):
         self.assertTrue(hasattr(self.product_page.votes, 'set_votes'))
 
 
-class BuyersGuideVoteTest(APITestCase, BuyersGuideTestMixin):
+class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestMixin):
 
     def test_successful_vote(self):
         # Reset votes

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -767,18 +767,18 @@ class TestProductPage(BuyersGuideTestMixin):
         self.assertEqual(current_tally, 25)
 
     def test_creepiness(self):
-        self.product_page.current_vote_count = 100
+        self.product_page.creepiness_value = 100
         self.product_page.votes.set_votes([5, 5, 5, 5, 5])
         creepiness = self.product_page.creepiness
         self.assertEqual(creepiness, 4)
 
-        self.product_page.current_vote_count = 0
+        self.product_page.creepiness_value = 0
         self.product_page.votes.set_votes([0, 0, 0, 0, 0])
         creepiness = self.product_page.creepiness
         self.assertEqual(creepiness, 0)
 
     def test_get_voting_json(self):
-        self.product_page.current_vote_count = 60
+        self.product_page.creepiness_value = 60
         self.product_page.votes.set_votes([1, 2, 3, 4, 5])
         creepiness = self.product_page.creepiness
         self.assertEqual(creepiness, 4)

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -638,17 +638,18 @@ class TestBuyersGuidePage(BuyersGuideTestMixin):
         self.assertEqual(len(response.context['products']), 0)
 
         # Add BuyersGuideProductCategory
-        orderable = ProductPageCategory(
+        category_orderable = ProductPageCategory(
             product=self.product_page,
             category=category,
         )
-        orderable.save()
+        category_orderable.save()
+        self.product_page.product_categories.add(category_orderable)
+        self.product_page.save_revision().publish()
 
-        response = self.client.get(url)
-        self.assertEqual(len(response.context['products']), 1)
-
-
-        import pudb; pu.db()
+        # Need to set dummy cache
+        with self.settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}}):
+            response = self.client.get(url)
+            self.assertEqual(len(response.context['products']), 1)
 
 
 class TestMigrateProducts(BuyersGuideTestMixin):

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -600,6 +600,21 @@ class TestBuyersGuidePage(BuyersGuideTestMixin):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.redirect_chain[0][0], product.url)
 
+    def test_sitemap_entries(self):
+        response = self.client.get('/sitemap.xml')
+        context = response.context
+
+        self.assertEqual(context.template_name, 'sitemap.xml')
+        self.assertContains(response, 'about/')
+        self.assertContains(response, 'about/why/')
+        self.assertContains(response, 'about/press/')
+        self.assertContains(response, 'about/contact/')
+        self.assertContains(response, 'about/methodology/')
+        self.assertContains(response, 'about/meets-minimum-security-standards/')
+
+        categories = BuyersGuideProductCategory.objects.filter(hidden=False)
+        for category in categories:
+            self.assertContains(response, f'categories/{category.slug}/')
 
 class TestMigrateProducts(BuyersGuideTestMixin):
 

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -807,8 +807,7 @@ class TestProductPage(BuyersGuideTestMixin):
         # Delete potential votes
         self.product_page.votes.delete()
         self.product_page.votes = None
-        self.product_page.save()
-        self.assertFalse(hasattr(self.product_page.votes, 'set_votes'))
+        self.assertEqual(self.product_page.votes, None)
 
         votes = self.product_page.get_or_create_votes()
         self.assertEqual(votes, [0, 0, 0, 0, 0])

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -832,6 +832,7 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestMixin):
         votes = self.product_page.votes.get_votes()
         self.assertListEqual(votes, [0, 1, 0, 0, 0])
         self.assertEqual(self.product_page.current_tally, 1)
+        self.assertEqual(self.product_page.creepiness_value, 25)
 
         response = self.client.post(self.product_page.url, {
             'value': 100,
@@ -844,6 +845,7 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestMixin):
         votes = self.product_page.votes.get_votes()
         self.assertListEqual(votes, [0, 1, 0, 0, 1])
         self.assertEqual(self.product_page.current_tally, 2)
+        self.assertEqual(self.product_page.creepiness_value, 125)
 
     def test_vote_values_as_strings(self):
         # Reset votes

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -522,47 +522,30 @@ class TestBuyersGuidePage(BuyersGuideTestMixin):
         response = self.client.get(self.bg.url)
         self.assertEqual(response.status_code, 200)
 
-    def test_buyersguide_about_how_to_use_view(self):
-        url = self.bg.reverse_subpage('how-to-use-view')
-        self.assertEqual(url, 'about/')
+    def about_url_test(self, view_name, target_url, template):
+        url = self.bg.reverse_subpage(view_name)
+        self.assertEqual(url, target_url)
         response = self.client.get(self.bg.url + url)
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'about/how_to_use.html')
+        self.assertTemplateUsed(response, f'about/{template}.html')
+
+    def test_buyersguide_about_how_to_use_view(self):
+        self.about_url_test('how-to-use-view', 'about/', 'how_to_use')
 
     def test_buyersguide_about_why_view(self):
-        url = self.bg.reverse_subpage('about-why-view')
-        self.assertEqual(url, 'about/why/')
-        response = self.client.get(self.bg.url + url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'about/why_we_made.html')
+        self.about_url_test('about-why-view', 'about/why/', 'why_we_made')
 
     def test_buyersguide_about_press_view(self):
-        url = self.bg.reverse_subpage('press-view')
-        self.assertEqual(url, 'about/press/')
-        response = self.client.get(self.bg.url + url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'about/press.html')
+        self.about_url_test('press-view', 'about/press/', 'press')
 
     def test_buyersguide_about_contact_view(self):
-        url = self.bg.reverse_subpage('contact-view')
-        self.assertEqual(url, 'about/contact/')
-        response = self.client.get(self.bg.url + url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'about/contact.html')
+        self.about_url_test('contact-view', 'about/contact/', 'contact')
 
     def test_buyersguide_about_methodology_view(self):
-        url = self.bg.reverse_subpage('methodology-view')
-        self.assertEqual(url, 'about/methodology/')
-        response = self.client.get(self.bg.url + url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'about/methodology.html')
+        self.about_url_test('methodology-view', 'about/methodology/', 'methodology')
 
     def test_buyersguide_about_mss_view(self):
-        url = self.bg.reverse_subpage('min-security-view')
-        self.assertEqual(url, 'about/meets-minimum-security-standards/')
-        response = self.client.get(self.bg.url + url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'about/minimum_security.html')
+        self.about_url_test('min-security-view', 'about/meets-minimum-security-standards/', 'minimum_security')
 
     def test_buyersguide_category_route(self):
         # Missing category

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -469,7 +469,6 @@ class BuyersGuideTestMixin(WagtailPageTests):
 
         site = Site.objects.first()
         site.root_page = self.homepage
-        site.port = 80
         site.save()
 
     def get_or_create_buyers_guide(self):

--- a/network-api/networkapi/buyersguide/tests.py
+++ b/network-api/networkapi/buyersguide/tests.py
@@ -10,18 +10,28 @@ from rest_framework.test import APITestCase
 from django.test import TestCase, RequestFactory
 from datetime import date
 
-from networkapi.buyersguide.factory import ProductFactory
+from networkapi.buyersguide.factory import (
+    ProductFactory,
+    GeneralProductFactory,
+    SoftwareProductFactory,
+)
 from networkapi.buyersguide.models import (
     RangeVote,
     BooleanVote,
     GeneralProduct,
+    SoftwareProduct,
     BuyersGuideProductCategory
 )
 from networkapi.buyersguide.views import product_view, category_view, buyersguide_home
 
 from networkapi.wagtailpages.factory.homepage import WagtailHomepageFactory
 from networkapi.wagtailpages.pagemodels.base import Homepage
-from networkapi.wagtailpages.pagemodels.products import BuyersGuidePage, ProductPage
+from networkapi.wagtailpages.pagemodels.products import (
+    BuyersGuidePage,
+    ProductPage,
+    GeneralProductPage,
+    SoftwareProductPage,
+)
 
 from wagtail.core.models import Page, Site
 from wagtail.tests.utils import WagtailPageTests
@@ -464,8 +474,17 @@ class AboutViewTest(TestCase):
         self.assertEqual(response.status_code, 200, 'No redirect when a valid locale is specified')
 
 
-@override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
-class TestBuyersGuidePage(WagtailPageTests):
+class BuyersGuideTestMixin(WagtailPageTests):
+
+    def setUp(self):
+        # Ensure there's always a BuyersGuide Page
+        self.bg = self.get_or_create_buyers_guide()
+        self.product_page = self.get_or_create_product_page()
+
+        site = Site.objects.first()
+        site.root_page = self.homepage
+        site.port = 80
+        site.save()
 
     def get_or_create_buyers_guide(self):
         """
@@ -495,18 +514,28 @@ class TestBuyersGuidePage(WagtailPageTests):
         self.homepage = Homepage.objects.first()
         return buyersguide
 
-    def setUp(self):
-        # Ensure there's always a BuyersGuide Page
-        self.bg = self.get_or_create_buyers_guide()
-        self.product_page = self.get_or_create_product_page()
+    def get_or_create_product_page(self):
+        product_page = ProductPage.objects.first()
+        if not product_page:
+            product_page = ProductPage(
+                slug='product-page',
+                slug_en='product-page',
+                title='Product Page',
+                title_en='Product Page',
+                live=True,
+            )
+            self.bg.add_child(instance=product_page)
+            product_page.save_revision().publish()
+        return product_page
 
-        site = Site.objects.first()
-        site.root_page = self.homepage
-        site.port = 80
-        site.save()
+
+@override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
+class TestBuyersGuidePage(BuyersGuideTestMixin):
 
     def test_buyersguide_url(self):
         self.assertEqual(self.bg.slug, 'privacynotincluded-new')
+        response = self.client.get(self.bg.url)
+        self.assertEqual(response.status_code, 200)
 
     def test_buyersguide_about_routes(self):
         url = self.bg.reverse_subpage('how-to-use-view')
@@ -545,20 +574,6 @@ class TestBuyersGuidePage(WagtailPageTests):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'about/minimum_security.html')
 
-    def get_or_create_product_page(self):
-        product_page = ProductPage.objects.first()
-        if not product_page:
-            product_page = ProductPage(
-                slug='product-page',
-                slug_en='product-page',
-                title='Product Page',
-                title_en='Product Page',
-                live=True,
-            )
-            self.bg.add_child(instance=product_page)
-            product_page.save_revision().publish()
-        return product_page
-
     def test_buyersguide_category_route(self):
         # Missing category
         missing_category = 'missing-category-slug'
@@ -584,3 +599,106 @@ class TestBuyersGuidePage(WagtailPageTests):
         response = self.client.get(f'/en/{self.bg.slug}/products/{product.slug}/', follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.redirect_chain[0][0], product.url)
+
+
+class TestMigrateProducts(BuyersGuideTestMixin):
+
+    def setUp(self):
+        # Create products
+        super().setUp()
+        for i in range(50):
+            general_product = GeneralProductFactory()  # noqa
+            software_product = SoftwareProductFactory()  # noqa
+
+        self.general_product_fields = [
+            'slug', 'privacy_ding', 'adult_content', 'uses_wifi', 'uses_bluetooth',
+            'company', 'blurb', 'price', 'worst_case',
+            'signup_requires_email', 'signup_requires_phone',
+            'signup_requires_third_party_account', 'signup_requirement_explanation',
+            'how_does_it_use_data_collected', 'data_collection_policy_is_bad',
+            'user_friendly_privacy_policy', 'show_ding_for_minimum_security_standards',
+            'meets_minimum_security_standards', 'uses_encryption',
+            'uses_encryption_helptext', 'security_updates', 'security_updates_helptext',
+            'strong_password', 'strong_password_helptext', 'manage_vulnerabilities',
+            'manage_vulnerabilities_helptext', 'privacy_policy', 'privacy_policy_helptext',
+            'phone_number', 'live_chat', 'email', 'twitter'
+        ]
+
+    def before_migrate(self):
+        total_product_pages = ProductPage.objects.count()
+        self.assertEqual(total_product_pages, 1)
+
+        total_general_products = GeneralProduct.objects.count()
+        self.assertEqual(total_general_products, 50)
+
+        total_software_products = SoftwareProduct.objects.count()
+        self.assertEqual(total_software_products, 50)
+
+    def migrate(self):
+        call_command('migrate_products')
+
+    def after_migrate(self):
+        self.assertEqual(ProductPage.objects.count(), 101)
+        self.assertEqual(GeneralProductPage.objects.count(), 50)
+        self.assertEqual(SoftwareProductPage.objects.count(), 50)
+        self.assertEqual(GeneralProduct.objects.count(), 50)
+        self.assertEqual(SoftwareProduct.objects.count(), 50)
+
+    def check_software_products_match(self):
+        """
+        Compare all SoftwareProducts with all SoftwareProductPages and all their fields
+        """
+        software_products = SoftwareProduct.objects.all()
+
+        for product in software_products:
+            # Find the equiv ProductPage.
+            product_page = ProductPage.objects.get(slug=product.slug).specific
+            # Get all the General Product Page fields.
+            specific_fields = self.general_product_fields + [
+                'medical_privacy_compliant', 'easy_to_learn_and_use', 'handles_recordings_how',
+                'recording_alert', 'recording_alert_helptext', 'medical_privacy_compliant_helptext',
+                'host_controls', 'easy_to_learn_and_use_helptext'
+            ]
+            # For every field, compare it to the old field in the Product object
+            for field in specific_fields:
+                self.assertEqual(
+                    getattr(product, field),
+                    getattr(product_page, field),
+                    f"{field} did not match on product: {product} (id:{product.id})",
+                )
+
+    def check_general_products_match(self):
+        """
+        Compare all GeneralProducts with all GeneralProductPages and all their fields
+        """
+        general_products = GeneralProduct.objects.all()
+        for product in general_products:
+            # Find the equiv ProductPage.
+            product_page = ProductPage.objects.get(slug=product.slug).specific
+            # Get all the General Product Page fields.
+            specific_fields = self.general_product_fields + [
+                'camera_device', 'camera_app', 'microphone_device', 'microphone_app',
+                'location_device', 'location_app', 'personal_data_collected',
+                'biometric_data_collected', 'social_data_collected',
+                'how_can_you_control_your_data', 'data_control_policy_is_bad',
+                'track_record_choices', 'company_track_record', 'track_record_is_bad',
+                'track_record_details', 'offline_capable', 'offline_use_description',
+                'uses_ai', 'ai_uses_personal_data', 'ai_is_transparent', 'ai_helptext'
+            ]
+            # For every field, compare it to the old field in the Product object
+            for field in specific_fields:
+                self.assertEqual(
+                    getattr(product, field),
+                    getattr(product_page, field),
+                    f"{field} did not match on product: {product} (id:{product.id})",
+                )
+
+    def test_migration(self):
+        """
+        All tests go in here to ensure they are executed in the proper order
+        """
+        self.before_migrate()
+        self.migrate()
+        self.after_migrate()
+        self.check_general_products_match()
+        self.check_software_products_match()

--- a/network-api/networkapi/wagtailpages/migrations/0017_product_voting.py
+++ b/network-api/networkapi/wagtailpages/migrations/0017_product_voting.py
@@ -33,6 +33,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='productpage',
             name='votes',
-            field=models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='votes', to='wagtailpages.ProductPageVotes'),
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='votes', to='wagtailpages.ProductPageVotes'),
         ),
     ]

--- a/network-api/networkapi/wagtailpages/migrations/0017_product_voting.py
+++ b/network-api/networkapi/wagtailpages/migrations/0017_product_voting.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('wagtailpages', '0015_auto_20201110_1957'),
-        ('wagtailpages', '0016_merge_20201117_1917.py'),
+        ('wagtailpages', '0016_merge_20201117_1917'),
     ]
 
     operations = [

--- a/network-api/networkapi/wagtailpages/migrations/0017_product_voting.py
+++ b/network-api/networkapi/wagtailpages/migrations/0017_product_voting.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='productpage',
-            name='current_vote_count',
+            name='creepiness_value',
             field=models.IntegerField(default=0),
         ),
         migrations.CreateModel(

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -343,7 +343,7 @@ class ProductPage(FoundationMetadataPageMixin, Page):
 
     @property
     def current_tally(self):
-        return sum(self.votes.get_or_create_votes())
+        return sum(self.get_or_create_votes())
 
     @property
     def creepiness(self):

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -575,13 +575,6 @@ class ProductPage(FoundationMetadataPageMixin, Page):
 
         return super().serve(request, *args, **kwargs)
 
-    def save(self, *args, **kwargs):
-        # When a new ProductPage is created, ensure a vote bin always exists.
-        # We can use save() or a post-save Wagtail hook.
-        save = super().save(*args, **kwargs)
-        self.get_or_create_votes()
-        return save
-
     class Meta:
         verbose_name = "Product Page"
 

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -343,7 +343,10 @@ class ProductPage(FoundationMetadataPageMixin, Page):
 
     @property
     def current_tally(self):
-        return sum(self.votes.get_votes())
+        if self.votes:
+            return sum(self.votes.get_votes())
+        else:
+            return 0
 
     @property
     def creepiness(self):

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -521,10 +521,9 @@ class ProductPage(FoundationMetadataPageMixin, Page):
             # If the request is POST. Parse the body.
             data = json.loads(request.body)
             # If the POST body has a productID and value, it's someone voting on the product
-            if data.get('productID') and data.get("value"):
+            if data.get("value"):
                 # Product ID and Value can both be zero. It's impossible to get a Page with ID of zero.
                 try:
-                    product_id = int(data['productID'])  # ie. 68
                     value = int(data["value"])  # ie. 0 to 100
                 except ValueError:
                     return HttpResponseNotAllowed('Product ID or value is invalid')
@@ -533,7 +532,7 @@ class ProductPage(FoundationMetadataPageMixin, Page):
                     return HttpResponseNotAllowed('Cannot save vote')
 
                 try:
-                    product = ProductPage.objects.get(id=product_id)
+                    product = ProductPage.objects.get(pk=self.id)
                     # If the product exists but isn't live and the user isn't logged in..
                     if (not product.live and not request.user.is_authenticated) or not product:
                         return HttpResponseNotFound("Product does not exist")
@@ -869,7 +868,7 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         # Find product by it's slug and redirect to the product page
         # If no product is found, redirect to the BuyersGuide page
         product = get_object_or_404(ProductPage, slug=slug)
-        return redirect(product.url, permanent=True)
+        return redirect(product.url)
 
     @route(r'^categories/(?P<slug>[\w\W]+)/', name='category-view')
     def categories_page(self, request, slug):

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -332,7 +332,7 @@ class ProductPage(FoundationMetadataPageMixin, Page):
     )
 
     # Un-editable voting fields. Don't add these to the content_panels.
-    current_vote_count = models.IntegerField(default=0)  # The total points for creepiness
+    creepiness_value = models.IntegerField(default=0)  # The total points for creepiness
     votes = models.ForeignKey(
         ProductPageVotes,
         on_delete=models.SET_NULL,
@@ -348,7 +348,7 @@ class ProductPage(FoundationMetadataPageMixin, Page):
     @property
     def creepiness(self):
         try:
-            average = self.current_vote_count / self.current_tally
+            average = self.creepiness_value / self.current_tally
         except ZeroDivisionError:
             average = 0
         return average
@@ -539,7 +539,7 @@ class ProductPage(FoundationMetadataPageMixin, Page):
                         return HttpResponseNotFound("Product does not exist")
 
                     # Save the new voting totals
-                    product.current_vote_count = product.current_vote_count + value
+                    product.creepiness_value = product.creepiness_value + value
 
                     # Add the vote to the vote bin
                     if not product.votes:

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.validators import int_list_validator
 from django.db import Error, models
-from django.http import Http404, HttpResponse, HttpResponseNotAllowed, HttpResponseServerError
+from django.http import HttpResponse, HttpResponseNotAllowed, HttpResponseServerError, HttpResponseNotFound
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import pgettext
 
@@ -364,7 +364,7 @@ class ProductPage(FoundationMetadataPageMixin, Page):
         votes = self.votes.get_votes()
         data = {
             'creepiness': {
-                'vote_breakdown':  {k:v for (k,v) in enumerate(votes)},
+                'vote_breakdown':  {k: v for (k, v) in enumerate(votes)},
                 'average': self.creepiness
             },
             'total': self.current_tally
@@ -542,7 +542,6 @@ class ProductPage(FoundationMetadataPageMixin, Page):
                         return HttpResponseNotFound("Product does not exist")
 
                     # Save the new voting totals
-                    # TODO: Confirm with @pomax this is the intended behaviour we desire.
                     product.current_vote_count = product.current_vote_count + value
 
                     # Add the vote to the vote bin

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -333,7 +333,7 @@ class ProductPage(FoundationMetadataPageMixin, Page):
 
     # Un-editable voting fields. Don't add these to the content_panels.
     current_vote_count = models.IntegerField(default=0)  # The total points for creepiness
-    votes = models.OneToOneField(
+    votes = models.ForeignKey(
         ProductPageVotes,
         on_delete=models.SET_NULL,
         null=True,
@@ -573,6 +573,13 @@ class ProductPage(FoundationMetadataPageMixin, Page):
         self.get_or_create_votes()
 
         return super().serve(request, *args, **kwargs)
+
+    def save(self, *args, **kwargs):
+        # When a new ProductPage is created, ensure a vote bin always exists.
+        # We can use save() or a post-save Wagtail hook.
+        save = super().save(*args, **kwargs)
+        self.get_or_create_votes()
+        return save
 
     class Meta:
         verbose_name = "Product Page"

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -870,7 +870,7 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         # Find product by it's slug and redirect to the product page
         # If no product is found, redirect to the BuyersGuide page
         product = get_object_or_404(ProductPage, slug=slug)
-        return redirect(product.url)
+        return redirect(product.url, permanent=True)
 
     @route(r'^categories/(?P<slug>[\w\W]+)/', name='category-view')
     def categories_page(self, request, slug):

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -343,10 +343,7 @@ class ProductPage(FoundationMetadataPageMixin, Page):
 
     @property
     def current_tally(self):
-        if self.votes:
-            return sum(self.votes.get_votes())
-        else:
-            return 0
+        return sum(self.votes.get_or_create_votes())
 
     @property
     def creepiness(self):

--- a/network-api/networkapi/wagtailpages/wagtail_hooks.py
+++ b/network-api/networkapi/wagtailpages/wagtail_hooks.py
@@ -94,3 +94,7 @@ def before_delete_page(request, page):
             pass
         else:
             uploader.destroy(page.cloudinary_image.public_id, invalidate=True)
+
+    if hasattr(page, 'votes'):
+        # Delete the vote from ProductPages
+        page.votes.delete()

--- a/network-api/networkapi/wagtailpages/wagtail_hooks.py
+++ b/network-api/networkapi/wagtailpages/wagtail_hooks.py
@@ -9,6 +9,8 @@ import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler
 from wagtail.core import hooks
 
+from networkapi.wagtailpages.pagemodels.products import ProductPage
+
 
 # Extended rich text features for our site
 @hooks.register('register_rich_text_features')
@@ -95,6 +97,6 @@ def before_delete_page(request, page):
         else:
             uploader.destroy(page.cloudinary_image.public_id, invalidate=True)
 
-    if hasattr(page, 'votes'):
+    if isinstance(page, ProductPage) and page.votes:
         # Delete the vote from ProductPages
         page.votes.delete()


### PR DESCRIPTION
Closes #5518 
Related PRs/issues #5489 

## Criteria:
- [x] Write tests for these new Wagtail views (the `@route`s). They dont need to be extensive since Wagtail comes with solid test coverage. But for routes that have custom logic we want to make sure:
  - [x] Routes are serving 200 http responses.
  - [x] Routes have the right products and categories in the `context` of each page.
  - [x] sitemap.xml is serving all the new page urls with the custom routes, categories and product urls.
  - [x] Test /privacynotincluded/produts/ and /privacynotincluded/categories/ return a 404 
  - [x] Test the /buyersguide/product/product_name/ redirects to the proper wagtail page URL 

- [x] Test the migration script 
  - [x] Test all Products get migrated. And that all fields are copied properly. 
  - [x] Test automatic creation of the buyersguide page. 
  - [x] Test ProductPages are using the right templates

- [x] Test BuyersGuide methods and custom properties 
- [x] Test ProductPage methods and custom properties 