### PR TITLE
Add wagtail localize

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -225,6 +225,10 @@ INSTALLED_APPS = list(filter(None, [
     # possibly still used?
     'networkapi.highlights',
 
+    # wagtail localization
+    'wagtail_localize',
+    'wagtail_localize.locales',
+
     # wagtail to airtable integration
     'wagtail_airtable',
 
@@ -413,6 +417,9 @@ LANGUAGES = (
     ('nl', 'Dutch'),
     ('pl', 'Polish'),
 )
+
+WAGTAIL_CONTENT_LANGUAGES = LANGUAGES
+WAGTAIL_I18N_ENABLED = True
 
 TIME_ZONE = 'UTC'
 USE_I18N = True

--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.db import models
-
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel
 from wagtail.core.models import Page, Orderable as WagtailOrderable
 from wagtail.core.fields import RichTextField
@@ -8,6 +7,8 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.admin.edit_handlers import PageChooserPanel
+
+from wagtail_localize.fields import SynchronizedField
 
 from modelcluster.fields import ParentalKey
 
@@ -278,6 +279,12 @@ class ParticipatePage2(PrimaryPage):
         InlinePanel('cta4', label='CTA Group 4', max_num=3),
     ]
 
+    override_translatable_fields = [
+        SynchronizedField('slug'),
+        SynchronizedField('ctaButtonURL'),
+        SynchronizedField('ctaButtonURL2'),
+    ]
+
 
 class Styleguide(PrimaryPage):
     template = 'wagtailpages/static/styleguide.html'
@@ -378,6 +385,11 @@ class CTABase(WagtailOrderable, models.Model):
         FieldPanel('subhead'),
         FieldPanel('buttonTitle'),
         FieldPanel('buttonURL'),
+    ]
+
+    override_translatable_fields = [
+        SynchronizedField('slug'),
+        SynchronizedField('buttonURL'),
     ]
 
     class Meta:
@@ -750,6 +762,10 @@ class Homepage(FoundationMetadataPageMixin, Page):
         'Styleguide',
         'ProductPage',
         'BuyersGuidePage',
+    ]
+
+    override_translatable_fields = [
+        SynchronizedField('slug'),
     ]
 
     def get_context(self, request):

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/annotated_image_block.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/annotated_image_block.py
@@ -1,4 +1,5 @@
 from wagtail.core import blocks
+from wagtail_localize.fields import SynchronizedField
 from .image_block import ImageBlock
 
 
@@ -6,10 +7,15 @@ class AnnotatedImageBlock(ImageBlock):
     caption = blocks.CharBlock(
         required=False
     )
+
     captionURL = blocks.CharBlock(
         required=False,
         help_text='Optional URL that this caption should link out to.'
     )
+
+    override_translatable_fields = [
+        SynchronizedField('captionURL'),
+    ]
 
     class Meta:
         icon = 'image'

--- a/network-api/networkapi/wagtailpages/pagemodels/index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/index.py
@@ -11,6 +11,8 @@ from wagtail.admin.edit_handlers import FieldPanel
 from wagtail.core.models import Page
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 
+from wagtail_localize.fields import SynchronizedField
+
 from .mixin.foundation_metadata import FoundationMetadataPageMixin
 
 from networkapi.wagtailpages.utils import (
@@ -57,6 +59,10 @@ class IndexPage(FoundationMetadataPageMixin, RoutablePageMixin, Page):
         FieldPanel('header'),
         FieldPanel('intro'),
         FieldPanel('page_size'),
+    ]
+
+    override_translatable_fields = [
+        SynchronizedField('slug'),
     ]
 
     def get_context(self, request):

--- a/network-api/networkapi/wagtailpages/pagemodels/primary.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/primary.py
@@ -5,6 +5,8 @@ from wagtail.core.models import Page
 from wagtail.core.fields import StreamField
 from wagtail.images.edit_handlers import ImageChooserPanel
 
+from wagtail_localize.fields import SynchronizedField
+
 from .base_fields import base_fields
 from .mixin.foundation_metadata import FoundationMetadataPageMixin
 from .mixin.foundation_banner_inheritance import FoundationBannerInheritanceMixin
@@ -76,6 +78,10 @@ class PrimaryPage(FoundationMetadataPageMixin, FoundationBannerInheritanceMixin,
         ImageChooserPanel('banner'),
         FieldPanel('intro'),
         StreamFieldPanel('body'),
+    ]
+
+    override_translatable_fields = [
+        SynchronizedField('slug'),
     ]
 
     subpage_types = [

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -363,11 +363,6 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
         related_name='votes',
     )
 
-    override_translatable_fields = [
-        SynchronizedField('votes'),
-        SynchronizedField('creepiness_value'),
-    ]
-
     def get_export_fields(self):
         """
         This should be a dictionary of the fields to send to Airtable.

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -22,6 +22,8 @@ from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.core.models import Orderable, Page
 from wagtail.core import hooks
 
+from wagtail_localize.fields import SynchronizedField
+
 from wagtail_airtable.mixins import AirtableMixin
 
 from networkapi.buyersguide.fields import ExtendedYesNoField
@@ -360,6 +362,11 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
         blank=True,
         related_name='votes',
     )
+
+    override_translatable_fields = [
+        SynchronizedField('votes'),
+        SynchronizedField('creepiness_value'),
+    ]
 
     def get_export_fields(self):
         """

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ requests
 social-auth-app-django
 wagtail-airtable
 wagtail==2.11.3
+wagtail-localize
 wagtail-factories
 wagtail-inventory
 wagtail-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,6 +73,7 @@ django==2.2.17
     #   djangorestframework
     #   wagtail
     #   wagtail-footnotes
+    #   wagtail-localize
 djangorestframework==3.12.2
     # via
     #   -r requirements.in
@@ -116,6 +117,8 @@ openpyxl==3.0.5
     # via tablib
 pillow==7.1.0
     # via wagtail
+polib==1.1.0
+    # via wagtail-localize
 psycopg2-binary==2.8.6
     # via -r requirements.in
 pycparser==2.20
@@ -194,6 +197,8 @@ wagtail-footnotes==0.4.1
     # via -r requirements.in
 wagtail-inventory==1.2
     # via -r requirements.in
+wagtail-localize==0.9.4
+    # via -r requirements.in
 wagtail-metadata==3.4.0
     # via -r requirements.in
 wagtail==2.11.3
@@ -203,6 +208,7 @@ wagtail==2.11.3
     #   wagtail-factories
     #   wagtail-footnotes
     #   wagtail-inventory
+    #   wagtail-localize
     #   wagtail-metadata
 webencodings==0.5.1
     # via html5lib


### PR DESCRIPTION
Builds on https://github.com/mozilla/foundation.mozilla.org/pull/6085 to add wagtail-localize, after that PR removes wagtail-modeltranslation

Note that this only adds wagtail-localize, and not the additional git/pontoon functionality.