### PR TITLE
post-generate category information for ProductPage

### DIFF
--- a/network-api/networkapi/buyersguide/pagemodels/product_category.py
+++ b/network-api/networkapi/buyersguide/pagemodels/product_category.py
@@ -50,7 +50,14 @@ class BuyersGuideProductCategory(models.Model):
 
     @property
     def published_product_count(self):
+        # TODO: REMOVE: LEGACY FUNCTION
         return Product.objects.filter(product_category=self, draft=False).count()
+
+    @property
+    def published_product_page_count(self):
+        # late-import to prevent a circular dependency.
+        from networkapi.wagtailpages.models import ProductPage
+        return ProductPage.objects.filter(product_categories__category=self, live=True).count()
 
     def __str__(self):
         return self.name

--- a/network-api/networkapi/buyersguide/templates/buyersguide/bg_base.html
+++ b/network-api/networkapi/buyersguide/templates/buyersguide/bg_base.html
@@ -86,7 +86,7 @@
             <a class="multipage-link {% if not category %} active{% endif %}" href="{{ page.url }}">{% trans "All" %}</a>
           {% endif %}
           {% for cat in categories %}
-            {% if cat.published_product_count > 0 %}
+            {% if cat.published_product_page_count > 0 %}
               {% routablepageurl page 'category-view' cat.slug as cat_url %}
               <a class="multipage-link {% check_active_category current_category cat %}{% if cat.featured is True %} featured{% endif %}{% if category == cat.slug %} active{% endif %}" href="{{ cat_url }}" data-name="{{ cat.name }}">{{ cat.name }}</a>
             {% endif %}

--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -89,7 +89,8 @@ from .pagemodels.products import (
     SoftwareProductPage,
     GeneralProductPage,
     BuyersGuidePage,
-    ProductPagePrivacyPolicyLink
+    ProductPagePrivacyPolicyLink,
+    ProductPageCategory
 )
 
 
@@ -129,6 +130,7 @@ __all__ = [
     Petition,
     PrimaryPage,
     ProductPage,
+    ProductPageCategory,
     ProductPagePrivacyPolicyLink,
     PublicationPage,
     RedirectingPage,


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/5875 by generating new "through" models for products that link them to one or more categories, with a new category function to check how many ProductPage instances are associated with it, rather than how many old Product instances are associated (with an update to the new bg_base template that uses that updated function as well for nav generation purposes)

Partially addresses https://github.com/mozilla/foundation.mozilla.org/issues/5886, too