### PR TITLE
Localize YouteRegrets landing page

### DIFF
--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -62,6 +62,7 @@
 
 
 {% block script_bundle %}
+  <script src="{% url "javascript-catalog" %}"></script>
   {# This uses the mofo main.js for now, to make sure "things work" until we (maybe never?) create a separate bundle #}
   <script src="{% static "_js/main.compiled.js" %}"></script>
   <script src="{% static "_js/mozfest.compiled.js" %}"></script>

--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -92,6 +92,7 @@
     {% endblock %}
 
     {% block script_bundle %}
+      <script src="{% url "javascript-catalog" %}"></script>
       <script src="{% static "_js/main.compiled.js" %}"></script>
     {% endblock %}
 

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -4,10 +4,11 @@ from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponse
+from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
-from django.views.i18n import set_language
+from django.views.i18n import set_language, JavaScriptCatalog
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
@@ -67,6 +68,7 @@ urlpatterns = list(filter(None, [
 
     # set up set language redirect view
     path('i18n/setlang/', csrf_exempt(set_language), name='set_language'),
+    path('jsi18n/', cache_page(86400)(JavaScriptCatalog.as_view()), name='javascript-catalog'),
 
     # Wagtail Footnotes package
     path("footnotes/", include(footnotes_urls)),

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -68,7 +68,7 @@ urlpatterns = list(filter(None, [
 
     # set up set language redirect view
     path('i18n/setlang/', csrf_exempt(set_language), name='set_language'),
-    path('jsi18n/', cache_page(86400)(JavaScriptCatalog.as_view()), name='javascript-catalog'),
+    path('jsi18n/', cache_page(3600)(JavaScriptCatalog.as_view()), name='javascript-catalog'),
 
     # Wagtail Footnotes package
     path("footnotes/", include(footnotes_urls)),

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/bg_base.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/bg_base.html
@@ -65,6 +65,7 @@
 
 
 {% block script_bundle %}
+  <script src="{% url "javascript-catalog" %}"></script>
   <script src="{% static "_js/bg-main.compiled.js" %}" async defer></script>
 {% endblock %}
 

--- a/tasks.py
+++ b/tasks.py
@@ -29,6 +29,17 @@ locale_abstraction_instructions = " ".join(
     ]
 )
 
+locale_abstraction_instructions_js = " ".join(
+    [
+        "makemessages",
+        "-d djangojs",
+        "--keep-pot",
+        "--no-wrap",
+        "--ignore=node_modules",
+        "--ignore=dockerpythonvenv/*",
+    ]
+)
+
 
 def create_env_file(env_file):
     """Create or update an .env to work with a docker environment"""
@@ -246,6 +257,7 @@ def makemessages(ctx):
     """Extract all template messages in .po files for localization"""
     ctx.run("./translation-management.sh import")
     manage(ctx, locale_abstraction_instructions)
+    manage(ctx, locale_abstraction_instructions_js)
     ctx.run("./translation-management.sh export")
 
 

--- a/translation-management.sh
+++ b/translation-management.sh
@@ -40,6 +40,7 @@ case $command in
     cp -r "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/buyersguide/locale/" "network-api/networkapi/wagtailpages/templates/buyersguide/locale/"
     cp -r "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/about/locale/" "network-api/networkapi/wagtailpages/templates/about/locale/"
     cp -r "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/locale/" "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/locale/"
+    cp -r "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale/" "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale/"
     cp -r "${L10N_REPO}foundation/translations/networkapi/mozfest/locale/" "network-api/networkapi/mozfest/locale/"
 esac
 
@@ -50,5 +51,6 @@ case $command in
     cp -r "network-api/networkapi/wagtailpages/templates/buyersguide/locale/" "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/buyersguide/locale/"
     cp -r "network-api/networkapi/wagtailpages/templates/about/locale/" "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/about/locale/"
     cp -r "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/locale/" "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/locale/"
+    cp -r "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale/" "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale/"
     cp -r "network-api/networkapi/mozfest/locale/" "${L10N_REPO}foundation/translations/networkapi/mozfest/locale/"
 esac


### PR DESCRIPTION
Part of #6916 

I just realized the charts labels are in js files, and the site was not set up to localize content there. I reused the same approach we’ve used on donate, and got it working.

I’ve also moved the landing page content into its own .po file to avoid exposing the content to other locales since it’s pretty massive.
 
 This PR can be merged independently of the YT landing page stuff

<img width="1035" alt="Capture d’écran 2021-07-01 à 19 07 09" src="https://user-images.githubusercontent.com/1294206/124164612-c29ec000-da98-11eb-8a6c-e17a4e08035e.png">

