### PR TITLE
Fix piechart numbers

### DIFF
--- a/source/js/foundation/pages/youtube-regrets/recommendations-pie-chart.js
+++ b/source/js/foundation/pages/youtube-regrets/recommendations-pie-chart.js
@@ -13,7 +13,7 @@ export const initYouTubeRegretsRecommendationsPieChart = () => {
       labels: [gettext("Recommendation"), gettext("Search"), gettext("Other")],
       datasets: [
         {
-          data: [71.1, 21.5, 7.47],
+          data: [70.9, 7.67, 21.4],
           backgroundColor: ["#FC4147", "#080708", "#FBD5D7"],
         },
       ],


### PR DESCRIPTION
Partially Closes #7021

**Link to sample test page**: https://foundation-s-7021-pie-c-ofvcle.herokuapp.com/en/campaigns/regrets-reporter/findings/ (look at Section #1; you'll need to click into it)

Numbers should have been: `[70.9, 7.67, 21.4]`. These are now fixed. 