### PR TITLE
Localization synching and creating management commands

### DIFF
--- a/network-api/networkapi/management/commands/create_locales.py
+++ b/network-api/networkapi/management/commands/create_locales.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from wagtail.core.models import Locale
+
+
+class Command(BaseCommand):
+    help = 'Look for and create locales if they do not exist. This can be run multiple times if needed.'
+
+    def handle(self, *args, **options):
+        for language_code, name in settings.WAGTAIL_CONTENT_LANGUAGES:
+            locale, created = Locale.objects.get_or_create(language_code=language_code)
+            if created:
+                print(f"Create new locale: {name}")

--- a/network-api/networkapi/management/commands/sync_locale.py
+++ b/network-api/networkapi/management/commands/sync_locale.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from wagtail.core.models import Locale
+from wagtail_localize.models import LocaleSynchronization
+
+
+class Command(BaseCommand):
+    help = 'Sync pages with original English pages'
+
+    def handle(self, *args, **options):
+        print("Select a language code to sync with English. ie: de")
+
+        for language_code, name in settings.WAGTAIL_CONTENT_LANGUAGES:
+            if language_code != 'en':
+                print(f"{language_code} ({name})")
+
+        language_code = input("Language code: ").lower()
+
+        # Confirm the language code is in the WAGTAIL_CONTENT_LANGUAGES
+        language_codes_dict = dict(settings.WAGTAIL_CONTENT_LANGUAGES)
+        if language_code not in language_codes_dict:
+            print("Invalid language code")
+            return
+
+        print("Getting both locales...")
+        english_locale, _ = Locale.objects.get_or_create(language_code='en')
+        locale, _ = Locale.objects.get_or_create(language_code=language_code)
+
+        print("Getting LocaleSynchronization object")
+        sync, created = LocaleSynchronization.objects.get_or_create(
+            locale=locale,
+            sync_from=english_locale,
+        )
+        if created:
+            print("\tNew LocaleSynchronization object created")
+
+        print(f"Syncing {locale} from {english_locale}")
+        sync.sync_trees()

--- a/network-api/networkapi/management/commands/sync_locale.py
+++ b/network-api/networkapi/management/commands/sync_locale.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
             if language_code != 'en':
                 print(f"{language_code} ({name})")
 
-        language_code = input("Language code: ").lower()
+        language_code = input("Language code: ")
 
         # Confirm the language code is in the WAGTAIL_CONTENT_LANGUAGES
         language_codes_dict = dict(settings.WAGTAIL_CONTENT_LANGUAGES)


### PR DESCRIPTION
Closes #6869

Two new management commands. 

### 1. create_locales
`python manage.py create_locales` will loop through all our language settings and create new locales if they don't exist. This can be run multiple times. 

### 2. sync_locale
`python manage.py sync_locale` will list all your available language codes and ask you to type one in. It will skip English because we shouldn't sync English with English (and the English Locale should exist for us already) 

It will then verify the language_code you entered is in our settings. 

It'll get_or_create the source locale and the target locale objects. 

Then it'll create a LocalSynchonization object using those locals, or find the one that already exists. 

Lastly, it'll run `.sync_trees()` to sync a locale against English (it always uses English as the source locale). 

This should be safe to run multiple times too. 

### Testing steps 
1. Checkout this branch 
2. Run `python manage.py create_locales` 
3. Run it again and notice it didn't create a second set of Locales (making this safe to run multiple times in production) 
4. Run `python manage.py sync_locale`. You'll need to specify a specific language from the list it will give you. 
5. Run the exact same command a second time. Notice there is _not_ a second set of pages, making this safe to run multiple times in production. Your Wagtail page explorer should show English pages, and also your new locale pages. 