### PR TITLE
restore query arguments if wagtail's redirect process strips them

### DIFF
--- a/network-api/networkapi/wagtailcustomization/redirects/middleware.py
+++ b/network-api/networkapi/wagtailcustomization/redirects/middleware.py
@@ -1,4 +1,6 @@
+from urllib.parse import urlencode
 from wagtail.contrib.redirects import middleware
+from wagtail.contrib.redirects.models import Redirect
 
 # We want to wrap the _get_redirect logic, so we need to cache the original.
 _original_get_redirect = middleware._get_redirect
@@ -11,10 +13,24 @@ def _new_get_redirect(request, path):
         locale_prefix = f'/{request.LANGUAGE_CODE}/'
         if path.startswith(locale_prefix):
             path = path.replace(locale_prefix, '/', 1)
-    if request.META['QUERY_STRING']:
-        path = path + f'/?{request.META["QUERY_STRING"]}'
+
     # Then hand off processing to the original redirect logic.
-    return _original_get_redirect(request, path)
+    redirect = _original_get_redirect(request, path)
+
+    # Wagtail currently does not forward query arguments, so for
+    # any URL with stripped query arguments we make a new, on-the-fly
+    # redirect with the same path/site bindings, but an updated link
+    # with the query arguments restored.
+    if redirect and request.GET:
+        target = redirect.link
+        if request.GET and "?" not in target:
+            redirect = Redirect(
+                old_path=redirect.old_path,
+                site=redirect.site,
+                redirect_link=f'{redirect.link}?{urlencode(request.GET)}'
+            )
+
+    return redirect
 
 
 # Then shim the redirect middleware...

--- a/network-api/networkapi/wagtailcustomization/redirects/middleware.py
+++ b/network-api/networkapi/wagtailcustomization/redirects/middleware.py
@@ -21,6 +21,8 @@ def _new_get_redirect(request, path):
     # any URL with stripped query arguments we make a new, on-the-fly
     # redirect with the same path/site bindings, but an updated link
     # with the query arguments restored.
+    #
+    # See https://github.com/wagtail/wagtail/issues/7339 for more details.
     if redirect and request.GET and "?" not in redirect.link:
         redirect = Redirect(
             old_path=redirect.old_path,

--- a/network-api/networkapi/wagtailcustomization/redirects/middleware.py
+++ b/network-api/networkapi/wagtailcustomization/redirects/middleware.py
@@ -23,7 +23,7 @@ def _new_get_redirect(request, path):
     # with the query arguments restored.
     if redirect and request.GET:
         target = redirect.link
-        if request.GET and "?" not in target:
+        if "?" not in target:
             redirect = Redirect(
                 old_path=redirect.old_path,
                 site=redirect.site,

--- a/network-api/networkapi/wagtailcustomization/redirects/middleware.py
+++ b/network-api/networkapi/wagtailcustomization/redirects/middleware.py
@@ -21,14 +21,12 @@ def _new_get_redirect(request, path):
     # any URL with stripped query arguments we make a new, on-the-fly
     # redirect with the same path/site bindings, but an updated link
     # with the query arguments restored.
-    if redirect and request.GET:
-        target = redirect.link
-        if "?" not in target:
-            redirect = Redirect(
-                old_path=redirect.old_path,
-                site=redirect.site,
-                redirect_link=f'{redirect.link}?{urlencode(request.GET)}'
-            )
+    if redirect and request.GET and "?" not in redirect.link:
+        redirect = Redirect(
+            old_path=redirect.old_path,
+            site=redirect.site,
+            redirect_link=f'{redirect.link}?{urlencode(request.GET)}'
+        )
 
     return redirect
 


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7072
Also See https://github.com/wagtail/wagtail/issues/7339

test urls:
- https://foundation-s-fix-redire-emlcd9.herokuapp.com/regrets?utm_campaign=youtuberegrets&utm_source=twitter&utm_medium=social&utm_content=1625741125
- https://foundation-s-fix-redire-emlcd9.herokuapp.com/campaigns/single-page/?subscribed=1&utm_source=email&utm_medium=email&utm_campaign=2020advocacy-fr&utm_content=appleidfathanks&utm_term=5382510