### PR TITLE
Marked fields are sync or translatable

### DIFF
--- a/network-api/networkapi/campaign/views.py
+++ b/network-api/networkapi/campaign/views.py
@@ -12,6 +12,7 @@ import logging
 import json
 from networkapi.wagtailpages.models import Petition, Signup
 
+
 def process_lang_code(lang):
     # Salesforce expects "pt" instead of "pt-BR".
     # See https://github.com/mozilla/foundation.mozilla.org/issues/5993

--- a/network-api/networkapi/highlights/models.py
+++ b/network-api/networkapi/highlights/models.py
@@ -9,6 +9,8 @@ from wagtail.core.models import TranslatableMixin
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.snippets.models import register_snippet
 
+from wagtail_localize.fields import TranslatableField
+
 from networkapi.utility.images import get_image_upload_path
 
 
@@ -96,6 +98,13 @@ class Highlight(TranslatableMixin, SortableMixin):
         FieldPanel("footer"),
         FieldPanel("publish_after"),
         FieldPanel("expires"),
+    ]
+
+    translatable_fields = [
+        TranslatableField('title'),
+        TranslatableField('description'),
+        TranslatableField('link_label'),
+        TranslatableField('footer'),
     ]
 
     objects = HighlightQuerySet.as_manager()

--- a/network-api/networkapi/wagtailpages/donation_modal.py
+++ b/network-api/networkapi/wagtailpages/donation_modal.py
@@ -5,6 +5,8 @@ from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.snippets.models import register_snippet
 from modelcluster.fields import ParentalKey
 
+from wagtail_localize.fields import SynchronizedField, TranslatableField
+
 
 @register_snippet
 class DonationModal(TranslatableMixin, models.Model):
@@ -40,6 +42,13 @@ class DonationModal(TranslatableMixin, models.Model):
         help_text='Dismiss button label',
         default="No thanks",
     )
+
+    translatable_fields = [
+        TranslatableField('header'),
+        TranslatableField('body'),
+        TranslatableField('donate_text'),
+        TranslatableField('dismiss_text'),
+    ]
 
     def to_simple_dict(self):
         keys = ['name', 'header', 'body', 'donate_text', 'dismiss_text']

--- a/network-api/networkapi/wagtailpages/donation_modal.py
+++ b/network-api/networkapi/wagtailpages/donation_modal.py
@@ -5,7 +5,7 @@ from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.snippets.models import register_snippet
 from modelcluster.fields import ParentalKey
 
-from wagtail_localize.fields import SynchronizedField, TranslatableField
+from wagtail_localize.fields import TranslatableField
 
 
 @register_snippet

--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -535,6 +535,12 @@ class FocusArea(TranslatableMixin, models.Model):
         PageChooserPanel('page'),
     ]
 
+    translatable_fields = [
+        SynchronizedField('interest_icon'),
+        TranslatableField('name'),
+        TranslatableField('description'),
+    ]
+
     def __str__(self):
         return self.name
 

--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -347,6 +347,7 @@ class ParticipatePage2(PrimaryPage):
 class Styleguide(PrimaryPage):
     template = 'wagtailpages/static/styleguide.html'
 
+
 class HomepageSpotlightPosts(TranslatableMixin, WagtailOrderable):
     page = ParentalKey(
         'wagtailpages.Homepage',
@@ -453,7 +454,7 @@ class CTABase(WagtailOrderable, models.Model):
     def __str__(self):
         return self.page.title + '->' + self.highlight.title
 
-# from wagtail.core.models import BootstrapTranslatableModel
+
 class CTA4(TranslatableMixin, CTABase):
     page = ParentalKey(
         'wagtailpages.ParticipatePage2',
@@ -492,11 +493,13 @@ class ParticipateHighlights(ParticipateHighlightsBase):
 
     class Meta(TranslatableMixin.Meta):
         pass
+
 class ParticipateHighlights2(ParticipateHighlightsBase):
     page = ParentalKey(
         'wagtailpages.ParticipatePage2',
         related_name='featured_highlights2',
     )
+
     class Meta(TranslatableMixin.Meta):
         pass
 

--- a/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
@@ -190,6 +190,9 @@ class Petition(TranslatableMixin, CTA):
         TranslatableField('comment_requirements'),
         TranslatableField('checkbox_1'),
         TranslatableField('checkbox_2'),
+        SynchronizedField('share_twitter'),
+        SynchronizedField('share_facebook'),
+        SynchronizedField('share_email'),
         TranslatableField('thank_you'),
         # Fields from the CTA model
         TranslatableField('header'),

--- a/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
@@ -68,6 +68,17 @@ class Signup(TranslatableMixin, CTA):
         default=False,
     )
 
+    translatable_fields = [
+        # This models fields
+        SynchronizedField('campaign_id'),
+        SynchronizedField('ask_name'),
+        # Fields from the CTA model
+        TranslatableField('name'),
+        TranslatableField('header'),
+        TranslatableField('description'),
+        TranslatableField('newsletter'),
+    ]
+
     class Meta(TranslatableMixin.Meta):
         verbose_name = 'signup snippet'
 
@@ -176,6 +187,29 @@ class Petition(TranslatableMixin, CTA):
         help_text='Message to show after thanking people for signing',
         default='Thank you for signing too!',
     )
