### PR TITLE
Use localized wagtail-footnotes

### DIFF
--- a/network-api/networkapi/mozfest/models.py
+++ b/network-api/networkapi/mozfest/models.py
@@ -192,9 +192,7 @@ class MozfestHomepage(MozfestPrimaryPage):
         TranslatableField('search_image'),
         TranslatableField('signup'),
         TranslatableField('body'),
-        # TODO: Add in footnote support when wagtail-footnotes and wagtail-localize can work together.
-        # Issue can be found at https://github.com/mozilla/foundation.mozilla.org/issues/6790
-        # TranslatableField('footnotes'),
+        TranslatableField('footnotes'),
     ]
 
     def get_context(self, request):

--- a/network-api/networkapi/wagtailpages/pagemodels/publications/article.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/publications/article.py
@@ -131,9 +131,7 @@ class ArticlePage(FoundationMetadataPageMixin, Page):
         TranslatableField('subtitle'),
         SynchronizedField('article_file'),
         TranslatableField('body'),
-        # TODO: Add in footnote support when wagtail-footnotes and wagtail-localize can work together.
-        # Issue can be found at https://github.com/mozilla/foundation.mozilla.org/issues/6790
-        # TranslatableField('footnotes'),
+        TranslatableField('footnotes'),
     ]
 
     @property

--- a/requirements.in
+++ b/requirements.in
@@ -30,5 +30,5 @@ whitenoise
 psycopg2-binary
 cloudinary
 sentry-sdk
-wagtail-footnotes
+git+https://github.com/MozillaFoundation/wagtail-footnotes.git@localized-footnotes
 scout-apm

--- a/requirements.txt
+++ b/requirements.txt
@@ -235,7 +235,7 @@ wagtail-airtable==0.1.6
     # via -r requirements.in
 wagtail-factories==2.0.1
     # via -r requirements.in
-wagtail-footnotes==0.5.0
+git+https://github.com/MozillaFoundation/wagtail-footnotes.git@localized-footnotes
     # via -r requirements.in
 wagtail-inventory==1.3
     # via -r requirements.in


### PR DESCRIPTION
Closes #6790

**Link to sample test page**: Will need to test on localhost. 

Steps for testing:
1. Checkout this branch
2. `inv new-env` to pull in the new wagtail-footnotes work 
3. Log in to the admin 
4. Create a new locale. Settings -> Locale -> New 
5. Sync English with a new locale (ie. German). 
6. Edit the English version of an ArticlePage 
7. Create new footnotes (bottom of the edit view). Try applying them in a richtext area too.
8. Edit the German version of the same ArticlePage. Note that footnote text shows up in there now and can be translated, and the page saves without error. 