### PR TITLE
Updated summary link width so they always appear on their own line

### DIFF
--- a/source/sass/views/article.scss
+++ b/source/sass/views/article.scss
@@ -50,7 +50,7 @@
 .article-summary-link {
   display: block;
   --spacing: 10px;
-
+  width: 100%;
   margin-top: 17px;
   flex-basis: calc(50% - var(--spacing));
   flex-grow: 0;


### PR DESCRIPTION
Closes #6613 

Hi Everyone, attached is an image of the same summary-link section where users were encountering the bug, but with my fix implemented.

Since the links had a width of "auto" shorter length links had the possibility of sharing a line with another link.

With the width now set to 100%, each link is taking up its own line.


<img width="515" alt="image" src="https://user-images.githubusercontent.com/18314510/116733984-ac458c80-a9a1-11eb-8424-a8a387f8fb16.png">



## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible]