### PR TITLE
Article page preview fixes

### DIFF
--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -325,30 +325,14 @@ def get_plaintext_titles(request, stream_data, stream_block_name):
         ('second-title-here', 'Second Title Here')
     )
     """
-    # Data is stored differently for live pages with streamfield data vs. preview streamfield data.
-    if not request.is_preview:
-        body = stream_data.__dict__['_raw_data']
-    else:
-        body = stream_data.__dict__['_bound_blocks']
     data = {}
     headers = []
-    for block in body:
-        if not request.is_preview:
-            # Check for live versions of the page first because these will be served
-            # much more frequently than preview pages.
-            # In live pages (not previews) we have a block `type` and block `value`.
-            if block['type'] == stream_block_name:
-                soup = BeautifulSoup(block['value'], 'html.parser')
-                _headers = soup.findAll('h2')
-                for _h in _headers:
-                    headers.append(_h.get_text())
-        else:
-            # If the page is a preview, look for preview streamfield data.
-            if block.block_type == stream_block_name:
-                soup = BeautifulSoup(str(block.value), 'html.parser')
-                _headers = soup.findAll('h2')
-                for _h in _headers:
-                    headers.append(_h.get_text())
+    for block in stream_data:
+        if block.block_type == stream_block_name:
+            soup = BeautifulSoup(str(block.value), 'html.parser')
+            _headers = soup.findAll('h2')
+            for _h in _headers:
+                headers.append(_h.get_text())
     data = {
         slugify(header): header for header in headers
     }

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -336,20 +336,14 @@ def get_plaintext_titles(request, stream_data, stream_block_name):
         if not request.is_preview:
             # Check for live versions of the page first because these will be served
             # much more frequently than preview pages.
-            # In live pages (not previewed) we have a block `type` and block `value`.
-            # In preview pages, we have a tuple where the first value is the block['type']
-            # and the second value is the block['value']
-            for block in body:
-                if block['type'] == stream_block_name:
-                    soup = BeautifulSoup(block['value'], 'html.parser')
-                    _headers = soup.findAll('h2')
-                    for _h in _headers:
-                        headers.append(_h.get_text())
+            # In live pages (not previews) we have a block `type` and block `value`.
+            if block['type'] == stream_block_name:
+                soup = BeautifulSoup(block['value'], 'html.parser')
+                _headers = soup.findAll('h2')
+                for _h in _headers:
+                    headers.append(_h.get_text())
         else:
-            # If the page is a preview, look for live streamfield data.
-            # Previewed streamfield is stored differently than live streamfield data; as a tuple
-            # And thus we check if the first value is the block name, and the second value in
-            # the tuple is going to be the actual block data.
+            # If the page is a preview, look for preview streamfield data.
             if block.block_type == stream_block_name:
                 soup = BeautifulSoup(str(block.value), 'html.parser')
                 _headers = soup.findAll('h2')

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -325,8 +325,11 @@ def get_plaintext_titles(request, stream_data, stream_block_name):
         ('second-title-here', 'Second Title Here')
     )
     """
-
-    body = stream_data.__dict__['_raw_data']
+    # Data is stored differently for live pages with streamfield data vs. preview streamfield data.
+    if not request.is_preview:
+        body = stream_data.__dict__['_raw_data']
+    else:
+        body = stream_data.__dict__['_bound_blocks']
     data = {}
     headers = []
     for block in body:
@@ -347,11 +350,11 @@ def get_plaintext_titles(request, stream_data, stream_block_name):
             # Previewed streamfield is stored differently than live streamfield data; as a tuple
             # And thus we check if the first value is the block name, and the second value in
             # the tuple is going to be the actual block data.
-            if block[0] == stream_block_name:
-                soup = BeautifulSoup(str(block[1]), 'html.parser')
+            if block.block_type == stream_block_name:
+                soup = BeautifulSoup(str(block.value), 'html.parser')
                 _headers = soup.findAll('h2')
                 for _h in _headers:
-                    headers.append(_h.text)
+                    headers.append(_h.get_text())
     data = {
         slugify(header): header for header in headers
     }


### PR DESCRIPTION
Closes #6763 

**Link to sample test pages**: 
1. Click "preview" on this page https://foundation-s-6763-publi-e3q2tx.herokuapp.com/cms/pages/163/edit/ 
2. This link is a published page https://foundation-s-6763-publi-e3q2tx.herokuapp.com/en/publication-page-with-child-article-pages/weight-yes-idea-need-discover-live-act-ago/ 

Steps to test locally:
1. Create a new Article page (under a Publication page) then preview the unsaved and undrafted version with an h2 inside of a "content" block 
2. Save the page as a draft. Preview the draft. 
3. Publish the page. Live-view the page. 
4. Everything should be working as expected. 


## Checklist

_Remove unnecessary checks_

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/master/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). **They are not. These changes are for Wagtail 2.12+ with telepath**

**Documentation:**
- [x] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
