### PR TITLE
update all homepage fragments to pull from localized content

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/cause_statement.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/cause_statement.html
@@ -3,7 +3,7 @@
     <div class="section-cause-statement dark-theme p-5 text-center">
       <p class="h4-heading">{{ page.cause_statement }}</p>
       {% if page.cause_statement_link_text and page.cause_statement_link_page %}
-        <a href="{{page.cause_statement_link_page.url}}" class="cta-link" id="homepage-cause-statement-cta">{{page.cause_statement_link_text}}</a>
+        <a href="{{page.cause_statement_link_page.localized.url}}" class="cta-link" id="homepage-cause-statement-cta">{{page.cause_statement_link_text}}</a>
       {% endif %}
     </div>
   </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/focus_area.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/focus_area.html
@@ -8,7 +8,7 @@
         <p>{{ area.description }}</p>
 
         {% if area.page %}<div class="mb-4 learn-more-link">
-            <a href="{{ area.page.url }}" aria-label="{% blocktrans with name=area.name %}Learn more about: {{ name }}{% endblocktrans %}">{% trans "Learn more →" %}</a>
+            <a href="{{ area.page.localized.url }}" aria-label="{% blocktrans with name=area.name %}Learn more about: {{ name }}{% endblocktrans %}">{% trans "Learn more →" %}</a>
         </div>{% endif %}
     </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/news_you_can_use.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/news_you_can_use.html
@@ -23,7 +23,7 @@
 
   {% endcomment %}
 
-      {% with first=items.first.blog %}
+      {% with first=items.first.blog.localized %}
       <div class="d-none d-xl-block col-xl-12 feature mb-md-5">
         <div class="position-relative h-100 d-flex justify-content-end">
           <div class="feature-image">
@@ -56,22 +56,24 @@
 
       {% with item_1_class="d-xl-none mb-5 mb-xl-0" item_2_class="mb-5 mb-xl-0" item_3_class="mb-5 mb-md-0"  %}
       {% for item in items %}
+      {% with localized=item.blog.localizes %}
       <div class="col-12 col-md-6 col-xl-4 d-flex {% if forloop.counter == 1 %} {{item_1_class}}{% endif %} {% if forloop.counter == 2 %} {{item_2_class}}{% endif %} {% if forloop.counter == 3 %} {{item_3_class}}{% endif %}">
         <div class="bg-white">
-          <img src="{% image_url item.blog.get_meta_image "fill-700x394" %}" alt="" class="embed-responsive-item">
+          <img src="{% image_url localized.get_meta_image "fill-700x394" %}" alt="" class="embed-responsive-item">
           <div class="p-4">
-            {% if item.blog.category.count %}
-              {% with category=item.blog.category.first %}
+            {% if localized.category.count %}
+              {% with category=localized.category.first %}
                 <a class="h6-heading d-block mb-1" href="/blog/category/{{ category.slug }}">{{ category }}</a>
               {% endwith %}
             {% else %}
                 <div class="h6-heading d-md-block d-none mb-1">&nbsp;</div>
             {% endif %}
-            <h3 class="h4-heading"><a href="{{item.blog.url}}">{{ item.blog.title }}</a></h3>
+            <h3 class="h4-heading"><a href="{{localized.url}}">{{ localized.title }}</a></h3>
             {% include "./blog_authors.html" with blog_page=item.blog %}
           </div>
         </div>
       </div>
+      {% endwith %}
       {% endfor %}
       {% endwith %}
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/news_you_can_use.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/news_you_can_use.html
@@ -56,7 +56,7 @@
 
       {% with item_1_class="d-xl-none mb-5 mb-xl-0" item_2_class="mb-5 mb-xl-0" item_3_class="mb-5 mb-md-0"  %}
       {% for item in items %}
-      {% with localized=item.blog.localizes %}
+      {% with localized=item.blog.localized %}
       <div class="col-12 col-md-6 col-xl-4 d-flex {% if forloop.counter == 1 %} {{item_1_class}}{% endif %} {% if forloop.counter == 2 %} {{item_2_class}}{% endif %} {% if forloop.counter == 3 %} {{item_3_class}}{% endif %}">
         <div class="bg-white">
           <img src="{% image_url localized.get_meta_image "fill-700x394" %}" alt="" class="embed-responsive-item">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/partner.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/partner.html
@@ -11,7 +11,7 @@
             {{ page.partner_intro_text }}
           </p>
         {% endif %}
-        <a href="{{ page.partner_page.url }}" class="text-white cta-link font-weight-bold" id="partner-cta">
+        <a href="{{ page.partner_page.localized.url }}" class="text-white cta-link font-weight-bold" id="partner-cta">
           {{ page.partner_page_text }}
         </a>
       </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/spotlight_posts.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/spotlight_posts.html
@@ -20,6 +20,7 @@
         </h4>
         {% include "./blog_authors.html" with blog_page=localized %}
       </div>
+    {% endwith %}
     {% endfor %}
   </div>
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/spotlight_posts.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/spotlight_posts.html
@@ -13,11 +13,12 @@
 
   <div class="col-12 col-lg-6">
     {% for post in page.spotlight_posts.all %}
+    {% with localized=post.blog.localized %}
       <div class="spotlight-post">
         <h4 class="mb-2 h5-heading">
-          <a href="{{post.blog.url}}">{{post.blog.title}}</a>
+          <a href="{{localized.url}}">{{localized.title}}</a>
         </h4>
-        {% include "./blog_authors.html" with blog_page=post.blog %}
+        {% include "./blog_authors.html" with blog_page=localized %}
       </div>
     {% endfor %}
   </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/take_action.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/take_action.html
@@ -9,18 +9,20 @@
       <div class="col-lg-8 col-md-12">
         <div class="row">
           {% for item in page.take_action_cards.all %}
+            {% with target=item.internal_link.localized %}
             <div class="col-md-6 d-flex">
               <div class="card flex-grow-1 mb-4">
-                  <a href="{{ item.internal_link.url }}">
+                  <a href="{{ target.url }}">
                     <img src="{% image_url item.image "fill-350x130" %}" class="card-img-top" alt="{{ img.alt }}" aria-label="{{ item.text }}">
                   </a>
                   <div class="card-body">
-                    <a href="{{ item.internal_link.url }}" class="h5-heading d-inline-block my-2">
+                    <a href="{{ target.url }}" class="h5-heading d-inline-block my-2">
                       {{ item.text }}
                     </a>
                   </div>
               </div>
             </div>
+            {% endwith %}
           {% endfor %}
         </div>
       </div>


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7034
Related PRs/issues https://github.com/mozilla/foundation.mozilla.org/issues/7066

This updates the template fragments used by the homepage, making sure to use the `.localized` property for any page that is a foreignkey/M2M/etc to another page in the CMS.

These updates are based on looking at both the `Homepage` class in `base.py` and identifying fields that are ForeignKey, or are properties defined through other models using a `related_name`, as well as by looking at each template file and looking for the use of `.url`, and updating everything to use the localized page for fields where it feels like that made sense.