### PR TITLE
allow authenticated users to hit the wagtail localize endpoints

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -477,7 +477,7 @@ if env("FRONTEND_CACHE_CLOUDFLARE_BEARER_TOKEN"):
 # Rest Framework Settings
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.IsAdminUser',
     ]
 }
 

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -477,7 +477,7 @@ if env("FRONTEND_CACHE_CLOUDFLARE_BEARER_TOKEN"):
 # Rest Framework Settings
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
+        'rest_framework.permissions.IsAuthenticated',
     ]
 }
 


### PR DESCRIPTION
Closes #6776 by opening all DRF endpoints as long as people are authenticated. We can tighten this further if we need to, but any locale changes folks would be tempted to make get overwritten by Pontoon, so leaving this a matter of policy, rather than a matter of code, feels fine for now.