### PR TITLE
added autocomplete=off to the privacy not included checkbox

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
@@ -52,7 +52,7 @@
           </span>
 
           <span id="product-filter-pni">
-            <input type="checkbox" id="product-filter-pni-toggle">
+            <input type="checkbox" id="product-filter-pni-toggle" autocomplete="off">
             <label for="product-filter-pni-toggle" class="pni-checkbox-facade"></label>
             <span class="pni-icon">&nbsp;</span>
             <label for="product-filter-pni-toggle">{% trans "*privacy not included" %} </label>


### PR DESCRIPTION
Closes #6421

**Link to sample test page**: [here](https://foundation-s-6421-pni-t-1zkk2x.herokuapp.com/en/privacynotincluded/)

Steps to test:
1. Visit the link above in firefox
2. Check the "privacy not included" checkbox in the top right corner
3. Refresh the page, the list of items should be unfiltered and the box should be unchecked as well.

## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible]