### PR TITLE
Fix the language picker

### DIFF
--- a/network-api/networkapi/templates/fragments/language_switcher.html
+++ b/network-api/networkapi/templates/fragments/language_switcher.html
@@ -4,7 +4,6 @@
 {% get_local_language_names as languages %}
 
 <form action="{% url 'set_language' %}" method="post">
-  {% csrf_token %}
   <input name="next" type="hidden" value="{% get_unlocalized_url page current_language %}" />
   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-center mb-md-0">
     <label class="h5-heading mb-0 d-flex align-items-center globe-glyph medium" for="language-switcher">{% trans "Language" %}</label>

--- a/network-api/networkapi/templates/fragments/language_switcher.html
+++ b/network-api/networkapi/templates/fragments/language_switcher.html
@@ -1,15 +1,17 @@
-{% load i18n localization %}
+{% load i18n localization wagtailcore_tags %}
+
+{% get_current_language as current_language %}
+{% get_local_language_names as languages %}
 
 <form action="{% url 'set_language' %}" method="post">
-  <input name="next" type="hidden" value="{{ request.path }}">
+  {% csrf_token %}
+  <input name="next" type="hidden" value="{% get_unlocalized_url page current_language %}" />
   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-center mb-md-0">
     <label class="h5-heading mb-0 d-flex align-items-center globe-glyph medium" for="language-switcher">{% trans "Language" %}</label>
     <select name="language" id="language-switcher" class="mt-3 mt-md-0 ml-md-3 w-100 form-control" onchange="this.form.submit()">
-      {% get_current_language as LANGUAGE_CODE %}
-      {% get_local_language_names as LANGUAGES %}
-      {% for CODE, NAME in LANGUAGES %}
-        <option value="{{ CODE }}"{% if CODE == LANGUAGE_CODE %} selected{% endif %}>
-          {{ NAME | capfirst }}
+      {% for language_code, language_name in languages %}
+        <option value="{{ language_code }}"{% if language_code == current_language %} selected{% endif %}>
+          {{ language_name | capfirst }}
         </option>
       {% endfor %}
     </select>

--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -43,3 +43,9 @@ def get_local_language_names():
     for lang in settings.LANGUAGES:
         languages.append([lang[0], get_language_info(lang[0])['name_local']])
     return sorted(languages, key=lambda x: locale.strxfrm(unicodedata.normalize('NFD', x[1])).casefold())
+
+
+# Get the url for a page, but with the locale code removed.
+@register.simple_tag()
+def get_unlocalized_url(page, locale):
+    return page.get_url().replace(f'/{locale}/', '/', 1)


### PR DESCRIPTION
Closes #6710 by making sure that the `next` form field points to the same page, but with the locale stripped off, so that Django can correctly further-redirect  from unlocalized to "localized, but for the new prefered locale".

This may also address https://github.com/mozilla/foundation.mozilla.org/issues/4290

Testing:

- load up https://foundation-s-wagtail-lo-6oyjbi.herokuapp.com/
- switch to "nederlands" with the footer picker
- notice the page text is now different (there is an nl localised homepage in the cms).
- now switch to "english" with the footer picker
- notice the page is back to `/en/`