### PR TITLE
Localized links in Related products section

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
@@ -295,7 +295,7 @@
           <h3 class="h2-heading mb-4">{% trans "Related products" %}</h3>
           <div class="row">
             {% for related_product_page in product.related_product_pages.all %}
-            {% with related_product=related_product_page.related_product %}
+            {% with related_product=related_product_page.related_product.localized %}
             <div class="related-product col-6 col-md-3 mb-3 mb-md-0">
               <a class="d-block{% if related_product.adult_content %} adult-content{% endif %}" href="{{ related_product.url }}">
                 <div class="img-container">


### PR DESCRIPTION
Closes #7119 

**Link to sample test page**: tried to get one, but the review app apparently didn’t appreciate running `sync_locale_trees` 🤷‍♂️

Locally you should be able to test by creating a locale, syncing the locale trees, then checking any product in this locale

