### PR TITLE
Fix factory warning around participate page

### DIFF
--- a/network-api/networkapi/wagtailpages/factory/participate_page_featured_highlights.py
+++ b/network-api/networkapi/wagtailpages/factory/participate_page_featured_highlights.py
@@ -37,7 +37,7 @@ def generate(seed):
     participate_page = None
 
     try:
-        participate_page = ParticipatePage2.objects.get(title='participate')
+        participate_page = ParticipatePage2.objects.get(title='What you can do')
     except WagtailPage.DoesNotExist:
         print('Participate page must exist. Ensure that ' +
               'networkapi.wagtailpages.factory.participage_page is executing first')


### PR DESCRIPTION
Closes #5735 

Run `inv new-db` locally. Once that's done, search the log. The `Participate page must exist. Ensure that ...` error should not exist anymore.

Note that as a result, the fake Particapte2 page is more complete as `highlights` are being generated correctly. See Percy for differences.