### PR TITLE
Show locale in admin title 

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/mixin/foundation_metadata.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/mixin/foundation_metadata.py
@@ -1,4 +1,5 @@
 from taggit.models import Tag
+
 from wagtailmetadata.models import MetadataPageMixin
 from wagtail.images.models import Image
 
@@ -68,6 +69,12 @@ class FoundationMetadataPageMixin(MetadataPageMixin):
         # We still haven't found a social share image, so, last resort: return
         # whatever is the default social share image. Which could be `None`!
         return default_social_share_image
+
+    def get_admin_display_title(self):
+        title = self.draft_title or self.title
+        if self.locale:
+            return f"({self.locale.language_code}) {title}"
+        return title
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Closes #6839 

This small PR adds `({code})`to the front of all page titles. This is not a very elegant solution but it helps us determine which pages are in what language and works for the time being. 

This is not the final solution to this, and should at some point be followed up by #6842 and possibly a Wagtail Core update to support this. 