+
+
+    translatable_fields = [
+        # This models fields
+        SynchronizedField('campaign_id'),
+        SynchronizedField('ask_name'),
+        SynchronizedField('requires_country_code'),
+        SynchronizedField('requires_postal_code'),
+        TranslatableField('comment_requirements'),
+        TranslatableField('checkbox_1'),
+        TranslatableField('checkbox_2'),
+        TranslatableField('share_link'),
+        TranslatableField('share_link_text'),
+        TranslatableField('share_twitter'),
+        TranslatableField('share_email'),
+        TranslatableField('thank_you'),
+        # Fields from the CTA model
+        TranslatableField('name'),
+        TranslatableField('header'),
+        TranslatableField('description'),
+        TranslatableField('newsletter'),
+    ]
+
 
     class Meta(TranslatableMixin.Meta):
         verbose_name = 'petition snippet'

--- a/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
@@ -69,14 +69,9 @@ class Signup(TranslatableMixin, CTA):
     )
 
     translatable_fields = [
-        # This models fields
-        SynchronizedField('campaign_id'),
-        SynchronizedField('ask_name'),
         # Fields from the CTA model
-        TranslatableField('name'),
         TranslatableField('header'),
         TranslatableField('description'),
-        TranslatableField('newsletter'),
     ]
 
     class Meta(TranslatableMixin.Meta):
@@ -191,23 +186,15 @@ class Petition(TranslatableMixin, CTA):
 
     translatable_fields = [
         # This models fields
-        SynchronizedField('campaign_id'),
-        SynchronizedField('ask_name'),
         SynchronizedField('requires_country_code'),
         SynchronizedField('requires_postal_code'),
         TranslatableField('comment_requirements'),
         TranslatableField('checkbox_1'),
         TranslatableField('checkbox_2'),
-        TranslatableField('share_link'),
-        TranslatableField('share_link_text'),
-        TranslatableField('share_twitter'),
-        TranslatableField('share_email'),
         TranslatableField('thank_you'),
         # Fields from the CTA model
-        TranslatableField('name'),
         TranslatableField('header'),
         TranslatableField('description'),
-        TranslatableField('newsletter'),
     ]
 
 

--- a/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
@@ -3,7 +3,7 @@ import json
 from django.db import models
 
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, StreamFieldPanel
-from wagtail.core.models import TranslatableMixin, TranslatableMixin, Page
+from wagtail.core.models import TranslatableMixin, Page
 from wagtail.core.fields import RichTextField
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.snippets.models import register_snippet
@@ -183,7 +183,6 @@ class Petition(TranslatableMixin, CTA):
         default='Thank you for signing too!',
     )
 
-
     translatable_fields = [
         # This models fields
         SynchronizedField('requires_country_code'),
@@ -196,7 +195,6 @@ class Petition(TranslatableMixin, CTA):
         TranslatableField('header'),
         TranslatableField('description'),
     ]
-
 
     class Meta(TranslatableMixin.Meta):
         verbose_name = 'petition snippet'

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -108,6 +108,12 @@ class BuyersGuideProductCategory(TranslatableMixin, models.Model):
         blank=True,
     )
 
+    translatable_fields = [
+        TranslatableField('name'),
+        TranslatableField('description'),
+        SynchronizedField('slug'),
+    ]
+
     @property
     def published_product_page_count(self):
         return ProductPage.objects.filter(product_categories__category=self).live().count()
@@ -273,6 +279,13 @@ class Update(TranslatableMixin, index.Indexed, models.Model):
 
     search_fields = [
         index.SearchField('title', partial_match=True),
+    ]
+
+    translatable_fields = [
+        SynchronizedField('source'),
+        SynchronizedField('title'),
+        SynchronizedField('author'),
+        SynchronizedField('snippet'),
     ]
 
     def __str__(self):

--- a/network-api/networkapi/wagtailpages/translation.py
+++ b/network-api/networkapi/wagtailpages/translation.py
@@ -1,3 +1,5 @@
+# TODO: REmove this and other translation.py files.
+# They aren't needed but keep coming back when we merge master into our localization branch
 from .models import (
     ModularPage,
     MiniSiteNameSpace,


### PR DESCRIPTION
Closes #6867 

Added snippet field translation support from [this document](https://docs.google.com/spreadsheets/d/1AU7pxboZoBiVcbTpZO-VUMAhxZwx5mdEH_FBLfo2D-w/edit#gid=134886357) 

One thing to note is the CTA model is not translatable. But it's child classes _are_, so the fields from the CTA model get passed into the translatable_fields for Signup() and Petition() 