### PR TITLE
Fix for 'header' tab mising

### DIFF
--- a/network-api/networkapi/mozfest/models.py
+++ b/network-api/networkapi/mozfest/models.py
@@ -5,6 +5,8 @@ from wagtail.core.models import Page
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
+from wagtail_localize.fields import SynchronizedField, TranslatableField
+
 from networkapi.wagtailpages.utils import (
     set_main_site_nav_information,
     get_page_tree_information
@@ -170,6 +172,22 @@ class MozfestHomepage(MozfestPrimaryPage):
     # Because we inherit from PrimaryPage, but the "use_wide_templatae" property does nothing
     # we should hide it and make sure we use the right template
     settings_panels = Page.settings_panels
+
+    translatable_fields = [
+        TranslatableField('title'),
+        TranslatableField('slug'),
+        TranslatableField('seo_title'),
+        SynchronizedField('show_in_menus'),
+        TranslatableField('search_description'),
+        SynchronizedField('search_image'),
+        SynchronizedField('signup'),
+        TranslatableField('body'),
+        SynchronizedField('use_wide_template'),
+        TranslatableField('cta_button_label'),
+        TranslatableField('cta_button_destination'),
+        TranslatableField('banner_heading'),
+        SynchronizedField('footnotes'),
+    ]
 
     def get_context(self, request):
         context = super().get_context(request)


### PR DESCRIPTION
Closes #6030 

Steps to reproduce:
* Create a new database with `inv new-db` 
* Add a new locale by going to Settings -> Locales 
* Edit the Mozfest Homepage 
* Translate the page into your chosen locale 
* Publish the translated page 
* View the original english page in the Wagtail admin. It should not error on you. Previews and the locale-prefixed URL should would for you as well. 

The problem and solution:
Mozfest Homepage has a "hardcoded" banner option. If the banner is hard coded, it removes the "header" (and other fields) from the `content_panels` — wagtail-localize is looking for each field to match the `content_panels`. So it was looking for "header" even though its not in a content_panel anymore. The solution is to avoid putting "header" (and other fields) into the `translatable_fields` option