### PR TITLE
Permanent pt-BR redirect

### DIFF
--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -72,7 +72,7 @@ urlpatterns = list(filter(None, [
     path("footnotes/", include(footnotes_urls)),
 
     # redirect /pt to /pt-BR. See https://github.com/mozilla/foundation.mozilla.org/issues/5993
-    re_path(r'^pt/(?P<rest>.*)', RedirectView.as_view(url='/pt-BR/%(rest)s', query_string=True)),
+    re_path(r'^pt/(?P<rest>.*)', RedirectView.as_view(url='/pt-BR/%(rest)s', query_string=True, permanent=True)),
 ]))
 
 # Anything that needs to respect the localised


### PR DESCRIPTION
Noticed redirects are temporary by default, we actually want to send a 301 HTTP status code so that search engines update URLs to pt-BR.

Fortunately, doing so is as simple as [passing an arg](https://docs.djangoproject.com/en/3.1/topics/http/shortcuts/#redirect)