### PR TITLE
remove is_current in favour of prefiltering the querysets

### DIFF
--- a/network-api/networkapi/buyersguide/templates/buyersguide/catalog.html
+++ b/network-api/networkapi/buyersguide/templates/buyersguide/catalog.html
@@ -66,8 +66,6 @@
   <div class="product-box-list-wrapper">
     <div class="product-box-list d-flex justify-content-center align-items-stretch flex-wrap">
       {% for product in products %}
-        {% if product.is_current %}
-
         <figure class="product-box d-flex flex-column justify-content-between{% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}{% if product.privacy_ding %} privacy-ding{% endif%}" data-creepiness="{{ product.creepiness }}">
           <div class="top-left-badge-container">
               {% if product.privacy_ding %}
@@ -104,7 +102,6 @@
             <input type="hidden" class="product-worst-case" value="{{ product.worst_case }}">
           </figcaption>
         </figure>
-        {% endif %}
       {% endfor %}
 
     </div>

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -51,7 +51,7 @@ def get_product_subset(authenticated, key, products):
     """
     filter a queryset based on our current cutoff date,
     as well as based on whether a user is authenticated
-    to the system or not (authenticated users get too
+    to the system or not (authenticated users get to
     see all products, including draft products)
     """
     products = products.filter(review_date__gte=public_cutoff_date)


### PR DESCRIPTION
Related PRs/issues https://github.com/mozilla/foundation.mozilla.org/issues/5777

This removes the `@property` decorated `is_current` and instead prefilters product lists on our current PNI cutoff date for which products we want folks to see. 

It also refactors the queryset caching code since both homepage and category pages basically do the exact same thing, given an initial product set and caching key.