### PR TITLE
updated wagtailinventory to a custom version that fixes its own bug

### DIFF
--- a/dockerfiles/Dockerfile.python
+++ b/dockerfiles/Dockerfile.python
@@ -2,6 +2,7 @@ FROM python:3.7.8-slim
 
 RUN apt-get update && apt-get install -y \
       gettext \
+      git \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 # We want output

--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,8 @@ social-auth-app-django
 wagtail-airtable
 wagtail==2.11.3
 wagtail-factories
-wagtail-inventory
+# see https://github.com/mozilla/foundation.mozilla.org/issues/6162
+git+git://github.com/Pomax/wagtail-inventory.git@ea9a6533e69ff0a6faaf0f069efa115bc22ce697#egg=wagtail-inventory
 wagtail-metadata
 whitenoise
 wagtail-modeltranslation==0.10.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -196,7 +196,7 @@ wagtail-factories==2.0.1
     # via -r requirements.in
 wagtail-footnotes==0.4.1
     # via -r requirements.in
-wagtail-inventory==1.2
+git+git://github.com/Pomax/wagtail-inventory.git@ea9a6533e69ff0a6faaf0f069efa115bc22ce697#egg=wagtail-inventory
     # via -r requirements.in
 wagtail-metadata==3.4.0
     # via -r requirements.in


### PR DESCRIPTION
Addresses the "immediate" part of https://github.com/mozilla/foundation.mozilla.org/issues/6162

The only way I can think of to test this is on a copy of the prod (or staging) data:
- set up a local copy of the prod/stage db (see the docs)
- run the `master` branch with that database, and load http://localhost:8000/cms/pages/1313/edit/ (Publication page)
- in the promote tab for that page, try to change/set the SEO image
- hit publish
- this will error out.

Then check out this branch, run `inv new-env` because there's a new dependency as well as python docker utility installs. then
- set up the local copy of the prod/stage db again
- run the setup and navigate to http://localhost:8000/cms/pages/1313/edit
- in the promote tab, chance/set the SEO image
- hit publish
- this should now work, with the changes saved

this should now work without any errors