### PR TITLE
Wrap more strings on YT page

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/hero_carousel.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/hero_carousel.html
@@ -13,10 +13,10 @@
                 <span class="carousel-hero__count-first">1 </span><span class="carousel-hero__count-second"> / 3</span>
               </div>
             </div>
-            <button class="carousel-hero__button carousel-hero__button--prev button mr-3" aria-label="Previous slide" data-glide-dir="<">
+            <button class="carousel-hero__button carousel-hero__button--prev button mr-3" aria-label="{% trans "Previous slide" %}" data-glide-dir="<">
               <svg aria-hidden="true" width="41" height="41" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="circle" d="M20.48 39.736c10.586 0 19.167-8.581 19.167-19.167 0-10.585-8.58-19.166-19.166-19.166S1.314 9.983 1.314 20.569s8.581 19.167 19.167 19.167z" stroke="#000" stroke-linecap="round" stroke-linejoin="round"/><path class="arrow" d="M20.48 12.903l-7.666 7.666 7.667 7.667M28.147 20.57H12.814" stroke="#000" stroke-linecap="round" stroke-linejoin="round"/></svg>
             </button>
-            <button class="carousel-hero__button carousel-hero__button--next button" aria-label="Next slide" data-glide-dir=">">
+            <button class="carousel-hero__button carousel-hero__button--next button" aria-label="{% trans "Next slide" %}" data-glide-dir=">">
               <svg aria-hidden="true" width="41" height="41" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="circle" d="M20.48 39.736c10.586 0 19.167-8.581 19.167-19.167 0-10.585-8.58-19.166-19.166-19.166S1.314 9.983 1.314 20.569s8.581 19.167 19.167 19.167z" stroke="#000" stroke-linecap="round" stroke-linejoin="round"/><path class="arrow" d="M20.48 28.236l7.667-7.667-7.666-7.666M12.814 20.57h15.333" stroke="#000" stroke-linecap="round" stroke-linejoin="round"/></svg>
             </button>
           </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/youtube_regrets_accordion.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/youtube_regrets_accordion.html
@@ -104,7 +104,7 @@
               </div>
               <div class="row">
                 <div class="col-md-8 offset-md-1">
-                  <p>Our past work has shown that these video recommendations can have significant impacts on people’s lives.</p>
+                  <p>{% trans "Our past work has shown that these video recommendations can have significant impacts on people’s lives." %}</p>
 
                   {# Carousel #}
                   <div class="full-width-container">

--- a/source/js/foundation/pages/youtube-regrets/count-up.js
+++ b/source/js/foundation/pages/youtube-regrets/count-up.js
@@ -4,7 +4,7 @@ export const initYoutubeRegretsResearchCountUp = () => {
   if ("IntersectionObserver" in window) {
     const localeSeparator = get_format("THOUSAND_SEPARATOR");
     const localizedSuffix = gettext("K");
-    const reportCountUp = new CountUp("reports-count-up", 5234, {
+    const reportCountUp = new CountUp("reports-count-up", 3362, {
       separator: localeSeparator,
     });
     const volunteersCountUp = new CountUp("volunteers-count-up", 1662, {


### PR DESCRIPTION
Closes #6916

Wrap more strings for localization.

Also updates the report number in countup (it’s been only updated in the template) — fixes #7017