### PR TITLE
Tag cleanup management command

### DIFF
--- a/network-api/networkapi/management/commands/tag_cleanup.py
+++ b/network-api/networkapi/management/commands/tag_cleanup.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand
+from taggit.models import Tag
+
+
+class Command(BaseCommand):
+    help = '''
+        Remove unused tags, if there are any. Then look for similar tags and delete the duplicates.
+        The remaining tag will be renamed to a lowercase tag in preparation for case insensitive
+        tags.
+    '''
+
+    def handle(self, *args, **options):
+        for tag in Tag.objects.all():
+            if (
+                not tag.wagtailpages_blogpagetag_items.all()
+                and not tag.wagtailpages_banneredcampaigntag_items.count()
+            ):
+                # This tag is not being used. Deleted it.
+                tag.delete()
+            else:
+                # Tag is being used. Look for other tags with the same name and remove them.
+                Tag.objects.filter(name__iexact=tag.name).exclude(slug=tag.slug)
+
+                # Make the tag in the forloop have a lowercase name
+                tag.name = tag.name.lower()
+                tag.save()


### PR DESCRIPTION
Partially Closes #6430 

We can't clean up all the tags in an automated way because there are too many data inconsistencies. 

Ideally we'd go through all the tags in the production site and clean them up before running this script. We don't need to check if they are being used or not because this management command will delete unused tags. Afterwards it'll convert all tags to lowercase for tag-name consistency. 

Tags in production need a unique name, so if we aren't sure if it's being used or not let's at least make sure the tags have unique names. That means "Mozilla", "MOZILLA", and "mozilla" should be named different things.

Keep in mind if we rename a tag it might be exposed through the frontend so renamed "MoziLLa" to "mozilla-2" might not be the best approach. 

After this we should be able to enable `TAGGIT_CASE_INSENSITIVE = True`. 

I'm iffy about landing this management command as well because after a manual (human-based) tag cleanup in production we might not actually need this work.