### PR TITLE
Change 'Become a Sponsor' footer string

### DIFF
--- a/network-api/networkapi/mozfest/templates/partials/mozfest_footer.html
+++ b/network-api/networkapi/mozfest/templates/partials/mozfest_footer.html
@@ -32,7 +32,7 @@
 {% block general_links %}
   <li><a id="donate-footer-btn" href="https://donate.mozilla.org/" rel="noopener noreferrer" class="dark-theme">{% trans "Donate" %}</a></li>
   <!-- the rest of the links should be listed alphabetically -->
-  <li><a href="https://www.mozillafestival.org/sponsor" class="dark-theme">{% trans "Become a Sponsor" %}</a></li>
+  <li><a href="https://www.mozillafestival.org/sponsor" class="dark-theme">{% trans "Support MozFest" %}</a></li>
   <li><a href="https://careers.mozilla.org/listings/?team=Mozilla%20Foundation" class="dark-theme">{% trans "Careers" %}</a></li>
   <li><a href="https://www.mozilla.org/privacy/websites/#cookies" class="dark-theme">{% trans "Cookies" %}</a></li>
   <li><a href="https://www.mozilla.org/about/legal/terms/mozilla/" class="dark-theme">{% trans "Legal" %}</a></li>


### PR DESCRIPTION
Change footer string.
Requested by MozFest team. I thought I'd do it and save someone the time of making a ticket.
Let me know if this is not good.

live URL: https://foundation-s-switch-foo-6gy8nq.herokuapp.com/en/