### PR TITLE
allow tags in richtext headings for heading link purposes

### DIFF
--- a/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
+++ b/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
@@ -25,7 +25,7 @@ __original__html__ = RichText.__html__
 # 1. "everything after the h" for the opening tag
 # 2. the heading number
 # 3. the tag's text content
-heading_re = r"<h((\d)[^>]*)>([^<]*)</h\1>"
+heading_re = r"<h((\d)[^>]*)>(.+?)</h\1>"
 
 
 def add_id_attribute(match):


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/6326 by changing the regex for heading matching to one that allows "any content" between the opening and closing `h` tag.

STR:
- fire up the admin interface
- edit a blog page's rich text field, assign it this content:

```
Heading2
test

Heading2bi
test

heading3
test

heading3bi
test

heading4
test

heading4bi
test

heading5
test

heading5bi
test
```

Mark all headings as their respective headings using the richtext button bar.
Also highlight each "bi" heading and make the entire heading bold and italic.

- Publish, view live version, inspect the headings using "inspect element"

You should see this:

![image](https://user-images.githubusercontent.com/177243/117864274-75952f00-b249-11eb-8bb1-ba290a23f00f.png)

