### PR TITLE
Remove 'eslint-config-prettier'

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,4 @@
 {
-  "extends": [
-    "prettier"
-  ],
   "plugins": [
     "prettier",
     "react"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "chokidar-cli": "^2.1.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.20.0",
-    "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",


### PR DESCRIPTION
Closes #6265

Seems like we don't really need `'eslint-config-prettier` because [reasons](https://github.com/mozilla/foundation.mozilla.org/issues/6265#issuecomment-787050124)