### PR TITLE
Remove encryption help text from MSS field

### DIFF
--- a/network-api/networkapi/buyersguide/templates/buyersguide/product_page.html
+++ b/network-api/networkapi/buyersguide/templates/buyersguide/product_page.html
@@ -204,7 +204,7 @@
           {% blocktrans with url=min_sec_url asvar minimum_security_standards trimmed %}
             Does this product meet our <a id="mss-link" href="{{ url }}">Minimum Security Standards</a>?
           {% endblocktrans %}
-          {% include "fragments/product_criterion.html"  with  show_value_as_symbol=False  value=product.meets_minimum_security_standards|yes_no  help=product.uses_encryption_helptext         label=minimum_security_standards|safe    ding=product.show_ding_for_minimum_security_standards   class="meets-minimum-security-standards" %}
+          {% include "fragments/product_criterion.html"  with  show_value_as_symbol=False   value=product.meets_minimum_security_standards|yes_no   help=""   label=minimum_security_standards|safe   ding=product.show_ding_for_minimum_security_standards   class="meets-minimum-security-standards" %}
           <input type="checkbox" id="mss-accordion-toggle">
           <label for="mss-accordion-toggle"><span class="sr-only">{% trans "Toggle expandable section" context "Accessibility label for an accordion toggle" %}</span></label>
           <div id="mss-expandable">


### PR DESCRIPTION
Closes #5943

Makes the field help text for the MSS field an empty string (instead of being the entirely wrong encryption help text =)