### PR TITLE
improve local dev workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - SHELL=/bin/sh
       # Force polling because inotify doesn't work on Docker Windows
       - CHOKIDAR_USEPOLLING=1
-      - CHOKIDAR_INTERVAL=2000
     command: npm run watch
     volumes:
       - .:/app:delegated
@@ -46,6 +45,7 @@ services:
       - dockerpythonvenv:/app/dockerpythonvenv/:delegated
     depends_on:
       - postgres
+      - watch-static-files
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,6 @@ services:
       - dockerpythonvenv:/app/dockerpythonvenv/:delegated
     depends_on:
       - postgres
-      - watch-static-files
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - SHELL=/bin/sh
       # Force polling because inotify doesn't work on Docker Windows
       - CHOKIDAR_USEPOLLING=1
+      - CHOKIDAR_INTERVAL=2000
     command: npm run watch
     volumes:
       - .:/app:delegated
@@ -45,7 +46,6 @@ services:
       - dockerpythonvenv:/app/dockerpythonvenv/:delegated
     depends_on:
       - postgres
-      - watch-static-files
 
 volumes:
   postgres_data:

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:scss:styleguide:color": "stylelint \"source/sass/**/*.scss\" \"source/js/**/*.scss\" \"!source/sass/**/_colors.scss\" --syntax scss --config .stylelintrc-colors.js",
     "test:css": "stylelint \"network-api/networkapi/{,!(frontend)/**/}*.css\" --syntax scss",
     "test": "run-s test:** build",
-    "watch": "run-s build:clean && run-p build:js:dev build:common watch:**",
+    "watch": "wait-on http://backend:8000/cms && run-s build:clean && run-p build:js:dev build:common watch:**",
     "watch:images": "chokidar \"source/images/**/*\" -c \"npm run build:images\"",
     "watch:sass": "chokidar \"source/**/*.scss\" -c \"npm run build:sass\""
   },


### PR DESCRIPTION
Related PRs/issues https://github.com/mozilla/foundation.mozilla.org/issues/6403

This improves the local dev experience by always deferring the frontend building until Wagtail's already up and running. It doesn't change the time to done, but it drastically changes the time to "there is a server".