### PR TITLE
Fix PNI UI l10n

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -438,6 +438,7 @@ USE_TZ = True
 LOCALE_PATHS = (
     os.path.join(BASE_DIR, 'locale'),
     os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/about/locale'),
+    os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/buyersguide/locale'),
 )
 
 


### PR DESCRIPTION
Closes #6610

Prod homepage in French:
<img width="963" alt="Capture d’écran 2021-04-29 à 11 34 02" src="https://user-images.githubusercontent.com/1294206/116530929-81423680-a8d6-11eb-9d12-a2ace6f1784b.png">


French homepage on https://foundation-s-fix-pni-ui-x9lzo0.herokuapp.com/fr/privacynotincluded/:

<img width="1174" alt="Capture d’écran 2021-04-29 à 12 24 05" src="https://user-images.githubusercontent.com/1294206/116536881-6b843f80-a8dd-11eb-9796-b176bc777c58.png">
