### PR TITLE
Reorder some SCSS imports

### DIFF
--- a/source/sass/buyers-guide/bg-main.scss
+++ b/source/sass/buyers-guide/bg-main.scss
@@ -12,9 +12,12 @@ html {
 
 // Site-wide
 
+@import "../resets";
 @import "../glyphs";
 @import "../mixins";
 @import "./mixins"; // Buyer's Guide specific mixins
+@import "../type";
+@import "../buttons";
 
 // PNI specific
 
@@ -48,9 +51,6 @@ html {
 
 // Misc
 
-@import "../resets";
-@import "../type";
-@import "../buttons";
 @import "../global";
 @import "../utilities";
 

--- a/source/sass/main.scss
+++ b/source/sass/main.scss
@@ -7,8 +7,11 @@
 @import "./buyers-guide/colors";
 
 // Site-wide
+@import "./resets";
 @import "./glyphs";
 @import "./mixins";
+@import "./type";
+@import "./buttons";
 
 // React Components
 
@@ -39,9 +42,6 @@
 
 // Misc
 
-@import "./resets";
-@import "./type";
-@import "./buttons";
 @import "./global";
 @import "./utilities";
 @import "./cms";


### PR DESCRIPTION
Closes #6404

I don't know why Percy is flagging an issue on article page. I compared the review app page and the page called but I couldn't find any SCSS difference in the hero section. I'm guessing this is safe to merge... as the difference Percy flagged seems to be a tiny offset?

This is where Percy flags the visual regression issue
- https://foundation-s-issue-6404-5fvwnt.herokuapp.com/en/publication-page-with-chapter-pages/fixed-title-chapter-page/fixed-title-article-page/

Local page
- http://test.example.com:8000/en/publication-page-with-chapter-pages/fixed-title-chapter-page/fixed-title-article-page/
