### PR TITLE
Allow banner pages to be further localized

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
@@ -291,8 +291,13 @@ class BanneredCampaignPage(PrimaryPage):
         TranslatableField('search_description'),
         SynchronizedField('search_image'),
         # Content tab fields
+        TranslatableField('header'),
+        TranslatableField('intro'),
+        TranslatableField('body'),
         TranslatableField("title"),
         SynchronizedField("banner"),
+        SynchronizedField("narrowed_page_content"),
+        SynchronizedField("zen_nav"),
         TranslatableField("cta"),
         TranslatableField("signup"),
     ]


### PR DESCRIPTION
Closes #6868 

Because this page inherits from the PrimaryPage, we need to re-set the fields on the child model. There's a cleaner way to do this, but for now this works. 

The "cta" (Its a Petition() ForeignKey) and the "signup" (It's a ForeignKey to a Signup()) may not translate properly on this branch, but should translate fine on #6867 (PR #6875)