### PR TITLE
Use dynamic image urls to decrease time to first byte

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_authors.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_authors.html
@@ -7,8 +7,7 @@
   {% for author in authors %}
     <div class="author-image d-flex align-items-center justify-content-center {% if author.image is None %}no-avatar{% endif %}" aria-label="{{ author.name }}">
     {% if author.image %}
-      {% image author.image fill-100x100 as img %}
-      <img src="{{ img.url }}" alt="{{ author.name }}" title="{{ author.name }}" />
+      <img src="{% image_url author.image "fill-100x100" %}" alt="{{ author.name }}" title="{{ author.name }}" />
     {% endif %}
     </div>
   {% endfor %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/news_you_can_use.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/news_you_can_use.html
@@ -27,7 +27,7 @@
       <div class="d-none d-xl-block col-xl-12 feature mb-md-5">
         <div class="position-relative h-100 d-flex justify-content-end">
           <div class="feature-image">
-            {% image first.get_meta_image fill-1000x500 %}
+            <img src="{% image_url first.get_meta_image "fill-1000x500" %}" alt="{{ first.title }}">
           </div>
           <div class="feature-content align-self-center">
             {% if first.category.count %}
@@ -58,7 +58,7 @@
       {% for item in items %}
       <div class="col-12 col-md-6 col-xl-4 d-flex {% if forloop.counter == 1 %} {{item_1_class}}{% endif %} {% if forloop.counter == 2 %} {{item_2_class}}{% endif %} {% if forloop.counter == 3 %} {{item_3_class}}{% endif %}">
         <div class="bg-white">
-          {% image item.blog.get_meta_image fill-700x394 class="embed-responsive-item" %}
+          <img src="{% image_url item.blog.get_meta_image "fill-700x394" %}" alt="" class="embed-responsive-item">
           <div class="p-4">
             {% if item.blog.category.count %}
               {% with category=item.blog.category.first %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/partner.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/partner.html
@@ -1,8 +1,7 @@
 {% load wagtailimages_tags %}
 
 
-{% image page.partner_background_image fill-1200x600 as partner_img %}
-<div class="bg-secondary partner-section dark-theme" style='background-image: url("{{ partner_img.url }}");'>
+<div class="bg-secondary partner-section dark-theme" style='background-image: url("{% image_url page.partner_background_image "fill-1200x600" %}");'>
   <div class="container">
     <div class="row">
       <div class="col-12">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/primary_heroguts.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/primary_heroguts.html
@@ -2,33 +2,25 @@
 
 <div id="hero">
   <div class="banner bg-black">
-    {% with banner=page.specific.get_banner %}
+    {% with banner=page.hero_image %}
       {% if banner %}
         {% if homepage %}
         <picture>
-          {% image banner fill-4032x480 as image_xl %}
-          {% image banner fill-2400x480 as image_lg %}
-          {% image banner fill-1984x480 as image_md %}
-          {% image banner fill-1536x390 as image_sm %}
-          <source media="(min-width: 1200px)" srcset="{{ image_xl.url }}">
-          <source media="(min-width: 992px)" srcset="{{ image_lg.url }}">
-          <source media="(min-width: 768px)" srcset="{{ image_md.url }}">
-          <source media="(min-width: 576px)" srcset="{{ image_sm.url }}">
+          <source media="(min-width: 1200px)" srcset="{% image_url banner "fill-4032x480" %}">
+          <source media="(min-width: 992px)" srcset="{% image_url banner "fill-2400x480" %}">
+          <source media="(min-width: 768px)" srcset="{% image_url banner "fill-1984x480" %}">
+          <source media="(min-width: 576px)" srcset="{% image_url banner "fill-1536x390" %}">
           {# Fallback Image #}
-          <img src="{{ image_sm.url }}" alt="">
+          <img src="{% image_url banner "fill-1536x390" %}" alt="">
         </picture>
         {% else %}
         <picture>
-          {% image banner fill-4032x1152 as image_xl %}
-          {% image banner fill-2400x686 as image_lg %}
-          {% image banner fill-1984x567 as image_md %}
-          {% image banner fill-1536x439 as image_sm %}
-          <source media="(min-width: 1200px)" srcset="{{ image_xl.url }}">
-          <source media="(min-width: 992px)" srcset="{{ image_lg.url }}">
-          <source media="(min-width: 768px)" srcset="{{ image_md.url }}">
-          <source media="(min-width: 576px)" srcset="{{ image_sm.url }}">
+          <source media="(min-width: 1200px)" srcset="{% image_url banner "fill-4032x1152" %}">
+          <source media="(min-width: 992px)" srcset="{% image_url banner "fill-2400x686" %}">
+          <source media="(min-width: 768px)" srcset="{% image_url banner "fill-1984x567" %}">
+          <source media="(min-width: 576px)" srcset="{% image_url banner "fill-1536x439" %}">
           {# Fallback Image #}
-          {% image banner fill-1008x288 alt="" %}
+          <img src="{% image_url banner "fill-1536x439" %}" alt="">
         </picture>
         {% endif %}
       {% else %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/quote.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/quote.html
@@ -11,19 +11,11 @@
     {% endcomment %}
     {% with alt_text=quote_image.alt %}
     <picture class="cms-image {{class_names}}">
-        {% image quote_image width-540 as image_large %}
-        {% image quote_image width-1080 as image_large_2x %}
-        <source media="(min-width: 992px)" srcset="{{ image_large.url }}, {{ image_large_2x.url }} 2x"  alt="{{ alt_text }}">
+        <source media="(min-width: 992px)" srcset="{% image_url quote_image "width-540" %}, {% image_url quote_image "width-1080" %} 2x"  alt="{{ alt_text }}">
+        <source media="(min-width: 768px)" srcset="{% image_url quote_image "width-210" %}, {% image_url quote_image "width-420" %} 2x" alt="{{ alt_text }}">
+        <source srcset="{% image_url quote_image "width-510" %}, {% image_url quote_image "width-1020" %} 2x" alt="{{ alt_text }}">
 
-        {% image quote_image width-210 as image_medium %}
-        {% image quote_image width-420 as image_medium_2x %}
-        <source media="(min-width: 768px)" srcset="{{ image_medium.url }}, {{ image_medium_2x.url }} 2x" alt="{{ alt_text }}">
-
-        {% image quote_image width-510 as image_small %}
-        {% image quote_image width-1020 as image_small_2x %}
-        <source srcset="{{ image_small.url }}, {{ image_small_2x.url }} 2x" alt="{{ alt_text }}">
-
-        <img src="{{ image_large.url }}" class="wagtail-image w-100" srcset="{{image_small.url}} 510w, {{ image_medium.url }} 210w, {{ image_large.url }} 540w" alt="{{ alt_text }}"/>
+        <img src="{% image_url quote_image "width-540" %}" class="wagtail-image w-100" srcset="{% image_url quote_image "width-510" %} 510w, {% image_url quote_image "width-210" %} 210w, {% image_url quote_image "width-540" %} 540w" alt="{{ alt_text }}"/>
     </picture>
     {% endwith %}
   </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/spotlight_posts.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/spotlight_posts.html
@@ -5,9 +5,8 @@
   <div class="col-12">
     <h2 class="capsule-label mb-0 ml-md-4">{% trans "Spotlight" %}</h2>
   </div>
-  {% image page.spotlight_image width-540 as spotlight_image %}
   <div class="col-12 col-lg-6 mb-md-4 mb-lg-0 dark-theme">
-    <div class="spotlight-banner d-flex align-items-end full-bleed-xs p-3 p-md-4" style="background-image: linear-gradient(180deg, rgba(238,238,238,0) 14%, #000000 100%), url({{spotlight_image.url}});">
+    <div class="spotlight-banner d-flex align-items-end full-bleed-xs p-3 p-md-4" style="background-image: linear-gradient(180deg, rgba(238,238,238,0) 14%, #000000 100%), url({% image_url page.spotlight_image "width-540" %});">
       <h3 class="h2-heading spotlight-headline mb-0">{{ page.spotlight_headline }}</h3>
     </div>
   </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/take_action.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/take_action.html
@@ -11,9 +11,8 @@
           {% for item in page.take_action_cards.all %}
             <div class="col-md-6 d-flex">
               <div class="card flex-grow-1 mb-4">
-                {% image item.image fill-350x130 as img %}
                   <a href="{{ item.internal_link.url }}">
-                    <img src="{{ img.url }}" class="card-img-top" alt="{{ img.alt }}" aria-label="{{ item.text }}">
+                    <img src="{% image_url item.image "fill-350x130" %}" class="card-img-top" alt="{{ img.alt }}" aria-label="{{ item.text }}">
                   </a>
                   <div class="card-body">
                     <a href="{{ item.internal_link.url }}" class="h5-heading d-inline-block my-2">


### PR DESCRIPTION
Closes #6626 

### Things to try:
- [x] [Dynamic images](https://docs.wagtail.io/en/stable/advanced_topics/images/image_serve_view.html) - we do this one the PNI Homepage already 
- [ ] Reducing the number of image renditions we actually need. Remember, each rendition = 1 query OR if the image rendition size doesn't exist yet then it's going to process the image (crop it). We want to reduce this time as it makes time to first byte take longer. 
- [ ] If all else fails, lets look into template caching entire sections of the home page. 
  - [ ] We'll need to invalidate the cache when a related page is changed (using a wagtail hook most likely) and invalidate the cache when the homepage is saved.

I've implemented Dynamic image URLs on the homepage in several spots (not all due to some other issues that came up). But this should, hopefully, reduce page load times drastically and defer the image rendition and process to a new HTTP request. 

If this passes CI we should implement this in `master` and see how it goes. If the homepage is still slow, we'll reduce image <source>'s being generated (which won't speed things up too much) and add some caching as well. If we take this route, it'll go in its own ticket. 

🤞 Hope Percy doesn't hate this! 