### PR TITLE
ensure that 'All' is visible on mobile-size product view

### DIFF
--- a/network-api/networkapi/buyersguide/templates/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/bg_base.html
@@ -96,7 +96,7 @@
       <div class="row">
         <div class="col">
           {% url 'buyersguide-home' as home_url %}
-          {% if pagetype == "product" or pagetype == "about" %}
+          {% if page.product_type or pagetype == "product" or pagetype == "about" %}
             <a class="multipage-link active" href="{{ home_url }}">{% trans "All" %}</a>
           {% else %}
             <a class="multipage-link {% bg_active_nav request.get_full_path home_url %}" href="{{ home_url }}">{% trans "All" %}</a>


### PR DESCRIPTION
Related PRs/issues https://github.com/mozilla/foundation.mozilla.org/issues/5777

When on a product page at a narrow screen width, the word "All" should be visible in the dropdown nav.