### PR TITLE
cache.delete

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/index.py
@@ -78,7 +78,7 @@ class IndexPage(FoundationMetadataPageMixin, RoutablePageMixin, Page):
         return f'index_items_{self.slug}'
 
     def clear_index_page_cache(self):
-        cache.clear(self.cache_key)
+        cache.delete(self.cache_key)
 
     def get_all_entries(self):
         """

--- a/network-api/networkapi/wagtailpages/wagtail_hooks.py
+++ b/network-api/networkapi/wagtailpages/wagtail_hooks.py
@@ -110,9 +110,7 @@ def manage_index_pages_cache(request, page):
       TODO: remove this check and associated caching when we switch over to
             proper "related posts" in the CMS for blog pages and campaigns.
     """
+    parent = page.get_parent().specific
 
-    # COMMENTED OFF WHILE THIS GETS REDONE WITHOUT ERRORING OUT
-    #
-    # parent = page.get_parent().specific()
-    # if hasattr(parent, 'clear_index_page_cache'):
-    #     parent.clear_index_page_cache()
+    if hasattr(parent, 'clear_index_page_cache'):
+        parent.clear_index_page_cache()


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/6463 this time with the proper cache delete call, and without treating `.specific` as a function

testing steps:
- fire up this branch
- add `print("clearing cache!")` at the same depth as cache.delete
- edit a blog page, then publish it.