### PR TITLE
WIP: Streamfield blocks now using streamfield-as-row method

### DIFF
--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -32,26 +32,27 @@
 
 {% block content %}
   {% block secondary_nav %}{% endblock %}
-  <div class="container">
-    <div class="row">
+
       {% if page.signup != None %}
 
-        {# Use a two-colum layout #}
-        <div class="cms pb-5 col-lg-7">
-          {% include "partials/streamfield.html" with twocolumn=True %}
+        {# Use a two-column layout #}
+        <div class="container">
+          <div class="row">
+            <div class="cms mozfest-content two-col">
+              {% include "partials/streamfield.html" with twocolumn=True %}
+            </div>
+            {% block cta %}{% include "partials/signup.html" %}{% endblock %}
+          </div>
         </div>
-        {% block cta %}{% include "partials/signup.html" %}{% endblock %}
-
       {% else %}
 
         {# Single column layout #}
-        <div class="cms {% block bootstrap_width %}col-lg-8 offset-lg-2{% endblock %}">
+        <div class="cms mozfest-content">
           {% include "partials/streamfield.html" %}
         </div>
 
       {% endif %}
-    </div>
-  </div>
+
 {% endblock %}
 
 

--- a/network-api/networkapi/mozfest/templates/partials/streamfield.html
+++ b/network-api/networkapi/mozfest/templates/partials/streamfield.html
@@ -1,9 +1,19 @@
 {% load wagtailcore_tags %}
 
 {% for block in page.body %}
-  {% if block.block_type == 'heading' %}
-    <h1>{{ block.value }}</h1>
-  {% else %}
-    {% include_block block %}
-  {% endif %}
+{% if block.block_type == 'paragraph'%}
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      {% if block.block_type == 'heading' %}
+      <h1>{{ block.value }}</h1>
+      {% else %}
+      {% include_block block with parent_page=page page_type="blog"%}
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% else %}
+{% include_block block with parent_page=page page_type="blog" %}
+{% endif %}
 {% endfor %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/article_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/article_page.html
@@ -15,7 +15,7 @@
 
   <div class="container {% if not get_titles %} mt-5{% endif %}">
     <div class="row">
-      <div class="offset-sm-1 col-sm-10 col-12 article-blocks">
+      <div class="offset-sm-1 col-sm-10 col-12">
         {% if page.show_side_share_buttons %}
           <div class="article-summary-share-links d-lg-block d-none {% if get_titles %}with-top-offset{% endif %}">
             <div class="share-button-group-wrapper" data-version="mini" data-layout="stacked" data-share-text="{% blocktrans with title=page.title %}{{ title }} by @mozilla{% endblocktrans %}" data-link="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}"></div>
@@ -37,9 +37,9 @@
     </div>
   </div>
 
-  <div class="cms article-page-content mt-5">
+  <div class="cms article-page-content">
     {% for block in page.body %}
-    <h1> {{block.block_type}}</h1>
+    <!-- <h1> {{block.block_type}}</h1> -->
       {% if block.block_type == 'content'%}
         <div class="container {{block.block_type}}-block">
           <div class="row justify-content-center">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/article_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/article_page.html
@@ -39,7 +39,6 @@
 
   <div class="cms article-page-content">
     {% for block in page.body %}
-    <!-- <h1> {{block.block_type}}</h1> -->
       {% if block.block_type == 'content'%}
         <div class="container {{block.block_type}}-block">
           <div class="row justify-content-center">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/article_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/article_page.html
@@ -33,17 +33,29 @@
             </div>
           </div>
         {% endif %}
-
-
-        {% for block in page.body %}
-          {% comment %}
-            `is_last` is used to determine if a streamfield should close
-            after breaking out of its parent container
-          {% endcomment %}
-          {% include_block block with is_last=forloop.last page_type="article" %}
-        {% endfor %}
       </div>
     </div>
+  </div>
+
+  <div class="cms article-page-content mt-5">
+    {% for block in page.body %}
+    <h1> {{block.block_type}}</h1>
+      {% if block.block_type == 'content'%}
+        <div class="container {{block.block_type}}-block">
+          <div class="row justify-content-center">
+            <div class="streamfield-content">
+              {% if block.block_type == 'heading' %}
+                <h1>{{ block.value }}</h1>
+              {% else %}
+                {% include_block block with page_type="article" %}
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      {% else %}
+        {% include_block block with parent_page=page page_type="article" %}
+      {% endif %}
+    {% endfor %}
   </div>
 
   {% if page.footnotes_list %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/advanced_table_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/advanced_table_block.html
@@ -1,52 +1,59 @@
 {% load wagtailcore_tags %}
 
-<div class="article-table-block table-responsive">
-  <table class="table">
-    {% if self.caption %}
-      <caption>{{ self.caption }}</caption>
-    {% endif %}
 
-    {# Loop through every row #}
-    {% for row in self.table %}
-      {# If the "header" is checked, the first row will be a <thead> with a highlighted background #}
-      {% if self.header and forloop.first %}
-        <thead>
-          <tr>
-            {% for cell in row.value %}
-              <th
-                scope="col"
-                {% if cell.value.column_width %}colspan="{{ cell.value.column_width }}"{% endif %}
-                class="highlighted {% if cell.value.centered_text %}text-center{% endif %}"
-              >
-                {{ cell.value.content|richtext }}
-              </th>
-            {% endfor %}
-          </tr>
-        </thead>
-      {% else %}
-        {# For every other row that's not a header... #}
-        <tr>
-          {% for cell in row.value %}
-            {# If the first cell is supposed to be highlighted; when "column" is checked #}
-            {% if self.column %}
-              <td
-                {% if cell.value.column_width %}colspan="{{ cell.value.column_width }}"{% endif %}
-                class="{% if forloop.first and self.column and not cell.value.column_width %}highlighted{% endif %} {% if cell.value.centered_text %}text-center{% endif %} column-width-20"
-              >
-                {{ cell.value.content|richtext }}
-              </td>
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div class="article-table-block table-responsive">
+        <table class="table">
+          {% if self.caption %}
+            <caption>{{ self.caption }}</caption>
+          {% endif %}
+
+          {# Loop through every row #}
+          {% for row in self.table %}
+            {# If the "header" is checked, the first row will be a <thead> with a highlighted background #}
+            {% if self.header and forloop.first %}
+              <thead>
+                <tr>
+                  {% for cell in row.value %}
+                    <th
+                      scope="col"
+                      {% if cell.value.column_width %}colspan="{{ cell.value.column_width }}"{% endif %}
+                      class="highlighted {% if cell.value.centered_text %}text-center{% endif %}"
+                    >
+                      {{ cell.value.content|richtext }}
+                    </th>
+                  {% endfor %}
+                </tr>
+              </thead>
             {% else %}
-              {# For every other cell; when "column" is not checked #}
-              <td
-                {% if cell.value.column_width %}colspan="{{ cell.value.column_width }}"{% endif %}
-                class="{% if forloop.first and self.column %}highlighted{% endif %} {% if cell.value.centered_text %}text-center{% endif %}"
-              >
-                {{ cell.value.content|richtext }}
-              </td>
+              {# For every other row that's not a header... #}
+              <tr>
+                {% for cell in row.value %}
+                  {# If the first cell is supposed to be highlighted; when "column" is checked #}
+                  {% if self.column %}
+                    <td
+                      {% if cell.value.column_width %}colspan="{{ cell.value.column_width }}"{% endif %}
+                      class="{% if forloop.first and self.column and not cell.value.column_width %}highlighted{% endif %} {% if cell.value.centered_text %}text-center{% endif %} column-width-20"
+                    >
+                      {{ cell.value.content|richtext }}
+                    </td>
+                  {% else %}
+                    {# For every other cell; when "column" is not checked #}
+                    <td
+                      {% if cell.value.column_width %}colspan="{{ cell.value.column_width }}"{% endif %}
+                      class="{% if forloop.first and self.column %}highlighted{% endif %} {% if cell.value.centered_text %}text-center{% endif %}"
+                    >
+                      {{ cell.value.content|richtext }}
+                    </td>
+                  {% endif %}
+                {% endfor %}
+              </tr>
             {% endif %}
           {% endfor %}
-        </tr>
-      {% endif %}
-    {% endfor %}
-  </table>
+        </table>
+      </div>
+    </div>
+  </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/airtable_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/airtable_block.html
@@ -1,1 +1,10 @@
-<script async defer src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></script><iframe class="airtable-embed mb-4 airtable-dynamic-height" src="{{ value.url }}" frameborder="0" onmousewheel="" width="100%" height="{{ value.height }}" style="background: transparent; border: 1px solid #ccc;"></iframe>
+<div class="container {{block.block_type}}-block">
+    <div class="row justify-content-center no-gutters">
+        <div class="streamfield-content">
+            <script async defer src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></script><iframe
+                class="airtable-embed mb-4 airtable-dynamic-height" src="{{ value.url }}" frameborder="0"
+                onmousewheel="" width="100%" height="{{ value.height }}"
+                style="background: transparent; border: 1px solid #ccc;"></iframe>
+        </div>
+    </div>
+</div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/annotated_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/annotated_image_block.html
@@ -2,29 +2,23 @@
 
 {% image value.image original as img %}
 
-{% if value.wide_image %}
-    </div> <!-- End .blog-body -->
-  </div> <!-- End .cms -->
-</div> <!-- End .col-lg-8 -->
+<div class="container {{block.block_type}}-block {% if value.wide_image %} wide w-100 mw-100 px-0 mx-0{% endif %}">
+  <div class="row justify-content-center no-gutters">
+    <div class="{% if value.wide_image %} wide {% else %} streamfield-content {% endif %} ">
+      <figure class="my-default">
+        <img src="{{ img.url }}" alt="{{ value.altText }}" class="w-100" />
+        {% if value.caption %}
+        <figcaption class="body-small d-block mt-2">
+          {% if value.captionURL %}<a href="{{ value.captionURL }}">{% endif %}
+          {{ value.caption }}
+          {% if value.captionURL %}</a>{% endif %}
+        </figcaption>
+        {% endif %}
+      </figure>
+      </div>
+  </div>
+</div> 
 
-<div class="col-lg-12">
-{% endif %}
 
-  <figure class="my-default">
-    <img src="{{ img.url }}" alt="{{ value.altText }}" class="w-100" />
-    {% if value.caption %}
-    <figcaption class="body-small d-block mt-2">
-      {% if value.captionURL %}<a href="{{ value.captionURL }}">{% endif %}
-      {{ value.caption }}
-      {% if value.captionURL %}</a>{% endif %}
-    </figcaption>
-    {% endif %}
-  </figure>
 
-{% if value.wide_image %}
-</div>
 
-<div class="py-4 py-md-5 col-lg-8 offset-lg-2">
-  <div class="cms">
-    <div class="blog-body">
-{% endif %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/annotated_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/annotated_image_block.html
@@ -5,7 +5,7 @@
 <div class="container {{block.block_type}}-block {% if value.wide_image %} wide w-100 mw-100 px-0 mx-0{% endif %}">
   <div class="row justify-content-center no-gutters">
     <div class="{% if value.wide_image %} wide {% else %} streamfield-content {% endif %} ">
-      <figure class="my-default">
+      <figure>
         <img src="{{ img.url }}" alt="{{ value.altText }}" class="w-100" />
         {% if value.caption %}
         <figcaption class="body-small d-block mt-2">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/annotated_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/annotated_image_block.html
@@ -2,7 +2,7 @@
 
 {% image value.image original as img %}
 
-<div class="container {{block.block_type}}-block {% if value.wide_image %} wide w-100 mw-100 px-0 mx-0{% endif %}">
+<div class="container {{block.block_type}}-block">
   <div class="row justify-content-center no-gutters">
     <div class="{% if value.wide_image %} wide {% else %} streamfield-content {% endif %} ">
       <figure>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_blockquote_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_blockquote_block.html
@@ -1,3 +1,10 @@
-<div class="article-blockquote-block mx-auto my-4 {% if self|length > 230 %}article-blockquote-block--small{% endif %}">
-  {{ self }}
+
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div class="article-blockquote-block mx-auto my-4 {% if self|length > 230 %}article-blockquote-block--small{% endif %}">
+        {{ self }}
+      </div>
+    </div>
+  </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
@@ -3,7 +3,7 @@
 <div class="container {{block.block_type}}-block">
   <div class="row justify-content-center">
     <div class="streamfield-content">
-      <div class="offset-sm-1 double-image-block">
+      <div class="double-image-block">
         <div class="row">
           <div class="col-sm-6">
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
@@ -8,7 +8,7 @@
           <div class="col-sm-6">
 
             {% image self.image_1 fill-445x324 as img1 %}
-            <figure>
+            <figure class="my-default">
               <img src="{{ img1.url }}" alt="{{ img1.alt }}" class="w-100" />
               {% if self.image_1_caption %}
                 <figcaption>
@@ -21,7 +21,7 @@
           <div class="col-sm-6">
 
             {% image self.image_2 fill-445x324 as img2 %}
-            <figure>
+            <figure  class="my-default">
               <img src="{{ img2.url }}" alt="{{ img2.alt }}" class="w-100" />
               {% if self.image_2_caption %}
                 <figcaption>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
@@ -8,7 +8,7 @@
           <div class="col-sm-6">
 
             {% image self.image_1 fill-445x324 as img1 %}
-            <figure class="my-default">
+            <figure>
               <img src="{{ img1.url }}" alt="{{ img1.alt }}" class="w-100" />
               {% if self.image_1_caption %}
                 <figcaption>
@@ -21,7 +21,7 @@
           <div class="col-sm-6">
 
             {% image self.image_2 fill-445x324 as img2 %}
-            <figure class="my-default">
+            <figure>
               <img src="{{ img2.url }}" alt="{{ img2.alt }}" class="w-100" />
               {% if self.image_2_caption %}
                 <figcaption>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
@@ -1,37 +1,38 @@
 {% load wagtailcore_tags wagtailimages_tags remove_richtext_wrapping %}
 
-</div> <!-- End .col-sm-10 from main container -->
-  <div class="col-sm-10 offset-sm-1 double-image-block">
-    <div class="row">
-      <div class="col-sm-6">
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div class="offset-sm-1 double-image-block">
+        <div class="row">
+          <div class="col-sm-6">
 
-        {% image self.image_1 fill-445x324 as img1 %}
-        <figure class="my-default">
-          <img src="{{ img1.url }}" alt="{{ img1.alt }}" class="w-100" />
-          {% if self.image_1_caption %}
-            <figcaption>
-              {{ self.image_1_caption|richtext|remove_wrapping|safe }}
-            </figcaption>
-          {% endif %}
-        </figure>
+            {% image self.image_1 fill-445x324 as img1 %}
+            <figure class="my-default">
+              <img src="{{ img1.url }}" alt="{{ img1.alt }}" class="w-100" />
+              {% if self.image_1_caption %}
+                <figcaption>
+                  {{ self.image_1_caption|richtext|remove_wrapping|safe }}
+                </figcaption>
+              {% endif %}
+            </figure>
 
-      </div>
-      <div class="col-sm-6">
+          </div>
+          <div class="col-sm-6">
 
-        {% image self.image_2 fill-445x324 as img2 %}
-        <figure class="my-default">
-          <img src="{{ img2.url }}" alt="{{ img2.alt }}" class="w-100" />
-          {% if self.image_2_caption %}
-            <figcaption>
-              {{ self.image_2_caption|richtext|remove_wrapping|safe }}
-            </figcaption>
-          {% endif %}
-        </figure>
+            {% image self.image_2 fill-445x324 as img2 %}
+            <figure class="my-default">
+              <img src="{{ img2.url }}" alt="{{ img2.alt }}" class="w-100" />
+              {% if self.image_2_caption %}
+                <figcaption>
+                  {{ self.image_2_caption|richtext|remove_wrapping|safe }}
+                </figcaption>
+              {% endif %}
+            </figure>
 
+          </div>
+        </div>
       </div>
     </div>
   </div>
-{% if not is_last %}
-  {# Re-start the same containing row thats on the main article_page.html file #}
-  <div class="offset-sm-1 col-sm-10 col-12 article-blocks">
-{% endif %}
+</div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_full_width_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_full_width_image_block.html
@@ -1,33 +1,27 @@
 {% load wagtailimages_tags wagtailcore_tags custom_image_tags remove_richtext_wrapping %}
 
-    {% comment %} End the Article Block bootstrap grid {% endcomment %}
-    </div> <!-- End .col-sm-10 from main container -->
-  </div> <!-- End .row -->
-</div> <!-- End .container -->
 
-  <div class="full-width-image-block">
-    {% custom_image_height self.image self.image_height as img %}
-    <figure class="my-default">
-      <img src="{{ img.url }}" alt="{{ img.alt }}" class="w-100" />
-      {% if self.caption %}
-        <div class="container">
-          <div class="row">
-            <div class="offset-sm-1 col-sm-10 col-12 article-blocks">
+<div class="container {{block.block_type}}-block  wide w-100 mw-100 px-0 mx-0">
+  <div class="row justify-content-center no-gutters">
+    <div class="wide">
+      <div class="full-width-image-block">
+        {% custom_image_height self.image self.image_height as img %}
+        <figure class="my-default">
+          <img src="{{ img.url }}" alt="{{ img.alt }}" class="w-100" />
+          {% if self.caption %}
+            <div class="container">
+              <div class="row">
+                <div class="offset-sm-1 col-sm-10 col-12 article-blocks">
 
-              <figcaption>
-                {{ self.caption|richtext|remove_wrapping|safe }}
-              </figcaption>
+                  <figcaption>
+                    {{ self.caption|richtext|remove_wrapping|safe }}
+                  </figcaption>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      {% endif %}
-    </figure>
+          {% endif %}
+        </figure>
+      </div>
+    </div>
   </div>
-
-  {% comment %} Restart the Article Block bootstrap grid. If it is the last item, hide the empty container to keep from pushing footer down a couple px{% endcomment %}
-  <div class="container {% if is_last %}d-none{% endif %}"> <!-- Re-opening container -->
-    <div class="row"> <!-- Re-opening row -->
-      <div class="offset-sm-1 col-sm-10 col-12 article-blocks"> <!-- Re-opening col-sm-10 from main container -->
-
-
-
+</div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_full_width_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_full_width_image_block.html
@@ -6,7 +6,7 @@
     <div class="wide">
       <div class="full-width-image-block">
         {% custom_image_height self.image self.image_height as img %}
-        <figure class="my-default">
+        <figure>
           <img src="{{ img.url }}" alt="{{ img.alt }}" class="w-100" />
           {% if self.caption %}
             <div class="container">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_image_block.html
@@ -1,23 +1,19 @@
 {% load wagtailimages_tags wagtailcore_tags remove_richtext_wrapping %}
 
-{% comment %} We need to break out of the main container and re-open the container at the end {% endcomment %}
-{% if self.wide_image %}
-  </div>
-{% endif %}
-
-<div class="article-image-block {% if self.wide_image %}container{% endif %}">
-  {% comment %}Use a 2x resolution image{% endcomment %}
-  {% image self.image width-1840 as img %}
-  <figure class="my-default">
-    <img src="{{ img.url }}" alt="{% if self.alt_text %}{{ self.alt_text }}{% else %}{{ img.alt }}{% endif %}" class="w-100" />
-    {% if self.caption %}
+<div class="container {{block.block_type}}-block {% if value.wide_image %} wide w-100 mw-100 px-0 mx-0{% endif %}">
+  <div class="row justify-content-center no-gutters">
+    <div class="article-image-block {% if value.wide_image %} wide {% else %} streamfield-content {% endif %} ">
+      {% comment %}Use a 2x resolution image{% endcomment %}
+      {% image self.image width-1840 as img %}
+      <figure class="my-default">
+        <img src="{{ img.url }}" alt="{% if self.alt_text %}{{ self.alt_text }}{% else %}{{ img.alt }}{% endif %}"
+          class="w-100" />
+        {% if self.caption %}
         <figcaption class="body-small">
           {{ self.caption|richtext|remove_wrapping|safe }}
         </figcaption>
-    {% endif %}
-  </figure>
+        {% endif %}
+      </figure>
+    </div>
+  </div>
 </div>
-
-{% if self.wide_image %}
-  <div class="py-4 py-md-5 offset-sm-1 col-sm-10 col-12 article-blocks">
-{% endif %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_image_block.html
@@ -5,7 +5,7 @@
     <div class="article-image-block {% if value.wide_image %} wide {% else %} streamfield-content {% endif %} ">
       {% comment %}Use a 2x resolution image{% endcomment %}
       {% image self.image width-1840 as img %}
-      <figure class="my-default">
+      <figure>
         <img src="{{ img.url }}" alt="{% if self.alt_text %}{{ self.alt_text }}{% else %}{{ img.alt }}{% endif %}"
           class="w-100" />
         {% if self.caption %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_table_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_table_block.html
@@ -1,10 +1,8 @@
 {% load table_block_tags %}
 
-  <!-- <div class="col-sm-10 offset-sm-1"> -->
-
-    <div class="container {{block.block_type}}-block">
-        <div class="row justify-content-center">
-          <div class="streamfield-content">
+<div class="container {{block.block_type}}-block">
+    <div class="row justify-content-center">
+        <div class="streamfield-content">
             <div class="article-table-block table-responsive">
                 {% comment %}
                 Modified table template comes from "table_block/blocks/table.html"

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_table_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_table_block.html
@@ -1,71 +1,72 @@
 {% load table_block_tags %}
 
-  </div> <!-- End .col-sm-8 -->
-  <div class="col-sm-10 offset-sm-1">
+  <!-- <div class="col-sm-10 offset-sm-1"> -->
 
-  <div class="article-table-block table-responsive">
-    {% comment %}
-      Modified table template comes from "table_block/blocks/table.html"
-    {% endcomment %}
-    <table class="table">
-        {% if table_caption %}
-          <caption>{{ table_caption }}</caption>
-        {% endif %}
-        {% if table_header %}
-            <thead>
-            <tr>
-                {% for column in table_header %}
-                {% with forloop.counter0 as col_index %}
-                    <th scope="col" {% cell_classname 0 col_index %}>
-                        {% if column.strip %}
-                            {% if html_renderer %}
-                                {{ column.strip|safe|linebreaksbr }}
-                            {% else %}
-                                {{ column.strip|linebreaksbr }}
-                            {% endif %}
-                        {% endif %}
-                    </th>
-                {% endwith %}
-                {% endfor %}
-            </tr>
-            </thead>
-        {% endif %}
-        <tbody>
-        {% for row in data %}
-        {% with forloop.counter0 as row_index %}
-            <tr>
-                {% for column in row %}
-                {% with forloop.counter0 as col_index %}
-                    {% if first_col_is_header and forloop.first %}
-                        <th scope="row" class="{% if first_col_is_header and forloop.first %}highlighted{% endif %}" {% cell_classname row_index col_index table_header %}>
-                            {% if column.strip %}
-                                {% if html_renderer %}
-                                    {{ column.strip|safe|linebreaksbr }}
-                                {% else %}
-                                    {{ column.strip|linebreaksbr }}
-                                {% endif %}
-                            {% endif %}
-                        </th>
-                    {% else %}
-                        <td class="{% if first_col_is_header and forloop.first %}highlighted{% endif %}" {% cell_classname row_index col_index table_header %}>
-                            {% if column.strip %}
-                                {% if html_renderer %}
-                                    {{ column.strip|safe|linebreaksbr }}
-                                {% else %}
-                                    {{ column.strip|linebreaksbr }}
-                                {% endif %}
-                            {% endif %}
-                        </td>
+    <div class="container {{block.block_type}}-block">
+        <div class="row justify-content-center">
+          <div class="streamfield-content">
+            <div class="article-table-block table-responsive">
+                {% comment %}
+                Modified table template comes from "table_block/blocks/table.html"
+                {% endcomment %}
+                <table class="table">
+                    {% if table_caption %}
+                    <caption>{{ table_caption }}</caption>
                     {% endif %}
-                {% endwith %}
-                {% endfor %}
-            </tr>
-        {% endwith %}
-        {% endfor %}
-        </tbody>
-    </table>
-  </div>
+                    {% if table_header %}
+                        <thead>
+                        <tr>
+                            {% for column in table_header %}
+                            {% with forloop.counter0 as col_index %}
+                                <th scope="col" {% cell_classname 0 col_index %}>
+                                    {% if column.strip %}
+                                        {% if html_renderer %}
+                                            {{ column.strip|safe|linebreaksbr }}
+                                        {% else %}
+                                            {{ column.strip|linebreaksbr }}
+                                        {% endif %}
+                                    {% endif %}
+                                </th>
+                            {% endwith %}
+                            {% endfor %}
+                        </tr>
+                        </thead>
+                    {% endif %}
+                    <tbody>
+                    {% for row in data %}
+                    {% with forloop.counter0 as row_index %}
+                        <tr>
+                            {% for column in row %}
+                            {% with forloop.counter0 as col_index %}
+                                {% if first_col_is_header and forloop.first %}
+                                    <th scope="row" class="{% if first_col_is_header and forloop.first %}highlighted{% endif %}" {% cell_classname row_index col_index table_header %}>
+                                        {% if column.strip %}
+                                            {% if html_renderer %}
+                                                {{ column.strip|safe|linebreaksbr }}
+                                            {% else %}
+                                                {{ column.strip|linebreaksbr }}
+                                            {% endif %}
+                                        {% endif %}
+                                    </th>
+                                {% else %}
+                                    <td class="{% if first_col_is_header and forloop.first %}highlighted{% endif %}" {% cell_classname row_index col_index table_header %}>
+                                        {% if column.strip %}
+                                            {% if html_renderer %}
+                                                {{ column.strip|safe|linebreaksbr }}
+                                            {% else %}
+                                                {{ column.strip|linebreaksbr }}
+                                            {% endif %}
+                                        {% endif %}
+                                    </td>
+                                {% endif %}
+                            {% endwith %}
+                            {% endfor %}
+                        </tr>
+                    {% endwith %}
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>
-
-{# Re-start the same containing row thats on the main article_page.html file #}
-<div class="offset-sm-1 col-sm-10 col-12 article-blocks">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/iframe_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/iframe_block.html
@@ -1,52 +1,30 @@
 {% load wagtailcore_tags %}
 {% comment %}
-  The iframe_block.html is used on Article pages and Blog pages.
-  Blog pages need to break out of the current grid system and open a 12 column block
-  for it to align with other content.
-  The Article page doesn't require as much "breaking out" of the parent grid because there's
-  less nesting in the article pages. But we still need to break out of the grid, and
-  use a 12 column grid.
+The iframe_block.html is used on Article pages and Blog pages.
+Blog pages need to break out of the current grid system and open a 12 column block
+for it to align with other content.
+The Article page doesn't require as much "breaking out" of the parent grid because there's
+less nesting in the article pages. But we still need to break out of the grid, and
+use a 12 column grid.
 {% endcomment %}
 
-{% if page_type == "blog" %}
-  {# Break out of the blog_page.html containment grid #}
-      </div> <!-- End .blog-body -->
-    </div> <!-- End .cms -->
-  </div> <!-- End .col-lg-8 -->
-{% elif page_type == "article" %}
-  {# Break out of the article_page.html containment grid #}
-  </div> <!-- end .offset-sm-1.col-sm-10.col-12.article-blocks -->
-{% else %}
-  {# Mozfest page. Break out of the containment grid #}
+<div
+  class="container {{block.block_type}}-block {% if self.wide_iframe %}wide{% endif %}">
+  <div class="row justify-content-center no-gutters">
+    <div class="streamfield-content">
+        <div class="my-default">
+          <div class="embed-responsive embed-responsive-16by9" {% if value.height %}style="height: {{value.height}}px;"
+            {% endif %}>
+            <iframe src="{{ value.url }}" class="embed-responsive-item"></iframe>
+          </div>
+          {% if value.caption %}
+          <p class="body-small mt-2">
+            {% if value.captionURL %}<a href="{{ value.captionURL }}">{% endif %}
+              {{ value.caption }}
+              {% if value.captionURL %}</a>{% endif %}
+          </p>
+          {% endif %}
+        </div>
     </div>
   </div>
-{% endif %}
-
-  <div class="{% if self.wide_iframe %}col-lg-12{% else %}col-lg-8 offset-lg-2{% endif %} {% if page_type != 'blog' and page_type != 'article' %}p-0{% endif %}">
-    <div class="my-default">
-      <div class="embed-responsive embed-responsive-16by9" {% if value.height %}style="height: {{value.height}}px;"{% endif %}>
-        <iframe src="{{ value.url }}" class="embed-responsive-item"></iframe>
-      </div>
-      {% if value.caption %}
-      <p class="body-small mt-2">
-        {% if value.captionURL %}<a href="{{ value.captionURL }}">{% endif %}
-        {{ value.caption }}
-        {% if value.captionURL %}</a>{% endif %}
-      </p>
-      {% endif %}
-    </div>
-  </div> <!-- end .col-lg-12 -->
-
-{% if page_type == "blog" %}
-  {# Re-open the original grid even if it's immediately closed afterwards. #}
-  <div class="py-2 py-md-3 col-lg-8 offset-lg-2">
-    <div class="cms">
-      <div class="blog-body">
-{% elif page_type == "article" %}
-  {# Re-open the original article_page.html grid #}
-  <div class="offset-sm-1 col-sm-10 col-12 article-blocks">
-{% else %}
-  {# Re-open the Mozfest containment grid #}
-    <div class="row">
-  <div class="cms col-lg-8 offset-lg-2">
-{% endif %}
+</div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/iframe_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/iframe_block.html
@@ -12,7 +12,7 @@ use a 12 column grid.
   class="container {{block.block_type}}-block {% if self.wide_iframe %}wide{% endif %}">
   <div class="row justify-content-center no-gutters">
     <div class="streamfield-content">
-        <div class="my-default">
+        <div>
           <div class="embed-responsive embed-responsive-16by9" {% if value.height %}style="height: {{value.height}}px;"
             {% endif %}>
             <iframe src="{{ value.url }}" class="embed-responsive-item"></iframe>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_block.html
@@ -1,4 +1,12 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {% image value.image original as img %}
-<img src="{{ img.url }}" alt="{{ img.alt }}" class="{{ value.size }} my-default">
+
+
+<div class="container {{block.block_type}}-block">
+    <div class="row justify-content-center">
+        <div class="streamfield-content">
+            <img src="{{ img.url }}" alt="{{ img.alt }}" class="{{ value.size }} my-default">
+        </div>
+    </div>
+</div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_block.html
@@ -6,7 +6,7 @@
 <div class="container {{block.block_type}}-block">
     <div class="row justify-content-center">
         <div class="streamfield-content">
-            <img src="{{ img.url }}" alt="{{ img.alt }}" class="{{ value.size }} my-default">
+            <img src="{{ img.url }}" alt="{{ img.alt }}" class="{{ value.size }}">
         </div>
     </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_grid_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_grid_block.html
@@ -3,7 +3,7 @@
 <div class="container {{block.block_type}}-block">
 	<div class="row justify-content-center">
 		<div class="streamfield-content">
-			<div class="row my-default">
+			<div class="row">
 			{% for block in self.grid_items %}
 				{% with value=block count=self.grid_items|length %}
 				{% include "./figure_block.html" %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_grid_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_grid_block.html
@@ -3,7 +3,7 @@
 <div class="container {{block.block_type}}-block">
 	<div class="row justify-content-center">
 		<div class="streamfield-content">
-			<div class="row">
+			<div class="row my-default">
 			{% for block in self.grid_items %}
 				{% with value=block count=self.grid_items|length %}
 				{% include "./figure_block.html" %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_grid_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_grid_block.html
@@ -1,9 +1,15 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
-<div class="row my-default">
-{% for block in self.grid_items %}
-	{% with value=block count=self.grid_items|length %}
-	{% include "./figure_block.html" %}
-	{% endwith %}
-{% endfor %}
+<div class="container {{block.block_type}}-block">
+	<div class="row justify-content-center">
+		<div class="streamfield-content">
+			<div class="row my-default">
+			{% for block in self.grid_items %}
+				{% with value=block count=self.grid_items|length %}
+				{% include "./figure_block.html" %}
+				{% endwith %}
+			{% endfor %}
+			</div>
+		</div>
+	</div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text.html
@@ -1,29 +1,37 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
-<div class="row my-4">
-  {% if value.small %}
-    <div class="col-12 d-flex flex-nowrap">
-      <div class="mr-3" style="width:50px; flex-shrink:0;">
-        {% if value.url %}<a href="{{ value.url }}">{% endif %}
-          {% image value.image fill-100x100-c100 format-jpeg class="w-100" %}
-        {% if value.url %}</a>{% endif %}
-      </div>
-      <div>
-        {{ value.text|richtext }}
+
+
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div class="row my-4">
+        {% if value.small %}
+          <div class="col-12 d-flex flex-nowrap">
+            <div class="mr-3" style="width:50px; flex-shrink:0;">
+              {% if value.url %}<a href="{{ value.url }}">{% endif %}
+                {% image value.image fill-100x100-c100 format-jpeg class="w-100" %}
+              {% if value.url %}</a>{% endif %}
+            </div>
+            <div>
+              {{ value.text|richtext }}
+            </div>
+          </div>
+        {% else %}
+        <div class="col-12 image-text-img">
+            <div class="col-12 px-0 d-md-flex align-items-md-center {{ divider_styles }}">
+              <div class="col-12 col-md-3 mb-3 mb-md-0 pl-0">
+              {% if value.url %}<a href="{{ value.url }}">{% endif %}
+                {% image value.image fill-760x760-c100 format-jpeg %}
+              {% if value.url %}</a>{% endif %}
+              </div>
+              <div class="col-12 col-md-9 pl-0">
+                  {{ value.text|richtext }}
+              </div>
+            </div>
+        </div>
+        {% endif %}
       </div>
     </div>
-  {% else %}
-  <div class="col-12 image-text-img">
-      <div class="col-12 px-0 d-md-flex align-items-md-center {{ divider_styles }}">
-        <div class="col-12 col-md-3 mb-3 mb-md-0 pl-0">
-        {% if value.url %}<a href="{{ value.url }}">{% endif %}
-          {% image value.image fill-760x760-c100 format-jpeg %}
-        {% if value.url %}</a>{% endif %}
-        </div>
-        <div class="col-12 col-md-9 pl-0">
-            {{ value.text|richtext }}
-        </div>
-      </div>
   </div>
-  {% endif %}
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text.html
@@ -5,7 +5,7 @@
 <div class="container {{block.block_type}}-block">
   <div class="row justify-content-center">
     <div class="streamfield-content">
-      <div class="row my-4">
+      <div class="row">
         {% if value.small %}
           <div class="col-12 d-flex flex-nowrap">
             <div class="mr-3" style="width:50px; flex-shrink:0;">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text_mini.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_text_mini.html
@@ -1,12 +1,20 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
-<div class="my-5">
-  <div class="p-2 p-md-3 col-12 d-flex align-items-center image-text-mini-container">
-    <div class="image-text-mini-img-container mr-2 mr-md-3">
-      {% image value.image fill-100x100-c100 format-jpeg class="w-100" %}
-    </div>
-    <div class="image-text-mini-text">
-      {{ value.text|richtext }}
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div class="my-5">
+        <div class="p-2 p-md-3 col-12 d-flex align-items-center image-text-mini-container">
+          <div class="image-text-mini-img-container mr-2 mr-md-3">
+            {% image value.image fill-100x100-c100 format-jpeg class="w-100" %}
+          </div>
+          <div class="image-text-mini-text">
+            {{ value.text|richtext }}
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
+
+

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/link_button_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/link_button_block.html
@@ -3,7 +3,7 @@
 <div class="container {{block.block_type}}-block">
   <div class="row justify-content-center">
     <div class="streamfield-content">
-      <div class="my-default">
+      <div>
         <a class="btn {{ value.styling }}" href="{{ value.URL }}">{{ value.label }}</a>
       </div>
     </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/link_button_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/link_button_block.html
@@ -1,5 +1,11 @@
 {% load wagtailcore_tags %}
 
-<div class="my-default">
-  <a class="btn {{ value.styling }}" href="{{ value.URL }}">{{ value.label }}</a>
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div class="my-default">
+        <a class="btn {{ value.styling }}" href="{{ value.URL }}">{{ value.label }}</a>
+      </div>
+    </div>
+  </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_blocks.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_blocks.html
@@ -13,4 +13,4 @@
       </div>
     </div>
   </div>
-</div>
+</div> 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_blocks.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_blocks.html
@@ -1,9 +1,16 @@
 {% load static %}
 
-<div class="profiles" data-program-type="{{ value.program_type }}" data-program-year="{{ value.program_year }}" data-profile-type="{{ value.profile_type }}">
-  <div class="row">
-    {% for profile in profiles %}
-    {% include "./profile_block.html" with profile=profile %}
-    {% endfor %}
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div class="profiles" data-program-type="{{ value.program_type }}" data-program-year="{{ value.program_year }}"
+        data-profile-type="{{ value.profile_type }}">
+        <div class="row">
+          {% for profile in profiles %}
+          {% include "./profile_block.html" with profile=profile %}
+          {% endfor %}
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_directory.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_directory.html
@@ -3,22 +3,22 @@
 <div class="container {{block.block_type}}-block">
   <div class="row justify-content-center">
     <div class="streamfield-content">
-        <div class="fellowships-directory-filter px-2 mb-5">
-          {% for label in filters %}
-          <div class="filter-option">
-            <button {% if forloop.first %}class="active"{% endif %}>{{ label }}</button>
-          </div>
-          {% endfor %}
+      <div class="fellowships-directory-filter px-2 mb-5">
+        {% for label in filters %}
+        <div class="filter-option">
+          <button {% if forloop.first %}class="active" {% endif %}>{{ label }}</button>
         </div>
-    </div>
-      <div class="profile-directory">
-
-        {% include "./profile_blocks.html" %}
-
-        {% if filters|length > 0 %}
-        <input type="hidden" data-api-endpoint="{{ api_endpoint }}">
-        <script src="{% static '_js/directory-listing-filters.compiled.js' %}" async defer></script>
-        {% endif %}
+        {% endfor %}
       </div>
-    </div>    
+    </div>
+    <div class="profile-directory">
+
+      {% include "./profile_blocks.html" %}
+
+      {% if filters|length > 0 %}
+      <input type="hidden" data-api-endpoint="{{ api_endpoint }}">
+      <script src="{% static '_js/directory-listing-filters.compiled.js' %}" async defer></script>
+      {% endif %}
+    </div>
+  </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_directory.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_directory.html
@@ -1,18 +1,24 @@
 {% load static %}
 
-<div class="profile-directory">
-  <div class="fellowships-directory-filter px-2 mb-5">
-    {% for label in filters %}
-    <div class="filter-option">
-      <button {% if forloop.first %}class="active"{% endif %}>{{ label }}</button>
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+        <div class="fellowships-directory-filter px-2 mb-5">
+          {% for label in filters %}
+          <div class="filter-option">
+            <button {% if forloop.first %}class="active"{% endif %}>{{ label }}</button>
+          </div>
+          {% endfor %}
+        </div>
     </div>
-    {% endfor %}
-  </div>
+      <div class="profile-directory">
 
-  {% include "./profile_blocks.html" %}
+        {% include "./profile_blocks.html" %}
 
-  {% if filters|length > 0 %}
-  <input type="hidden" data-api-endpoint="{{ api_endpoint }}">
-  <script src="{% static '_js/directory-listing-filters.compiled.js' %}" async defer></script>
-  {% endif %}
+        {% if filters|length > 0 %}
+        <input type="hidden" data-api-endpoint="{{ api_endpoint }}">
+        <script src="{% static '_js/directory-listing-filters.compiled.js' %}" async defer></script>
+        {% endif %}
+      </div>
+    </div>    
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
@@ -1,9 +1,16 @@
-<div
-  class="pulse-project-list my-default"
-  data-featured="{{ value.only_featured_entries}}"
-  data-help="{{ value.help }}"
-  data-issues="{{ value.issues }}"
-  data-max="{{ value.size }}"
-  data-query="{{ value.search_terms }}"
-  data-reversed="{{ value.newest_first }}"
-  data-direct-link="{{ value.direct_link }}"></div>
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div
+        class="pulse-project-list my-default"
+        data-featured="{{ value.only_featured_entries}}"
+        data-help="{{ value.help }}"
+        data-issues="{{ value.issues }}"
+        data-max="{{ value.size }}"
+        data-query="{{ value.search_terms }}"
+        data-reversed="{{ value.newest_first }}"
+        data-direct-link="{{ value.direct_link }}">
+      </div>
+    </div>
+  </div>
+</div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/pulse_project_list.html
@@ -2,7 +2,7 @@
   <div class="row justify-content-center">
     <div class="streamfield-content">
       <div
-        class="pulse-project-list my-default"
+        class="pulse-project-list"
         data-featured="{{ value.only_featured_entries}}"
         data-help="{{ value.help }}"
         data-issues="{{ value.issues }}"

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/quote_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/quote_block.html
@@ -4,7 +4,7 @@
 <div class="container {{block.block_type}}-block">
   <div class="row justify-content-center">
     <div class="streamfield-content">
-      <div class="row my-default">
+      <div class="row">
         <div class="col">
           {% for quote in value.quotes %}
           {% comment %} Next task for this component is to handle multiple quotes. For now, let's use just the first {% endcomment %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/quote_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/quote_block.html
@@ -3,7 +3,7 @@
 
 <div class="container {{block.block_type}}-block">
   <div class="row justify-content-center">
-    <div class="streamfield-content">
+    <div class="streamfield-content quote-block-content">
       <div class="row my-default">
         <div class="col">
           {% for quote in value.quotes %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/quote_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/quote_block.html
@@ -1,15 +1,22 @@
 {% load wagtailcore_tags %}
 
-<div class="row my-default">
-  <div class="col">
-    {% for quote in value.quotes %}
-    {% comment %} Next task for this component is to handle multiple quotes. For now, let's use just the first {% endcomment %}
-    {% if forloop.counter is 1 %}
-    <div class="feature-quote">
-      <h3>{{quote.quote}}</h3>
-      <p class="h6-heading">{{quote.attribution}}</p>
+
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div class="row my-default">
+        <div class="col">
+          {% for quote in value.quotes %}
+          {% comment %} Next task for this component is to handle multiple quotes. For now, let's use just the first {% endcomment %}
+          {% if forloop.counter is 1 %}
+          <div class="feature-quote">
+            <h3>{{quote.quote}}</h3>
+            <p class="h6-heading">{{quote.attribution}}</p>
+          </div>
+          {% endif %}
+          {% endfor %}
+        </div>
+      </div>
     </div>
-    {% endif %}
-    {% endfor %}
   </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/quote_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/quote_block.html
@@ -4,7 +4,7 @@
 <div class="container {{block.block_type}}-block">
   <div class="row justify-content-center">
     <div class="streamfield-content">
-      <div class="row">
+      <div class="row my-default">
         <div class="col">
           {% for quote in value.quotes %}
           {% comment %} Next task for this component is to handle multiple quotes. For now, let's use just the first {% endcomment %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/recent_blog_entries.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/recent_blog_entries.html
@@ -4,7 +4,7 @@
   <div class="row justify-content-center">
     <div class="streamfield-content">
       {% if entries|length != 0 %}
-      <div class="recent-blog-entries index-entries row my-default mx-0 d-flex flex-column {{ divider_styles }}">
+      <div class="recent-blog-entries index-entries row mx-0 d-flex flex-column {{ divider_styles }}">
         <div class="mb-4">
           <h3>{{ value.title }}</h3>
         </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/recent_blog_entries.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/recent_blog_entries.html
@@ -1,19 +1,25 @@
 {% load i18n %}
 
-{% if entries|length != 0 %}
-<div class="recent-blog-entries index-entries row my-default mx-0 d-flex flex-column {{ divider_styles }}">
-  <div class="mb-4">
-    <h3>{{ value.title }}</h3>
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      {% if entries|length != 0 %}
+      <div class="recent-blog-entries index-entries row my-default mx-0 d-flex flex-column {{ divider_styles }}">
+        <div class="mb-4">
+          <h3>{{ value.title }}</h3>
+        </div>
+        <div class="row">
+          {% include "../fragments/entry_cards.html" %}
+        </div>
+        {% if more_entries %}
+        <div class="col-12 text-center mb-5">
+          <a class="btn btn-secondary text" href="{{ more_entries_link }}">
+            {% trans "More from our blog" %}
+          </a>
+        </div>
+        {% endif %}
+      </div>
+      {% endif %}
+    </div>
   </div>
-  <div class="row">
-    {% include "../fragments/entry_cards.html" %}
-  </div>
-  {% if more_entries %}
-  <div class="col-12 text-center mb-5">
-    <a class="btn btn-secondary text" href="{{ more_entries_link }}">
-      {% trans "More from our blog" %}
-    </a>
-  </div>
-  {% endif %}
 </div>
-{% endif %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/typeform_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/typeform_block.html
@@ -1,7 +1,14 @@
-<a
-  id="btn-typeform-popup"
-  class="btn {{ value.button_type }} my-3"
-  href="https://form.typeform.com/to/{{ value.embed_id }}"
-  target="_blank">{{ value.button_text }}</a>
 
-<script async defer src="https://embed.typeform.com/embed.js" ></script>
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <a
+        id="btn-typeform-popup"
+        class="btn {{ value.button_type }} my-3"
+        href="https://form.typeform.com/to/{{ value.embed_id }}"
+        target="_blank">{{ value.button_text }}</a>
+
+      <script async defer src="https://embed.typeform.com/embed.js" ></script>
+    </div>
+  </div>
+</div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/video_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/video_block.html
@@ -4,7 +4,7 @@
 <div class="container {{block.block_type}}-block">
   <div class="row justify-content-center">
     <div class="streamfield-content">
-      <div class="my-default">
+      <div>
         <div class="embed-responsive embed-responsive-16by9 d-print-none">
           <iframe
             src="{{ value.url }}"

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/video_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/video_block.html
@@ -1,20 +1,27 @@
 {% load wagtailcore_tags %}
 
-<div class="my-default">
-  <div class="embed-responsive embed-responsive-16by9 d-print-none">
-    <iframe
-      src="{{ value.url }}"
-      frameborder="0"
-      class="embed-responsive-item"
-      allow="autoplay; encrypted-media"
-      allowfullscreen>
-    </iframe>
+
+<div class="container {{block.block_type}}-block">
+  <div class="row justify-content-center">
+    <div class="streamfield-content">
+      <div class="my-default">
+        <div class="embed-responsive embed-responsive-16by9 d-print-none">
+          <iframe
+            src="{{ value.url }}"
+            frameborder="0"
+            class="embed-responsive-item"
+            allow="autoplay; encrypted-media"
+            allowfullscreen>
+          </iframe>
+        </div>
+        {% if value.caption %}
+        <p class="caption-wrapper body-small mt-2">
+          {% if value.captionURL %}<a href="{{ value.captionURL }}">{% endif %}
+          {{ value.caption }}
+          {% if value.captionURL %}</a>{% endif %}
+        </p>
+        {% endif %}
+      </div>
+    </div>
   </div>
-  {% if value.caption %}
-  <p class="caption-wrapper body-small mt-2">
-    {% if value.captionURL %}<a href="{{ value.captionURL }}">{% endif %}
-    {{ value.caption }}
-    {% if value.captionURL %}</a>{% endif %}
-  </p>
-  {% endif %}
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_page.html
@@ -20,22 +20,28 @@
 {% block body_id %}blog{% endblock %}
 
 {% block subcontent %}
-    <div class="blog-sticky-side-container offset-lg-1 col-lg-1 py-4 py-md-5 text-center d-print-none">
-      <div class="blog-sticky-side d-none d-lg-flex justify-content-lg-end">
-        <div class="share-button-group-wrapper" data-version="mini" data-layout="stacked"
-          data-share-text="{% blocktrans with title=page.title %}{{ title }} by @mozilla{% endblocktrans %}"
-          data-link="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}"></div>
-      </div>
-    </div>
-  
-    <div class="pt-4 pt-md-5 col-lg-8">
-      <div class="cms {% if show_comments %}mb-5{% endif %}">
-        <h1 class="h1-heading">{{ page.title }}</h1>
-        {% include "./fragments/blog_authors.html" with blog_page=page show_full_info=True %}
-  
-      </div>
-    </div>
+
+
 <div class="cms blog-body">
+
+  <div class="container">
+    <div class="row">
+      <div class="blog-sticky-side-container offset-lg-1 col-lg-1 pt-4 pt-md-5 text-center d-print-none">
+        <div class="blog-sticky-side d-none d-lg-flex justify-content-lg-end">
+          <div class="share-button-group-wrapper" data-version="mini" data-layout="stacked"
+            data-share-text="{% blocktrans with title=page.title %}{{ title }} by @mozilla{% endblocktrans %}"
+            data-link="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}"></div>
+        </div>
+      </div>
+      <div class="pt-4 pt-md-5 col-lg-8">
+        <div class="cms {% if show_comments %}mb-5{% endif %}">
+          <h1 class="h1-heading">{{ page.title }}</h1>
+          {% include "./fragments/blog_authors.html" with blog_page=page show_full_info=True %}
+
+        </div>
+      </div>
+    </div>
+  </div>
   {% for block in page.body %}
   {% if block.block_type == 'paragraph'%}
   <div class="container {{block.block_type}}-block">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_page.html
@@ -21,10 +21,8 @@
 
 {% block subcontent %}
 
-
 <div class="cms blog-body">
-
-  <div class="container">
+  <div class="container share-button-blog-title-container">
     <div class="row">
       <div class="blog-sticky-side-container offset-lg-1 col-lg-1 pt-4 pt-md-5 text-center d-print-none">
         <div class="blog-sticky-side d-none d-lg-flex justify-content-lg-end">
@@ -33,6 +31,7 @@
             data-link="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}"></div>
         </div>
       </div>
+
       <div class="pt-4 pt-md-5 col-lg-8">
         <div class="cms {% if show_comments %}mb-5{% endif %}">
           <h1 class="h1-heading">{{ page.title }}</h1>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_page.html
@@ -3,55 +3,77 @@
 {% load wagtailcore_tags mini_site_tags i18n %}
 
 {% block commento_meta %}
-  <meta property="article:author" content="{{ page.author }}" />
-  <meta property="article:published_time" content="{{ page.first_published_at|date:"DATE_FORMAT" }}">
-  {% if page.last_published_at %}
-    <meta property="article:modified" content="{{ page.last_published_at|date:"DATE_FORMAT" }}"/>
-  {% endif %}
-  {% with category=page.specific.category.first %}
-    {% if category %}
-      <meta property="article:section" content="{{ category }}" />
-    {% endif %}
-  {% endwith %}
-  <link rel="canonical" href="{{ page.full_url }}" />
+<meta property="article:author" content="{{ page.author }}" />
+<meta property="article:published_time" content="{{ page.first_published_at|date:" DATE_FORMAT" }}">
+{% if page.last_published_at %}
+<meta property="article:modified" content="{{ page.last_published_at|date:" DATE_FORMAT" }}" />
+{% endif %}
+{% with category=page.specific.category.first %}
+{% if category %}
+<meta property="article:section" content="{{ category }}" />
+{% endif %}
+{% endwith %}
+<link rel="canonical" href="{{ page.full_url }}" />
 {% endblock %}
 
 
 {% block body_id %}blog{% endblock %}
 
 {% block subcontent %}
-  <div class="offset-lg-1 col-lg-1 py-4 py-md-5 text-center d-print-none">
-    <div class="blog-sticky-side d-none d-lg-flex justify-content-lg-end">
-      <div class="share-button-group-wrapper" data-version="mini" data-layout="stacked" data-share-text="{% blocktrans with title=page.title %}{{ title }} by @mozilla{% endblocktrans %}" data-link="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}"></div>
-    </div>
-  </div>
-  <div class="py-4 py-md-5 col-lg-8">
-    <div class="cms {% if show_comments %}mb-5{% endif %}">
-      <h1 class="h1-heading">{{ page.title }}</h1>
-      {% include "./fragments/blog_authors.html" with blog_page=page show_full_info=True %}
-      <div class="blog-body">
-        {% for stream_block in page.body %}
-          {% include_block stream_block with page_type="blog" %}
-        {% endfor %}
-        <div class="share-button-group-wrapper mt-5 d-print-none" data-share-text="{% blocktrans with title=page.title %}{{ title }} by @mozilla{% endblocktrans %}" data-link="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}"></div>
+    <div class="blog-sticky-side-container offset-lg-1 col-lg-1 py-4 py-md-5 text-center d-print-none">
+      <div class="blog-sticky-side d-none d-lg-flex justify-content-lg-end">
+        <div class="share-button-group-wrapper" data-version="mini" data-layout="stacked"
+          data-share-text="{% blocktrans with title=page.title %}{{ title }} by @mozilla{% endblocktrans %}"
+          data-link="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}"></div>
       </div>
     </div>
-
-    {% if show_comments %}
-      <h2 class="h4-heading">{% trans "Comments" %}</h2>
-      <div id="commento"></div>
-    {% endif %}
-
-    {% include "./fragments/post_tags.html" %}
+  
+    <div class="pt-4 pt-md-5 col-lg-8">
+      <div class="cms {% if show_comments %}mb-5{% endif %}">
+        <h1 class="h1-heading">{{ page.title }}</h1>
+        {% include "./fragments/blog_authors.html" with blog_page=page show_full_info=True %}
+  
+      </div>
+    </div>
+<div class="cms blog-body">
+  {% for block in page.body %}
+  {% if block.block_type == 'paragraph'%}
+  <div class="container {{block.block_type}}-block">
+    <div class="row justify-content-center">
+      <div class="streamfield-content">
+        {% if block.block_type == 'heading' %}
+        <h1>{{ block.value }}</h1>
+        {% else %}
+        {% include_block block with parent_page=page page_type="blog"%}
+        {% endif %}
+      </div>
+    </div>
   </div>
+  {% else %}
+  {% include_block block with parent_page=page page_type="blog" %}
+  {% endif %}
+  {% endfor %}
+</div>
+<div class="py-4 py-md-5 col-lg-8 m-auto bottom-share-button-container">
+  <div class="share-button-group-wrapper mt-5 d-print-none"
+    data-share-text="{% blocktrans with title=page.title %}{{ title }} by @mozilla{% endblocktrans %}"
+    data-link="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}"></div>
+
+  {% if show_comments %}
+  <h2 class="h4-heading">{% trans "Comments" %}</h2>
+  <div id="commento"></div>
+  {% endif %}
+
+  {% include "./fragments/post_tags.html" %}
+</div>
 {% endblock %}
 
 {% block prefooter %}
-  {% include "./fragments/related_posts.html" %}
+{% include "./fragments/related_posts.html" %}
 {% endblock %}
 
 {% block extra_scripts %}
-  {% if show_comments %}
-    <script async defer src="https://cdn.commento.io/js/commento.js"></script>
-  {% endif %}
+{% if show_comments %}
+<script async defer src="https://cdn.commento.io/js/commento.js"></script>
+{% endif %}
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/campaign_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/campaign_page.html
@@ -43,13 +43,25 @@
         </div>
       {% endblock %}
         {% block html_content %}
+        <div class="cms campaign-page-content wide">
           {% for block in page.body %}
-            {% if block.block_type == 'heading' %}
-                <h1>{{ block.value }}</h1>
+            {% if block.block_type == 'paragraph'%}
+              <div class="container {{block.block_type}}-block">
+                <div class="row justify-content-center">
+                  <div class="streamfield-content">
+                    {% if block.block_type == 'heading' %}
+                      <h1>{{ block.value }}</h1>
+                    {% else %}
+                      {% include_block block%}
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
             {% else %}
-                {% include_block block %}
+              {% include_block block with parent_page=page %}
             {% endif %}
           {% endfor %}
+        </div>
         {% endblock %}
       </div>
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_authors.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_authors.html
@@ -13,7 +13,7 @@
   {% endfor %}
   </div>
 
-  <p class="body-small my-2">
+  <p class="body-small mt-2">
     {% with authors_length=authors|length %}
     {% spaceless %}
     {% if show_full_info %}{% trans "By" %} {% endif %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/publication_hero.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/publication_hero.html
@@ -29,7 +29,7 @@
           </h2>
         {% endif %}
         {% if page.secondary_subtitle or page.publication_date %}
-          <div class="mt-2 mb-4 body-small publication-secondary-subtitle">
+          <div class="mt-2 body-small publication-secondary-subtitle">
             {% if page.secondary_subtitle %}
               {{ page.secondary_subtitle }}
             {% endif %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/publication_hero.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/publication_hero.html
@@ -29,7 +29,7 @@
           </h2>
         {% endif %}
         {% if page.secondary_subtitle or page.publication_date %}
-          <div class="mt-2 body-small publication-secondary-subtitle">
+          <div class="mt-2 mb-4 body-small publication-secondary-subtitle">
             {% if page.secondary_subtitle %}
               {{ page.secondary_subtitle }}
             {% endif %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/modular_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/modular_page.html
@@ -7,6 +7,9 @@
 
   {% include "partials/multipage_nav_mobile.html" %}
 
+  <div class="container">
+    <div class="row">
       {% block subcontent %}{% endblock %}
-
+    </div>
+  </div>
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/modular_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/modular_page.html
@@ -7,9 +7,6 @@
 
   {% include "partials/multipage_nav_mobile.html" %}
 
-  <div class="container">
-    <div class="row">
       {% block subcontent %}{% endblock %}
-    </div>
-  </div>
+
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/opportunity_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/opportunity_page.html
@@ -25,12 +25,31 @@
         {{ page.title }}
       {% endif %}
     </h1>
-    <div class="cms">
+    <!-- <div class="cms">
       {% for block in page.body %}
         {% if block.block_type == 'heading' %}
           <h1>{{ block.value }}</h1>
         {% else %}
           {% include_block block %}
+        {% endif %}
+      {% endfor %}
+    </div> -->
+    <div class="cms oppurtunity-page-content">
+      {% for block in page.body %}
+        {% if block.block_type == 'paragraph'%}
+          <div class="container {{block.block_type}}-block">
+            <div class="row justify-content-center">
+              <div class="streamfield-content">
+                {% if block.block_type == 'heading' %}
+                  <h1>{{ block.value }}</h1>
+                {% else %}
+                  {% include_block block%}
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        {% else %}
+          {% include_block block with parent_page=page %}
         {% endif %}
       {% endfor %}
     </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/opportunity_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/opportunity_page.html
@@ -25,15 +25,6 @@
         {{ page.title }}
       {% endif %}
     </h1>
-    <!-- <div class="cms">
-      {% for block in page.body %}
-        {% if block.block_type == 'heading' %}
-          <h1>{{ block.value }}</h1>
-        {% else %}
-          {% include_block block %}
-        {% endif %}
-      {% endfor %}
-    </div> -->
     <div class="cms oppurtunity-page-content">
       {% for block in page.body %}
         {% if block.block_type == 'paragraph'%}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/primary_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/primary_page.html
@@ -16,17 +16,23 @@
 
   {% primary_page_menu page %}
 
-  <div class="container cms">
-    <div class="row my-1 d-flex align-items-center">
-      <div class="pb-5 {% if page.specific.narrowed_page_content %}col-lg-8 offset-lg-2{% else %}col-12{% endif %}">
-        {% for block in page.body %}
-          {% if block.block_type == 'heading' %}
-            <h1>{{ block.value }}</h1>
-          {% else %}
-            {% include_block block %}
-          {% endif %}
-        {% endfor %}
-      </div>
-    </div>
+  <div class="cms primary-page-content {% if page.specific.narrowed_page_content %} narrow {% else %} wide {% endif %}">
+    {% for block in page.body %}
+      {% if block.block_type == 'paragraph'%}
+        <div class="container {{block.block_type}}-block">
+          <div class="row justify-content-center">
+            <div class="streamfield-content">
+              {% if block.block_type == 'heading' %}
+                <h1>{{ block.value }}</h1>
+              {% else %}
+                {% include_block block%}
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      {% else %}
+        {% include_block block with parent_page=page %}
+      {% endif %}
+    {% endfor %}
   </div>
-{% endblock %}
+{% endblock %} 

--- a/source/js/foundation/pages/directory-listing-filters.js
+++ b/source/js/foundation/pages/directory-listing-filters.js
@@ -3,7 +3,7 @@
 
   const profileCache = {};
   const labels = document.querySelectorAll(
-    `.profile-directory .fellowships-directory-filter .filter-option button`
+    `.fellowships-directory-filter .filter-option button`
   );
   const profileContainer = document.querySelector(`.profiles .row`);
   const { profileType, programType } = document.querySelector(

--- a/source/js/foundation/template-js-handler/window/sticky-share-button-group.js
+++ b/source/js/foundation/template-js-handler/window/sticky-share-button-group.js
@@ -6,7 +6,7 @@ export default () => {
     `#view-blog .blog-sticky-side .share-button-group`
   );
   let blogPageFullButtons = document.querySelector(
-    `#view-blog .blog-body .share-button-group`
+    `.bottom-share-button-container .share-button-group`
   );
 
   if (blogPageStickyButtons && blogPageFullButtons) {

--- a/source/sass/views/article.scss
+++ b/source/sass/views/article.scss
@@ -2,7 +2,7 @@
 // Also see publication-page.scss and chapter-page.scss
 
 #view-article {
-  .article-blocks {
+  .article-page-content {
     p,
     ul,
     ol {
@@ -153,7 +153,7 @@
 }
 
 // StreamBlocks
-.article-blocks .rich-text {
+.article-page-content .rich-text {
   /**
    * .rich-text styling needs to be specified in CSS rather than Bootstrap classes
    * because we don't have access to the individual elements.

--- a/source/sass/views/blog.scss
+++ b/source/sass/views/blog.scss
@@ -2,9 +2,9 @@
   margin-top: 95px;
 }
 
-.blog-sticky-side {
+.blog-sticky-side-container {
   position: sticky;
-  top: 140px;
+  top: 90px;
 
   .share-button-group {
     transition: opacity 0.2s ease-in-out;

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -23,3 +23,9 @@
     }
   }
 }
+
+.article-page-content {
+  .streamfield-content {
+    @extend .col-10;
+  }
+}

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -1,3 +1,25 @@
 .cms {
   @import "./profiles";
 }
+
+.wide {
+  @extend .no-gutters;
+  @extend .px-0;
+  @extend .mx-0;
+  @extend .w-100;
+  @extend .mw-100;
+}
+
+.primary-page-content {
+  &.wide {
+    .streamfield-content {
+      @extend .col-12;
+    }
+  }
+
+  &.narrow {
+    .streamfield-content {
+      @extend .col-8;
+    }
+  }
+}

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -27,19 +27,45 @@
 .article-page-content {
   .streamfield-content {
     @extend .col-8;
+    &.wide {
+      @extend .col-12;
+    }
   }
 }
 
 .blog-body {
-  // margin-top: 80px;
   .streamfield-content {
     @extend .col-lg-8;
   }
 }
 
 .oppurtunity-page-content {
-  // margin-top: 80px;
   .streamfield-content {
     @extend .col-lg-12;
+  }
+}
+
+.campaign-page-content {
+  &.wide {
+    .streamfield-content {
+      @extend .col-12;
+    }
+  }
+
+  &.narrow {
+    .streamfield-content {
+      @extend .col-7;
+    }
+  }
+}
+
+.image-block {
+  @extend .px-0;
+}
+
+.iframe-block {
+  @extend .px-0;
+  .wide {
+    @extend .col-12;
   }
 }

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -90,3 +90,7 @@
     @extend .col-lg-8;
   }
 }
+
+.share-button-blog-title-container {
+  margin-bottom: -2em;
+}

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -26,7 +26,7 @@
 
 .article-page-content {
   .streamfield-content {
-    @extend .col-8;
+    @extend .col-10;
     &.wide {
       @extend .col-12;
     }

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -73,3 +73,7 @@
     @extend .col-12;
   }
 }
+
+.quote-block-content {
+  width: 100%;
+}

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -77,3 +77,12 @@
 .quote-block-content {
   width: 100%;
 }
+
+.mozfest-content {
+  &.two-col {
+    @extend .col-lg-7;
+  }
+  .streamfield-content {
+    @extend .col-lg-8;
+  }
+}

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -26,6 +26,20 @@
 
 .article-page-content {
   .streamfield-content {
-    @extend .col-10;
+    @extend .col-8;
+  }
+}
+
+.blog-body {
+  // margin-top: 80px;
+  .streamfield-content {
+    @extend .col-lg-8;
+  }
+}
+
+.oppurtunity-page-content {
+  // margin-top: 80px;
+  .streamfield-content {
+    @extend .col-lg-12;
   }
 }

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -80,6 +80,7 @@
 
 .mozfest-content {
   &.two-col {
+    @extend .p-0;
     @extend .col-lg-7;
     .streamfield-content {
       @extend .col-lg-12;

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -42,10 +42,14 @@
 .oppurtunity-page-content {
   .streamfield-content {
     @extend .col-lg-12;
+    @extend .px-0;
   }
 }
 
 .campaign-page-content {
+  .streamfield-content {
+    @extend .px-0;
+  }
   &.wide {
     .streamfield-content {
       @extend .col-12;

--- a/source/sass/wagtail/blocks.scss
+++ b/source/sass/wagtail/blocks.scss
@@ -81,6 +81,9 @@
 .mozfest-content {
   &.two-col {
     @extend .col-lg-7;
+    .streamfield-content {
+      @extend .col-lg-12;
+    }
   }
   .streamfield-content {
     @extend .col-lg-8;

--- a/source/sass/wagtail/blocks/annotated-image-block.scss
+++ b/source/sass/wagtail/blocks/annotated-image-block.scss
@@ -1,0 +1,9 @@
+// .image-block {
+//   .wide {
+//     @extend .no-gutters;
+//     @extend .px-0;
+//     @extend .mx-0;
+//     @extend .w-100;
+//     @extend .mw-100;
+//   }
+// }


### PR DESCRIPTION
Closes #6761 

**Link to sample test pages**:

**Or** if you would like to compare the differences side by side, please use the percy details found here: [link](https://percy.io/Mozilla-Foundation/foundation.mozilla.org/builds/11009587/changed/618331412?browser=chrome&browser_ids=14%2C16&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1280&widths=375%2C1280
)
- Homepage: [link](https://foundation-s-6761-strea-zvcfdj.herokuapp.com/en/who-we-are/)
- Article Page: [link](https://foundation-s-6761-strea-zvcfdj.herokuapp.com/en/publication-page-with-child-article-pages/fixed-title-article-page/)
- Mozfest page: Seems to be getting 500 errors? [link](https://foundation-s-6761-strea-zvcfdj.herokuapp.com/cms/pages/158/edit/preview/)
- Single page campaign: [link](https://foundation-s-6761-strea-zvcfdj.herokuapp.com/en/campaigns/single-page/)
- Single Page Campaign (Two-Column): [link](https://foundation-s-6761-strea-zvcfdj.herokuapp.com/cms/pages/33/edit/preview/)
- MultiPage Campaign: [link](https://foundation-s-6761-strea-zvcfdj.herokuapp.com/en/campaigns/multi-page/)
- MultiPage Campaign (two column):  [link](https://foundation-s-6761-strea-zvcfdj.herokuapp.com/cms/pages/34/edit/preview/)
- SinglePage Opportunity: [link](https://foundation-s-6761-strea-zvcfdj.herokuapp.com/en/initiatives/single-page-opportunity/)
- Multi-Page Opportunity:[link]( https://foundation-s-6761-strea-zvcfdj.herokuapp.com/en/initiatives/multi-page-opportunity/doctor-especially-wall/
)

**Part I would like to ask about:** At the moment, the [blog page ](https://foundation-s-6761-strea-zvcfdj.herokuapp.com/en/blog/initial-test-blog-post-with-fixed-title/) is working correctly, minus the wide images. They are still bigger than normal images, however they do not reach side to side. 
We can add the functionality to implement the wide image, however the share buttons become a point of concern as they rely on being wrapped in the same container div as the rest of the content, unless we want to use things like "Position:fixed" and negative margins to get things aligned properly. 

Some immediate ideas that come to mind are: 

- Make them static like the share buttons on article pages
- Implement the fix, and then make wide images have a z index of 99 so they dont overlap
- Leave the page functional as is, minus the side to side wide image, however, the design team mentioned it would be useful to have them. 

## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible]

