### PR TITLE
Don't verify SSL certificate for Redis connections

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -357,7 +357,10 @@ if env('REDIS_URL'):
                 # Enable compression
                 'COMPRESSOR': 'django_redis.compressors.zlib.ZlibCompressor',
                 # Ignore exceptions, redis only used for caching (i.e. if redis fails, will use database)
-                'IGNORE_EXCEPTIONS': True
+                'IGNORE_EXCEPTIONS': True,
+                'CONNECTION_POOL_KWARGS': {
+                    "ssl_cert_reqs": None
+                }
             }
         }
     }


### PR DESCRIPTION
To support Heroku's required upgrades to Redis 6.0 with SSL enabled, we need to disable SSL certificate verification.