### PR TITLE
Renamed migrations

### DIFF
--- a/network-api/networkapi/buyersguide/migrations/0009_auto_20210127_0010.py
+++ b/network-api/networkapi/buyersguide/migrations/0009_auto_20210127_0010.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('buyersguide', '0007_auto_20201210_1827'),
+        ('buyersguide', '0008_auto_20210126_1943'),
     ]
 
     operations = [

--- a/network-api/networkapi/wagtailpages/migrations/0032_pni_update_unknown_to_cant_determine.py
+++ b/network-api/networkapi/wagtailpages/migrations/0032_pni_update_unknown_to_cant_determine.py
@@ -54,7 +54,7 @@ def update_unknown_to_cantdetermine(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailpages', '0030_auto_20210125_2123'),
+        ('wagtailpages', '0031_auto_20210122_0006'),
     ]
 
     operations = [

--- a/network-api/networkapi/wagtailpages/migrations/0033_productpage_user_friendly_privacy_policy_helptext.py
+++ b/network-api/networkapi/wagtailpages/migrations/0033_productpage_user_friendly_privacy_policy_helptext.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailpages', '0031_pni_update_unknown_to_cant_determine'),
+        ('wagtailpages', '0032_pni_update_unknown_to_cant_determine'),
     ]
 
     operations = [


### PR DESCRIPTION
Fixing migration names. I just renamed the files and changed the dependencies in each one to reflect the previous migration. 