### PR TITLE
Top level mozfest homepage in review app?

### DIFF
--- a/network-api/networkapi/mozfest/factory.py
+++ b/network-api/networkapi/mozfest/factory.py
@@ -66,10 +66,7 @@ def generate(seed):
     except MozfestHomepage.DoesNotExist:
         print('Generating a Homepage')
         # If this is a review app, make the root of the mozfest site a child of the main site
-        if is_review_app:
-            site_root = WagtailPage.objects.get(title='Homepage')
-        else:
-            site_root = WagtailPage.objects.get(id=1)
+        site_root = WagtailPage.objects.get(depth=1)
 
         home_page = MozfestHomepageFactory.create(
             parent=site_root,

--- a/network-api/networkapi/mozfest/factory.py
+++ b/network-api/networkapi/mozfest/factory.py
@@ -65,7 +65,6 @@ def generate(seed):
         print('Homepage already exists')
     except MozfestHomepage.DoesNotExist:
         print('Generating a Homepage')
-        # If this is a review app, make the root of the mozfest site a child of the main site
         site_root = WagtailPage.objects.get(depth=1)
 
         home_page = MozfestHomepageFactory.create(


### PR DESCRIPTION
Closes #5674 
Review app: https://foundation-s-5674-revie-4lxipk.herokuapp.com/

**Note**: Fun little review-app caveat:
When you change the Site settings to the Mozfest Homepage, it took a few minutes before this warning went away
![image](https://user-images.githubusercontent.com/4743971/100671972-821e6e80-331e-11eb-948d-3359b4e1e760.png)
As soon as this kicked in, it seemed to work. I'm not sure if this was caused by caching or a timed event on Herokus end, but this PR officially allows Mozfest Homepage to be beside the Foundation Homepage. And we can swap the Site root pages now. 