### PR TITLE
Version bump

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ python-slugify
 requests
 social-auth-app-django
 wagtail-airtable
-wagtail==2.11.6
+wagtail==2.11.7
 wagtail-factories
 # see https://github.com/mozilla/foundation.mozilla.org/issues/6162
 git+git://github.com/Pomax/wagtail-inventory.git@ea9a6533e69ff0a6faaf0f069efa115bc22ce697#egg=wagtail-inventory

--- a/requirements.txt
+++ b/requirements.txt
@@ -218,7 +218,7 @@ wagtail-metadata==3.4.0
     # via -r requirements.in
 wagtail-modeltranslation==0.10.17
     # via -r requirements.in
-wagtail==2.11.6
+wagtail==2.11.7
     # via
     #   -r requirements.in
     #   wagtail-airtable


### PR DESCRIPTION
Closes #6537 

A small Wagtail version bump to keep us on the latest LTS version (2.11 is LTS). 

To test:
1. Checkout this branch
2. `inv new-env`
3. `inv test-python` 
4. Click around the site to make sure pages still work as expected. I found no issues on the pages I hit. 