### PR TITLE
Change wagtail image settings

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -447,6 +447,8 @@ STATICFILES_DIRS = [app('frontend')]
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 WAGTAIL_SITE_NAME = 'Mozilla Foundation'
+WAGTAILIMAGES_INDEX_PAGE_SIZE = 100
+WAGTAIL_USAGE_COUNT_ENABLED = True
 
 # Rest Framework Settings
 REST_FRAMEWORK = {


### PR DESCRIPTION
Closes #5954

Show 100 images per page. And show the usage. (Example image of usage below)

![image](https://user-images.githubusercontent.com/4743971/106791405-1accb580-6612-11eb-8bb3-6d6b54dc3317.png)

**Note**: Where it shows the number of times an image is used it doesn't include where its used in streamfield blocks. This is purely on the Field-level. The reason for this is because StreamField uses JSON behind the scenes, and it'd have to loop through every page and every streamfield to determine the number of times an image is being used (which could take a VERY long time to process)