### PR TITLE
use the correct static tagset

### DIFF
--- a/network-api/networkapi/wagtailcustomization/templates/wagtailadmin/404.html
+++ b/network-api/networkapi/wagtailcustomization/templates/wagtailadmin/404.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailadmin_tags wagtailcore_tags staticfiles i18n %}
+{% load wagtailadmin_tags wagtailcore_tags static i18n %}
 
 {% block titletag %}{% trans "Error 404: Page not found" %}{% endblock %}
 


### PR DESCRIPTION
Closes #6774 by making the 404 page use the proper `static` tagset, instead of the nonexistent `staticfiles`