### PR TITLE
Fix makemessages command for Django >= 3.1

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -18,10 +18,10 @@ else:
 locale_abstraction_instructions = " ".join(
     [
         "makemessages",
+        "--all",
         "--keep-pot",
         "--no-wrap",
         "--ignore=network-api/networkapi/wagtailcustomization/*",
-        "--ignore=network-api/networkapi/wagtail_l10n_customization/*",
         "--ignore=network-api/networkapi/settings.py",
         "--ignore=network-api/networkapi/wagtailpages/__init__.py",
         "--ignore=network-api/networkapi/wagtailpages/templates/wagtailpages/pages/dear_internet_page.html",


### PR DESCRIPTION
The `makemessages` command stopped working on Django 3.1, looks like it requires specifying locales now. In our case, we will use `--all`
<img width="1183" alt="Capture d’écran 2021-06-21 à 14 02 10" src="https://user-images.githubusercontent.com/1294206/122758640-f277e780-d290-11eb-8237-7705864d5ee4.png">

Also dropped `wagtail_l10n_customization` since this doesn’t exist anymore