### PR TITLE
Remove CSRF from petition and signup forms. 

### DIFF
--- a/network-api/networkapi/campaign/tests.py
+++ b/network-api/networkapi/campaign/tests.py
@@ -36,7 +36,7 @@ class PostRouteTests(TestCase):
         response_dict = json.loads(response.content)
         self.assertEqual(response.status_code, 500)
         self.assertTrue('error' in response_dict)
-        self.assertEqual(response_dict['error'], 'Server is missing campaign for petition')
+        self.assertEqual(response_dict['error'], 'Server is missing campaign id for petition')
         print('(intentional 500 error)')
 
         petition.campaign_id = 123

--- a/network-api/networkapi/campaign/tests.py
+++ b/network-api/networkapi/campaign/tests.py
@@ -68,29 +68,28 @@ class PostRouteTests(TestCase):
         response = self.client.post(url, post_data, content_type='application/json')
         self.assertEqual(response.status_code, 201)
 
-    # TODO: Fix whatever is breaking this test
-    # def test_bad_signup_post(self):
-    #     """
-    #     Tests the signup posting route
-    #     """
+    def test_bad_signup_post(self):
+        """
+        Tests the signup posting route
+        """
 
-    #     signup = Signup.objects.create()
-    #     url = reverse('signup-submission', kwargs={'pk': signup.id})
+        signup = Signup.objects.create()
+        url = reverse('signup-submission', kwargs={'pk': signup.id})
 
-    #     # no email
+        # no email
 
-    #     post_data = json.dumps({
-    #         'source': 'http://localhost/testing/signup',
-    #     })
+        post_data = json.dumps({
+            'source': 'http://localhost/testing/signup',
+        })
 
-    #     response = self.client.post(url, post_data, content_type='application/json')
-    #     self.assertEqual(response.status_code, 400)
+        response = self.client.post(url, post_data, content_type='application/json')
+        self.assertEqual(response.status_code, 400)
 
-    #     # no source
+        # no source
 
-    #     post_data = json.dumps({
-    #         'email': 'user_test@example.org',
-    #     })
+        post_data = json.dumps({
+            'email': 'user_test@example.org',
+        })
 
-    #     response = self.client.post(url, post_data, content_type='application/json')
-    #     self.assertEqual(response.status_code, 400)
+        response = self.client.post(url, post_data, content_type='application/json')
+        self.assertEqual(response.status_code, 400)

--- a/network-api/networkapi/campaign/tests.py
+++ b/network-api/networkapi/campaign/tests.py
@@ -68,28 +68,29 @@ class PostRouteTests(TestCase):
         response = self.client.post(url, post_data, content_type='application/json')
         self.assertEqual(response.status_code, 201)
 
-    def test_bad_signup_post(self):
-        """
-        Tests the signup posting route
-        """
+    # TODO: Fix whatever is breaking this test
+    # def test_bad_signup_post(self):
+    #     """
+    #     Tests the signup posting route
+    #     """
 
-        signup = Signup.objects.create()
-        url = reverse('signup-submission', kwargs={'pk': signup.id})
+    #     signup = Signup.objects.create()
+    #     url = reverse('signup-submission', kwargs={'pk': signup.id})
 
-        # no email
+    #     # no email
 
-        post_data = json.dumps({
-            'source': 'http://localhost/testing/signup',
-        })
+    #     post_data = json.dumps({
+    #         'source': 'http://localhost/testing/signup',
+    #     })
 
-        response = self.client.post(url, post_data, content_type='application/json')
-        self.assertEqual(response.status_code, 400)
+    #     response = self.client.post(url, post_data, content_type='application/json')
+    #     self.assertEqual(response.status_code, 400)
 
-        # no source
+    #     # no source
 
-        post_data = json.dumps({
-            'email': 'user_test@example.org',
-        })
+    #     post_data = json.dumps({
+    #         'email': 'user_test@example.org',
+    #     })
 
-        response = self.client.post(url, post_data, content_type='application/json')
-        self.assertEqual(response.status_code, 400)
+    #     response = self.client.post(url, post_data, content_type='application/json')
+    #     self.assertEqual(response.status_code, 400)

--- a/source/js/components/petition/petition.jsx
+++ b/source/js/components/petition/petition.jsx
@@ -211,7 +211,6 @@ export default class Petition extends Component {
       xhr.open(`POST`, this.props.apiUrl, true);
       xhr.setRequestHeader(`Content-Type`, `application/json`);
       xhr.setRequestHeader(`X-Requested-With`, `XMLHttpRequest`);
-      xhr.setRequestHeader(`X-CSRFToken`, this.props.csrfToken);
       xhr.timeout = 5000;
       xhr.ontimeout = () => reject(new Error(`xhr timed out`));
 


### PR DESCRIPTION
Closes #6566 

We apparently cant use csrf exempt views with drf's api_view. So I opted for regular Django views that return a JsonResponse instead of a drf.Response. 

Notes:

- you will need to add a `campaign_id` value when manually testing petition/signup CTA, and make sure your `.env` is up to date with a `BASKET_API_ROOT_URL`  set to https://basket-dev.allizom.org/
- you will also need to set the `newsletter` field for your signup snippet to `mozilla-foundation`