### PR TITLE
Add caching to RSS/Atom feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ translations_github_commit_*
 
 # VSCode  project config
 .vscode/settings.json
+
+# Localization testing SSH keys
+wagtail-localize-key*

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -44,6 +44,7 @@ env = environ.Env(
     DATABASE_URL=(str, None),
     DEBUG=(bool, False),
     DJANGO_LOG_LEVEL=(str, 'INFO'),
+    FEED_CACHE_TIMEOUT=(int, 60*60*24),
     DOMAIN_REDIRECT_MIDDLEWARE_ENABLED=(bool, False),
     FEED_LIMIT=(int, 10),
     FILEBROWSER_DEBUG=(bool, False),
@@ -629,6 +630,7 @@ PNI_STATS_DB_URL = env('PNI_STATS_DB_URL')
 NETWORK_SITE_URL = env('NETWORK_SITE_URL')
 
 # RSS / ATOM settings
+FEED_CACHE_TIMEOUT = env('FEED_CACHE_TIMEOUT')
 FEED_LIMIT = env('FEED_LIMIT')
 
 # Support pages with a large number of fields

--- a/network-api/networkapi/wagtailpages/rss.py
+++ b/network-api/networkapi/wagtailpages/rss.py
@@ -25,11 +25,18 @@ class RSSFeed(Feed):
             # specifically using the English page title, as an IndexPage rather than
             # as a BlogIndexPage, to make sure we're not filtering out all the
             # "featured" posts (which we need to do for site content purposes).
-            index = IndexPage.objects.get(title_en__iexact='Blog')
+            try:
+                index = IndexPage.objects.get(title_en__iexact='Blog')
 
-            # If that doesn't yield the blog page, pull using the universal title
-            if index is None:
-                index = IndexPage.objects.get(title__iexact='Blog')
+            except IndexPage.DoesNotExist:
+                # If that doesn't yield the blog page, pull using the universal title
+                try:
+                    index = IndexPage.objects.get(title__iexact='Blog')
+
+                except IndexPage.DoesNotExist:
+                    # At this point there's not much we can do other than to pretend
+                    # there are no posts to serialize to RSS/Atom format.
+                    return []
 
             # Then sort the collection and only yield the top FEED_LIMIT posts
             blog_pages = index.get_all_entries().order_by('-first_published_at')


### PR DESCRIPTION
Closes #6374 

This adds caching to the RSS/Atom `items()` function so that we only hit the database once a day for the current list of blog posts to include in our feed. It's self-invalidating, with the value defaulting to one day but overridable using a `FEED_CACHE_TIMEOUT` environment variable.

I tested this by setting that var to `10`, with a `print('caching')` inside the `if feed_set is None: ...` block so I could see it building or hitting the cache by reloading the RSS page on http://localhost:8000/en/blog/rss/