### PR TITLE
Update a deprecated stylelint rule name

### DIFF
--- a/.stylelintrc-colors.js
+++ b/.stylelintrc-colors.js
@@ -3,7 +3,7 @@
     "rules": {
       "color-named": "never",
       "color-no-hex": true,
-      "declaration-property-value-blacklist": [
+      "declaration-property-value-disallowed-list": [
         {
           "/.*/": [
             /rgba{0,1}\(/i,


### PR DESCRIPTION
Fixed this warning that I just caught
```bash
Deprecation Warning: 'declaration-property-value-blacklist' has been deprecated. Instead use 'declaration-property-value-disallowed-list'. See: https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/declaration-property-value-blacklist/README.md
```
