### PR TITLE
Add description to SCSS files & todo notes in main.scss

### DIFF
--- a/source/sass/buyers-guide/components/header.scss
+++ b/source/sass/buyers-guide/components/header.scss
@@ -1,3 +1,5 @@
+// Stylings for PNI nav, hero, header sections
+
 // Mixin for setting border bottom style for category nav
 @mixin set-category-border-bottom-style() {
   border-bottom: 1px solid $gray-20;

--- a/source/sass/components/airtable-block.scss
+++ b/source/sass/components/airtable-block.scss
@@ -1,3 +1,5 @@
+// Airtable Stream Block
+
 .airtable-embed {
   box-sizing: content-box;
 }

--- a/source/sass/components/article-page.scss
+++ b/source/sass/components/article-page.scss
@@ -1,7 +1,5 @@
-/**
- * ArticlePage-specific styling.
- * Also see publication-page.scss and chapter-page.scss
- */
+// ArticlePage-specific styling.
+// Also see publication-page.scss and chapter-page.scss
 
 #view-article {
   .article-blocks {

--- a/source/sass/components/blog-authors.scss
+++ b/source/sass/components/blog-authors.scss
@@ -1,3 +1,5 @@
+// Blog Authors
+
 .blog-authors {
   .author-images {
     $image-offset: 0.7rem;

--- a/source/sass/components/card.scss
+++ b/source/sass/components/card.scss
@@ -1,3 +1,6 @@
+// Card Related SCSS
+// Example usage: https://foundation.mozilla.org/en/blog/
+
 .card-regular {
   position: relative;
 

--- a/source/sass/components/chapter-page.scss
+++ b/source/sass/components/chapter-page.scss
@@ -1,9 +1,7 @@
-/**
- * ChapterPage-specific styling.
- * Also see publication-page.scss and article-page.scss
- * "ChapterPage" is a child PublicationPage
- * PublicationPage is the most parent PublicationPage
- */
+// ChapterPage-specific styling.
+// Also see publication-page.scss and article-page.scss
+// "ChapterPage" is a child PublicationPage
+// PublicationPage is the most parent PublicationPage
 
 .chapter-number {
   display: flex;

--- a/source/sass/components/dear-internet-letter.scss
+++ b/source/sass/components/dear-internet-letter.scss
@@ -1,3 +1,7 @@
+// SCSS code for DearInternetLetterBlock Stream Block used on
+// the special one-off campaign page #DearInternet
+// https://foundation.mozilla.org/en/campaigns/dearinternet/
+
 .dear-internet-letter-wrapper {
   $breakpoint: $bp-md;
   --border-width: 2px;

--- a/source/sass/components/feature-quote.scss
+++ b/source/sass/components/feature-quote.scss
@@ -1,3 +1,6 @@
+// Quote Stream Block
+// Example usage: https://foundation.mozilla.org/en/privacynotincluded/about/press/
+
 .feature-quote {
   $breakpoint: $bp-md;
 

--- a/source/sass/components/hr-emphasis.scss
+++ b/source/sass/components/hr-emphasis.scss
@@ -1,6 +1,0 @@
-.hr-emphasis {
-  height: 4px;
-  background: $black;
-  border: 0;
-  margin: 30px 0;
-}

--- a/source/sass/components/image-text-mini.scss
+++ b/source/sass/components/image-text-mini.scss
@@ -1,3 +1,6 @@
+// ImageTextMini Stream Block
+// For #6496: this file should be relocated?
+
 .image-text-mini {
   &-container {
     border-top: 1px solid $black;

--- a/source/sass/components/multipage-nav.scss
+++ b/source/sass/components/multipage-nav.scss
@@ -1,3 +1,6 @@
+// Multipage Nav (Secondary Nav)
+// Example usage: https://foundation.mozilla.org/en/who-we-are/
+
 #multipage-horizontal-nav-wrapper {
   @include intro-and-content-spacing(true);
 

--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -1,3 +1,5 @@
+// Primary Nav (Site Nav)
+
 .primary-nav-container {
   $logo-height: 28px;
 

--- a/source/sass/components/publication-page.scss
+++ b/source/sass/components/publication-page.scss
@@ -1,9 +1,7 @@
-/**
- * PublicationPage-specific styling.
- * Also see chapter-page.scss and article-page.scss
- * "ChapterPage" is a child PublicationPage.
- * PublicationPage is the most parent PublicationPage
- */
+// PublicationPage-specific styling.
+// Also see chapter-page.scss and article-page.scss
+// "ChapterPage" is a child PublicationPage.
+// PublicationPage is the most parent PublicationPage
 
 .publication-hero-file-size {
   color: $gray-40;

--- a/source/sass/components/select-dropdown.scss
+++ b/source/sass/components/select-dropdown.scss
@@ -1,3 +1,5 @@
+// <select> styling
+
 select {
   &.form-control {
     $background-size: 24px;

--- a/source/sass/global.scss
+++ b/source/sass/global.scss
@@ -29,6 +29,13 @@ hr {
   }
 }
 
+.hr-emphasis {
+  height: 4px;
+  background: $black;
+  border: 0;
+  margin: 30px 0;
+}
+
 #hero {
   $bg-pattern-height: 144px;
 

--- a/source/sass/main.scss
+++ b/source/sass/main.scss
@@ -25,20 +25,19 @@
 
 // Non-React Components
 
-@import "./components/hr-emphasis";
-@import "./components/feature-quote";
+@import "./components/feature-quote"; // stream block. TODO:FIXME: relocate file?
 @import "./components/nav";
 @import "./components/primary-nav";
 @import "./components/multipage-nav";
 @import "./components/card";
-@import "./components/airtable-block";
-@import "./components/image-text-mini";
-@import "./components/select-dropdown";
+@import "./components/airtable-block"; // stream block. TODO:FIXME: relocate file?
+@import "./components/image-text-mini"; // stream block. TODO:FIXME: relocae file?
+@import "./components/select-dropdown"; // TODO:FIXME: consider relocate code to a new file scss/form.scss
 @import "./components/blog-authors";
-@import "./components/publication-page";
-@import "./components/chapter-page";
-@import "./components/article-page";
-@import "./components/dear-internet-letter";
+@import "./components/publication-page"; // TODO:FIXME: relocate file to scss/views/
+@import "./components/chapter-page"; // TODO:FIXME: relocate file to scss/views/
+@import "./components/article-page"; // TODO:FIXME: relocate file to scss/views/
+@import "./components/dear-internet-letter"; // stream block. TODO:FIXME: relocate file?
 
 // Misc
 

--- a/source/sass/mozfest.scss
+++ b/source/sass/mozfest.scss
@@ -1,3 +1,6 @@
+// MozFest-specific styling
+// https://www.mozillafestival.org
+
 body.mozfest {
   .primary-nav-container {
     // The following overrides are to make sure


### PR DESCRIPTION
Closes #6501 

- I didn't add description to all SCSS files because some are really self-explanatory 
  - by their file name
  - or by their corresponding React component. See docs I added in PR #6551. e.g., description for `creep-vote.jsx` will explain why we need a corresponding SCSS file`creep-vote.scss`
- Added some `TODO:FIXME:` notes in [main.scss](https://github.com/mozilla/foundation.mozilla.org/pull/6556/files#diff-0fb6caf9fa4f229fec42cf28fd2bfed9565f7372efb37e55e6564762123fe75e) so we can tackle them in #6496 