### PR TITLE
home.scss cleanup & update factory to include partner logo

### DIFF
--- a/network-api/networkapi/wagtailpages/factory/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/__init__.py
@@ -4,8 +4,9 @@ from . import (
     bannered_campaign_page,
     dear_internet_page,
     homepage_cause_statement_link,
-    homepage_take_action,
     homepage_features,
+    homepage_partner_logos,
+    homepage_take_action,
     homepage_usable_news,
     homepage,
     initiatives_page,
@@ -29,8 +30,9 @@ def generate(seed):
     dear_internet_page.generate(seed)
     # homepage_features.generate requires blog pages to exist first
     homepage_features.generate(seed)
-    homepage_usable_news.generate(seed)
+    homepage_partner_logos.generate(seed)
     homepage_take_action.generate(seed)
+    homepage_usable_news.generate(seed)
     initiatives_page.generate(seed)
     news_page.generate(seed)
     opportunity.generate(seed)

--- a/network-api/networkapi/wagtailpages/factory/homepage_partner_logos.py
+++ b/network-api/networkapi/wagtailpages/factory/homepage_partner_logos.py
@@ -1,13 +1,8 @@
 from random import choice
 
-from factory import (
-    Faker,
-    SubFactory
-)
+from factory import Faker
 
 from wagtail.images.models import Image
-
-from networkapi.wagtailpages.factory.image_factory import ImageFactory
 
 from networkapi.wagtailpages.models import (
     PartnerLogos,

--- a/network-api/networkapi/wagtailpages/factory/homepage_partner_logos.py
+++ b/network-api/networkapi/wagtailpages/factory/homepage_partner_logos.py
@@ -1,0 +1,40 @@
+from random import choice
+
+from factory import (
+    Faker,
+    SubFactory
+)
+
+from wagtail.images.models import Image
+
+from networkapi.wagtailpages.factory.image_factory import ImageFactory
+
+from networkapi.wagtailpages.models import (
+    PartnerLogos,
+)
+
+from networkapi.utility.faker.helpers import (
+    reseed,
+    get_homepage
+)
+
+
+def generate(seed):
+    print('Generating Partner Logos')
+
+    home_page = get_homepage()
+
+    reseed(seed)
+
+    all_images = list(Image.objects.all())
+
+    for i in range(3):
+        partner_logo_orderable = PartnerLogos.objects.create(
+            page=home_page,
+            logo=choice(all_images),
+            link=Faker('url').generate(),
+            name=Faker('text', max_nb_chars=30).generate(),
+        )
+        home_page.partner_logos.add(partner_logo_orderable)
+
+    home_page.save()

--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -16,6 +16,7 @@ from .pagemodels.base import (
     HomepageSpotlightPosts,
     ParticipateHighlights,
     ParticipateHighlights2,
+    PartnerLogos,
 )
 
 from .pagemodels.campaigns import (
@@ -120,6 +121,7 @@ __all__ = [
     ParticipateHighlights,
     ParticipateHighlights2,
     ParticipatePage2,
+    PartnerLogos,
     PeoplePage,
     Petition,
     PrimaryPage,

--- a/source/sass/variables.scss
+++ b/source/sass/variables.scss
@@ -2,11 +2,12 @@
 // for Bootstrap variable overrides use ./mofo-bootstrap/overrides/_variables.scss
 
 // Breakpoints (imported from Bootstrap)
+// https://getbootstrap.com/docs/4.1/layout/overview/#responsive-breakpoints
 
-$bp-xs: #{map-get($grid-breakpoints, xs)}; // < 576px
-$bp-sm: #{map-get($grid-breakpoints, sm)}; // >= 576px
-$bp-md: #{map-get($grid-breakpoints, md)}; // >= 768px
-$bp-lg: #{map-get($grid-breakpoints, lg)}; // >= 992px
-$bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px
+$bp-xs: #{map-get($grid-breakpoints, xs)}; // < 576px. Extra small devices (portrait phones)
+$bp-sm: #{map-get($grid-breakpoints, sm)}; // >= 576px. Small devices (landscape phones, 576px and up)
+$bp-md: #{map-get($grid-breakpoints, md)}; // >= 768px. Medium devices (tablets)
+$bp-lg: #{map-get($grid-breakpoints, lg)}; // >= 992px. Large devices (desktop)
+$bp-xl: #{map-get($grid-breakpoints, xl)}; // >= 1200px. Extra large devices (large desktops)
 
 $nav-full-logo-breakpoint: $bp-sm;

--- a/source/sass/views/home.scss
+++ b/source/sass/views/home.scss
@@ -185,7 +185,6 @@
         border-bottom: $border-thickness solid $black;
         position: relative;
         top: $border-thickness / 2;
-        z-index: 2;
       }
     }
   }
@@ -232,7 +231,6 @@
   background-position-y: top;
   background-position-x: right;
   position: relative;
-  z-index: 10;
   padding-top: 80px;
   padding-bottom: 80px;
 }
@@ -240,7 +238,6 @@
 .partner-section::before {
   content: "";
   position: absolute;
-  z-index: 0;
   top: 0;
   left: 0;
   width: 100%;
@@ -256,7 +253,6 @@
 
 .partner-section-logos {
   position: relative;
-  z-index: 1;
 }
 
 .partner-section-logo {

--- a/source/sass/views/home.scss
+++ b/source/sass/views/home.scss
@@ -251,7 +251,6 @@
 .partner-section-text {
   @include text-base-style("Nunito Sans", 300, $black, $white);
   @include set-text-size(20px, 30px);
-  font-size: 20px;
   max-width: 450px;
 }
 


### PR DESCRIPTION
Closes #5200 

There are toooooo many overrides uniquely to each homepage section so I couldn't get much clean up or refactor done. 
I ended up 
- added some inline comments to breakpoint variables for easy lookup
- remove extra z-index rules
- update factory to include homepage partner logos