### PR TITLE
fix PNI search filter

### DIFF
--- a/source/js/buyers-guide/search.js
+++ b/source/js/buyers-guide/search.js
@@ -20,6 +20,7 @@ const SearchFilter = {
     const searchInput = (SearchFilter.searchInput = searchBar.querySelector(
       `input`
     ));
+
     searchInput.addEventListener(`input`, (evt) => {
       const searchText = searchInput.value.trim();
 
@@ -92,11 +93,15 @@ const SearchFilter = {
   },
 
   filter: (text) => {
+    console.log(`filtering for ${text}`, ALL_PRODUCTS);
+
     ALL_PRODUCTS.forEach((product) => {
       if (SearchFilter.test(product, text)) {
         product.classList.remove(`d-none`);
+        product.classList.add(`d-flex`);
       } else {
         product.classList.add(`d-none`);
+        product.classList.remove(`d-flex`);
       }
     });
 

--- a/source/js/buyers-guide/search.js
+++ b/source/js/buyers-guide/search.js
@@ -93,8 +93,6 @@ const SearchFilter = {
   },
 
   filter: (text) => {
-    console.log(`filtering for ${text}`, ALL_PRODUCTS);
-
     ALL_PRODUCTS.forEach((product) => {
       if (SearchFilter.test(product, text)) {
         product.classList.remove(`d-none`);


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/6604

Fixes the PNI search filter by making sure that we don't just set `d-none` to hide elements but also remove the `d-flex` class (otherwise, `d-flex` wins, and `... d-flex ... d-none ...` will stay visible)