### PR TITLE
Make tests pass

### DIFF
--- a/network-api/networkapi/campaign/views.py
+++ b/network-api/networkapi/campaign/views.py
@@ -12,6 +12,7 @@ import logging
 import json
 from networkapi.wagtailpages.models import Petition, Signup
 
+
 def process_lang_code(lang):
     # Salesforce expects "pt" instead of "pt-BR".
     # See https://github.com/mozilla/foundation.mozilla.org/issues/5993

--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -347,6 +347,7 @@ class ParticipatePage2(PrimaryPage):
 class Styleguide(PrimaryPage):
     template = 'wagtailpages/static/styleguide.html'
 
+
 class HomepageSpotlightPosts(TranslatableMixin, WagtailOrderable):
     page = ParentalKey(
         'wagtailpages.Homepage',
@@ -453,7 +454,7 @@ class CTABase(WagtailOrderable, models.Model):
     def __str__(self):
         return self.page.title + '->' + self.highlight.title
 
-# from wagtail.core.models import BootstrapTranslatableModel
+
 class CTA4(TranslatableMixin, CTABase):
     page = ParentalKey(
         'wagtailpages.ParticipatePage2',
@@ -492,11 +493,14 @@ class ParticipateHighlights(ParticipateHighlightsBase):
 
     class Meta(TranslatableMixin.Meta):
         pass
+
+
 class ParticipateHighlights2(ParticipateHighlightsBase):
     page = ParentalKey(
         'wagtailpages.ParticipatePage2',
         related_name='featured_highlights2',
     )
+
     class Meta(TranslatableMixin.Meta):
         pass
 

--- a/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
@@ -3,7 +3,7 @@ import json
 from django.db import models
 
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, StreamFieldPanel
-from wagtail.core.models import TranslatableMixin, TranslatableMixin, Page
+from wagtail.core.models import TranslatableMixin, Page
 from wagtail.core.fields import RichTextField
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.snippets.models import register_snippet

--- a/network-api/networkapi/wagtailpages/tests.py
+++ b/network-api/networkapi/wagtailpages/tests.py
@@ -239,7 +239,7 @@ class TestBuyersGuidePage(BuyersGuideTestMixin):
         self.assertEqual(response.redirect_chain[0][0], product.url)
 
     def test_sitemap_entries(self):
-        response = self.client.get('/sitemap.xml')
+        response = self.client.get('/en/sitemap.xml')
         context = response.context
 
         self.assertEqual(context.template_name, 'sitemap.xml')


### PR DESCRIPTION
Closes #6709 

Not much to do here except flake8 some files and change the default sitemap URL. 

### Steps to run:
1. `inv test-python`. We should see a few skipped tests, but no errors. The skipped tests are expected. 
2. `inv test-node`. Everything should look good here. 
3. `inv test` to test node and python together - never hurts to re-run a test suite. 