### PR TITLE
Use the static page template; removed old static url/view

### DIFF
--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -28,7 +28,6 @@ from networkapi.wagtailcustomization.image_url_tag_urls import urlpatterns as im
 from networkapi.views import EnvVariablesView, review_app_help_view
 from networkapi.wagtailpages.rss import RSSFeed, AtomFeed
 from networkapi.redirects import foundation_redirects
-from .views import YoutubeRegrets2021View
 
 admin.autodiscover()
 
@@ -74,8 +73,6 @@ urlpatterns = list(filter(None, [
 
     # Wagtail Footnotes package
     path("footnotes/", include(footnotes_urls)),
-
-    path("youtube-regrets-2021/", YoutubeRegrets2021View)
 ]))
 
 # Anything that needs to respect the localised

--- a/network-api/networkapi/views.py
+++ b/network-api/networkapi/views.py
@@ -19,7 +19,3 @@ def review_app_help_view(request):
         return render(request, 'reviewapp-help.html')
     else:
         return HttpResponse(status=404)
-
-
-def YoutubeRegrets2021View(request):
-    return render(request, 'wagtailpages/pages/youtube-regrets-2021/youtube_regrets_2021.html')

--- a/network-api/networkapi/wagtailpages/pagemodels/youtube.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/youtube.py
@@ -92,7 +92,7 @@ class YoutubeRegretsReporterPage(FoundationMetadataPageMixin, Page):
 
 class YoutubeRegrets2021Page(FoundationMetadataPageMixin, Page):
 
-    template = 'wagtailpages/pages/youtube_regrets_page_2021.html'
+    template = 'wagtailpages/pages/youtube-regrets-2021/youtube_regrets_2021.html'
     max_count = 1
     zen_nav = True
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/youtube_regrets_2021.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/youtube_regrets_2021.html
@@ -11,11 +11,9 @@
 {% endblock %}
 
 {# Empty header; Do not add <header role="banner"> to the page #}
-{% block header_wrapped %}
-{% endblock %}
+{% block header_wrapped %}{% endblock %}
 
-{% block wagtail_metadata %}
-{% endblock %}
+{% block wagtail_metadata %}{% endblock %}
 
 {% block content_wrapped %}
   <main role="main">


### PR DESCRIPTION
Closes #7004 

This PR should leverage the static URL template for YouTube Regrets 2021 and remove the old static URL and view. 

**Link to sample test page**: https://foundation-s-7004-move--q8mp9w.herokuapp.com/en/campaigns/regrets-reporter/findings/

