### PR TITLE
Redirect /pt to /pt-BR

### DIFF
--- a/network-api/networkapi/campaign/views.py
+++ b/network-api/networkapi/campaign/views.py
@@ -12,6 +12,14 @@ import json
 from networkapi.wagtailpages.models import Petition, Signup
 
 
+def process_lang_code(lang):
+    # Salesforce expects "pt" instead of "pt-BR".
+    # See https://github.com/mozilla/foundation.mozilla.org/issues/5993
+    if lang == 'pt-BR':
+        return 'pt'
+    return lang
+
+
 class SQSProxy:
     """
     We use a proxy class to make sure that code that
@@ -107,7 +115,7 @@ def signup_submission(request, signup):
         "format": "html",
         "source_url": source,
         "newsletters": signup.newsletter,
-        "lang": rq.get('lang', 'en'),
+        "lang": process_lang_code(rq.get('lang', 'en')),
         "country": rq.get('country', ''),
         # Empty string instead of None due to Basket issues
         "first_name": rq.get('givenNames', ''),
@@ -150,7 +158,7 @@ def petition_submission(request, petition):
         "email": request.data['email'],
         "email_subscription": request.data['newsletterSignup'],
         "source_url": request.data['source'],
-        "lang": request.data['lang'],
+        "lang": process_lang_code(request.data['lang']),
     }
 
     if petition:

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -412,7 +412,7 @@ LANGUAGE_CODE = 'en'
 LANGUAGES = (
     ('en', 'English'),
     ('de', 'German'),
-    ('pt', 'Portuguese (Brazil)'),
+    ('pt-BR', 'Portuguese (Brazil)'),
     ('es', 'Spanish'),
     ('fr', 'French'),
     ('fy-NL', 'Frisian'),

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -412,7 +412,7 @@ LANGUAGE_CODE = 'en'
 LANGUAGES = (
     ('en', 'English'),
     ('de', 'German'),
-    ('pt', 'Portuguese'),
+    ('pt', 'Portuguese (Brazil)'),
     ('es', 'Spanish'),
     ('fr', 'French'),
     ('fy-NL', 'Frisian'),

--- a/network-api/networkapi/templates/fragments/canonical_url.html
+++ b/network-api/networkapi/templates/fragments/canonical_url.html
@@ -28,7 +28,7 @@
   {% elif CODE == 'pa-IN' %}
   <link rel="alternate" hreflang="pa" href="{{ CANONICAL_SITE_URL }}/{{ CODE }}{{ CANONICAL_PATH }}" title="{{ lang.name_local|safe }}">
   <link rel="alternate" hreflang="pa-IN" href="{{ CANONICAL_SITE_URL }}/{{ CODE }}{{ CANONICAL_PATH }}" title="{{ lang.name_local|safe }}">
-  {% elif CODE == 'pt' %}
+  {% elif CODE == 'pt-BR' %}
   <link rel="alternate" hreflang="pt" href="{{ CANONICAL_SITE_URL }}/{{ CODE }}{{ CANONICAL_PATH }}" title="{{ lang.name_local|safe }}">
   <link rel="alternate" hreflang="pt-PT" href="{{ CANONICAL_SITE_URL }}/{{ CODE }}{{ CANONICAL_PATH }}" title="{{ lang.name_local|safe }}">
   <link rel="alternate" hreflang="pt-BR" href="{{ CANONICAL_SITE_URL }}/{{ CODE }}{{ CANONICAL_PATH }}" title="{{ lang.name_local|safe }}">

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -65,6 +65,9 @@ urlpatterns = list(filter(None, [
 
     # Wagtail Footnotes package
     path("footnotes/", include(footnotes_urls)),
+
+    # redirect /pt to /pt-BR. See https://github.com/mozilla/foundation.mozilla.org/issues/5993
+    re_path(r'^pt/(?P<rest>.*)', RedirectView.as_view(url='/pt-BR/%(rest)s', query_string=True)),
 ]))
 
 # Anything that needs to respect the localised

--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -17,7 +17,7 @@ mappings = {
     'fy-NL': 'fy_NL',
     'nl': 'nl_NL',
     'pl': 'pl_PL',
-    'pt': 'pt_BR',  # our main focus is Brazilian Portuguese
+    'pt-BR': 'pt_BR',
 }
 
 

--- a/source/js/components/join/language-select.jsx
+++ b/source/js/components/join/language-select.jsx
@@ -17,7 +17,7 @@ export default class LanguageSelect extends Component {
       es: `Español`,
       fr: `Français`,
       pl: `Polski`,
-      pt: `Português`,
+      "pt-BR": `Português`,
     };
 
     let lang_codes = Object.keys(languages);

--- a/source/js/components/petition/locale-strings.jsx
+++ b/source/js/components/petition/locale-strings.jsx
@@ -258,7 +258,7 @@ export default {
   },
 
   // Portuguese
-  pt: {
+  "pt-BR": {
     "First name": `Nome`,
     "Please enter your given name(s)": `Insira seu nome`,
     "Last name": `Sobrenome`,

--- a/source/sass/buyers-guide/views/product.scss
+++ b/source/sass/buyers-guide/views/product.scss
@@ -81,7 +81,7 @@ $pni-product-breakpoint-larger: $bp-md;
         }
       }
 
-      @at-root html[lang="pt"] & {
+      @at-root html[lang="pt-BR"] & {
         background-image: url(../_images/buyers-guide/icon-privacy-ding-pt.svg);
         width: 53px;
 


### PR DESCRIPTION
Closes #5993 

The old PR (#6193) was getting too hard to rebase and fix migrations so I created this new one to save the headache 😂 I basically copied all approved code changes from there plus one differnce in `settings.py` (see inline comment below). I'm not sure why but this PR no longer requires migration files to work. Is this the new `wagtail-localize` magic 😮 ?

Test urls:
- https://foundation-s-new-issue--0xkd43.herokuapp.com/pt
- https://foundation-s-new-issue--0xkd43.herokuapp.com/pt/?hello=world
- https://foundation-s-new-issue--0xkd43.herokuapp.com/pt/privacynotincluded/
- https://foundation-s-new-issue--0xkd43.herokuapp.com/pt/privacynotincluded/?hello=world
