### PR TITLE
6987 Customize Tailwind Spacing Units

### DIFF
--- a/network-api/networkapi/context_processor.py
+++ b/network-api/networkapi/context_processor.py
@@ -16,3 +16,8 @@ def canonical_path(request):
 
 def canonical_site_url(request):
     return {'CANONICAL_SITE_URL': request.scheme + '://' + request.get_host()}
+
+
+def env_debug(request):
+    debug_flag = settings.DEBUG
+    return{"debug_flag": debug_flag}

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -325,6 +325,7 @@ TEMPLATES = [
                 'networkapi.context_processor.review_app',
                 'networkapi.context_processor.canonical_path',
                 'networkapi.context_processor.canonical_site_url',
+                'networkapi.context_processor.env_debug',
             ])),
             'libraries': {
                 'bg_nav_tags': 'networkapi.wagtailpages.templatetags.bg_nav_tags',

--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -31,7 +31,9 @@
     {% block commento_meta %}{% endblock %}
 
     {% block stylesheets %}
+      {% if debug_flag %}<link rel="stylesheet" href="{% static "_css/tailwind.compiled.css" %}">{% endif %}
       <link rel="stylesheet" href="{% static "_css/main.compiled.css" %}">
+      
       <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Nunito+Sans:400,300,700,300i,800,900,400i">
       <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,400,600,700,300i,400i,600i">
     {% endblock %}

--- a/network-api/networkapi/templates/partials/footer.html
+++ b/network-api/networkapi/templates/partials/footer.html
@@ -1,16 +1,16 @@
 {% load settings_value i18n static %}
 
-{% with wrapper_class="tw-py-12" %}
+{% with wrapper_class="tw-py-7" %}
 
 <footer role="contentinfo">
   {% if skip_donate != True %}
     {% block footer_donate %}
       <div class="tw-bg-blue dark-theme print:tw-hidden {{wrapper_class}}">
-        <div class="tw-container tw-mt-6">
+        <div class="tw-container tw-mt-5">
           <div class="tw-row">
             <div class="tw-w-full tw-px-4">
               <p class="h3-heading tw-mb-0">{% trans "We all love the Web. Join Mozilla in defending it." %}</p>
-              <p class="h3-heading tw-mb-6">{% trans "Let’s protect the world’s largest resource for future generations." %}</p>
+              <p class="h3-heading tw-mb-5">{% trans "Let’s protect the world’s largest resource for future generations." %}</p>
               <div>
                 <a href="https://donate.mozilla.org/?utm_source=foundation.mozilla.org&utm_medium=referral&utm_campaign=fmonav&utm_content=footer" target="_blank" rel="noopener noreferrer" class="btn btn-secondary dark-theme" id="donate-banner-cta">{% trans "Donate now" %}</a>
               </div>
@@ -22,13 +22,13 @@
   {% endif %}
 
   <div class="site-footer tw-bg-black dark-theme {{wrapper_class}} print:tw-hidden">
-    <div class="tw-container tw-mt-6">
+    <div class="tw-container tw-mt-5">
       <div class="tw-row">
 
         {% block left_footer_column %}
         <div class="medium:tw-w-5/12 large:tw-w-6/12 tw-px-4 tw-flex tw-flex-col tw-justify-between">
           <div class="join-us" data-form-position="footer" data-button-position="side"></div>
-          <a class="logo tw-block tw-my-12 medium:tw-my-0" href="https://foundation.mozilla.org" aria-label="{% trans 'Return to Homepage' %}"><img src="{% static "_images/mozilla-block-white.svg" %}" alt="{% trans 'Mozilla Foundation' %}" width="96"></a>
+          <a class="logo tw-block tw-my-7 medium:tw-my-0" href="https://foundation.mozilla.org" aria-label="{% trans 'Return to Homepage' %}"><img src="{% static "_images/mozilla-block-white.svg" %}" alt="{% trans 'Mozilla Foundation' %}" width="96"></a>
         </div>
         {% endblock %}
 
@@ -62,7 +62,7 @@
           </div>
           {% if exclude_language_switcher != True %}
           {% block language_switcher %}
-          <div class="tw-row tw-mt-12">
+          <div class="tw-row tw-mt-7">
             <div class="tw-w-full tw-px-4">
               {% include "../fragments/language_switcher.html" %}
             </div>
@@ -71,7 +71,7 @@
           {% endif %}
           <div class="tw-row">
             <div class="tw-w-full tw-px-4">
-              <hr class="tw-mt-12 tw-mb-4" />
+              <hr class="tw-mt-7 tw-mb-4" />
               <p class="dark-theme body-small tw-mb-0">
                 {% blocktrans with foundation_website_url='https://foundation.mozilla.org' foundation_website='foundation.mozilla.org' cc_website_url='https://foundation.mozilla.org/about/website-licensing/' %}Mozilla is a global non-profit dedicated to putting you in control of your online experience and shaping the future of the web for the public good. Visit us at <a href="{{foundation_website_url}}">{{foundation_website}}</a>. Most content available under a <a href="{{cc_website_url}}">Creative Commons license</a>.{% endblocktrans %}
               </p>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/campaign_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/campaign_page.html
@@ -11,7 +11,7 @@
 <div class="tw-container">
   <div class="tw-row">
     <div class="
-      {% block content_wrapper_class %}tw-py-6 medium:tw-py-12{% endblock %}
+      {% block content_wrapper_class %}tw-py-5 medium:tw-py-7{% endblock %}
       {% if page.specific.narrowed_page_content %}
         tw-w-8/12 tw-mx-auto tw-px-4
       {% else %}
@@ -40,7 +40,7 @@
             </h1>
           {% endblock %}
           {% block campaign_page_menu %}
-            <div class="tw-mb-6 tw-hidden medium:tw-block">
+            <div class="tw-mb-5 tw-hidden medium:tw-block">
             {% mini_site_horizontal_nav page %}
             </div>
           {% endblock %}
@@ -75,7 +75,7 @@
             <div class="narrow-sticky-button-container hidden">
               <a href="#cta-anchor" class="btn btn-primary tw-block">{% trans "TAKE ACTION" context "Sticky button in mobile view on campaign pages" %}</a>
             </div>
-            <div class="tw-sticky tw-top-20 tw-overflow-hidden tw-z-[1018]">
+            <div class="tw-sticky tw-top-[5rem] tw-overflow-hidden tw-z-[1018]">
               <div id="cta-anchor" class="tw-mt-[-80px] tw-pt-[80px]">
                 {% cta page %}
               </div>
@@ -91,7 +91,7 @@
             {% elif page.signup and page.specific.narrowed_page_content == False %}
               tw-w-7/12 tw-px-4
             {% else %}
-              tw-w-12 tw-px-4
+              tw-w-full tw-px-4
             {% endif %}"
           >
           </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/styleguide_color_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/styleguide_color_block.html
@@ -1,6 +1,6 @@
 <div class="tw-w-full small:tw-w-1/2 medium:tw-w-1/4 tw-mb-4 tw-px-4">
   <div class="tw-border tw-border-gray-20 tw-flex tw-flex-col tw-h-full">
-    <div class="tw-border-b tw-border-gray-20 tw-w-full tw-px-2 tw-py-12 {{classname}}"></div>
+    <div class="tw-border-b tw-border-gray-20 tw-w-full tw-px-2 tw-py-7 {{classname}}"></div>
     <div class="tw-p-2"><strong>{{name}}</strong>
       <div class="tw-text-gray-60 tw-font-normal tw-text-[80%]">{{hex}}</div>
     </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/static/styleguide.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/static/styleguide.html
@@ -4,13 +4,13 @@
 {% block body_id %}style-guide{% endblock %}
 
 {% block content %}
-<div class="tw-container tw-mt-6">
+<div class="tw-container tw-mt-7">
   <div class="tw-row">
-    <div class="tw-w-full tw-px-4 tw-pb-12">
+    <div class="tw-w-full tw-px-4 tw-pb-7">
       <h2 class="h1-heading">Colors</h2>
       <hr class="hr-emphasis">
 
-      <h3 class="h2-heading tw-mt-12">Site-wide Palette</h3>
+      <h3 class="h2-heading tw-mt-7">Site-wide Palette</h3>
       <hr />
 
       <div class="tw-row">
@@ -47,7 +47,7 @@
         {% include "../fragments/styleguide_color_block.html" with classname="tw-bg-blue-dark" name="Dark Blue ($dark-blue)" hex="#0d10bf" %}
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Privacy Not Included Palette</h3>
+      <h3 class="h2-heading tw-mt-7">Privacy Not Included Palette</h3>
       <hr />
 
       <div class="tw-row">
@@ -66,7 +66,7 @@
         {% include "../fragments/styleguide_color_block.html" with classname="tw-bg-gradient-to-r tw-from-pni-blue tw-to-pni-pink" name="PNI Gradient ($pni-gradient)" hex="linear-gradient(to right, #1808f2 0%, #e4487d 100%)" %}
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Festival Palette</h3>
+      <h3 class="h2-heading tw-mt-7">Festival Palette</h3>
       <hr />
 
       <div class="tw-row">
@@ -78,10 +78,10 @@
       </div>
 
 
-      <h2 class="h1-heading tw-mt-12">Grid</h2>
+      <h2 class="h1-heading tw-mt-7">Grid</h2>
       <hr class="hr-emphasis">
 
-      <h3 class="h2-heading tw-mt-12">Breakpoints</h3>
+      <h3 class="h2-heading tw-mt-7">Breakpoints</h3>
       <hr />
       <div class="tw-row">
         <div class="tw-w-full tw-px-4">
@@ -113,20 +113,20 @@
                 <td class="tw-p-3 tw-border tw-border-table">960px</td>
                 <td class="tw-p-3 tw-border tw-border-table">1140px</td>
               </tr>
-              <tr class="tw-bg-black tw-bg-opacity-5">
+              <tr4 class="tw-bg-black tw-bg-opacity-5">
                 <th class="tw-whitespace-nowrap tw-p-3 tw-border tw-border-table" scope="row">Design alias</th>
                 <td class="tw-p-3 tw-border tw-border-table"><code>mobile (potrait)</code></td>
                 <td class="tw-p-3 tw-border tw-border-table"><code>mobile (landscape)</code></td>
                 <td class="tw-p-3 tw-border tw-border-table"><code>tablet</code></td>
                 <td class="tw-p-3 tw-border tw-border-table"><code>desktop</code></td>
                 <td class="tw-p-3 tw-border tw-border-table"><code>wide desktop</code></td>
-              </tr>
+              </tr4
             </tbody>
           </table>
         </div>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Columns</h3>
+      <h3 class="h2-heading tw-mt-7">Columns</h3>
       <hr />
 
       <div class="tw-row dark-theme">
@@ -203,10 +203,10 @@
       <hr />
 
 
-      <h2 class="h1-heading tw-mt-12">Typography</h2>
+      <h2 class="h1-heading tw-mt-7">Typography</h2>
       <hr class="hr-emphasis">
 
-      <h3 class="h2-heading tw-mt-12">Headers</h3>
+      <h3 class="h2-heading tw-mt-7">Headers</h3>
       <hr />
       <div class="tw-py-2">
         <h1 class="h1-heading">.h1-heading</h1>
@@ -227,7 +227,7 @@
         <h6 class="h6-heading">.h6-heading</h6>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Headers with links</h3>
+      <h3 class="h2-heading tw-mt-7">Headers with links</h3>
       <hr />
       <div class="tw-py-2">
         <h1 class="h1-heading">.h1-heading with <a href="">link</a></h1>
@@ -248,7 +248,7 @@
         <h6 class="h6-heading">.h6-heading with <a href="">link</a></h6>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Paragraphs</h3>
+      <h3 class="h2-heading tw-mt-7">Paragraphs</h3>
       <hr />
       <div class="tw-py-2">
         <p class="body-large">.body-large with <b>bold</b> and <strong>strong</strong> and <i>italic</i> text</p>
@@ -266,7 +266,7 @@
         <h2 class="type-accent">.type-accent</h2>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Paragraphs with links</h3>
+      <h3 class="h2-heading tw-mt-7">Paragraphs with links</h3>
       <hr />
       <div class="tw-py-2">
         <p class="body-large">.body-large with <a href="">link</a></p>
@@ -278,7 +278,7 @@
         <p class="body-small">.body-small with <a href="">link</a></p>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Lists</h3>
+      <h3 class="h2-heading tw-mt-7">Lists</h3>
       <hr />
       <div class="tw-py-2">
         <h4>Default <xmp class="tw-inline"><ol></xmp> style</h4>
@@ -295,11 +295,11 @@
         </ul>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Anchors</h3>
+      <h3 class="h2-heading tw-mt-7">Anchors</h3>
       <hr />
       <div class="tw-py-2"><a class="cta-link" href="https://example.com">.cta-link</a></div>
 
-      <h3 class="h2-heading tw-mt-12">Dark Theme Headers</h3>
+      <h3 class="h2-heading tw-mt-7">Dark Theme Headers</h3>
       <hr />
       <div class="dark-theme tw-bg-black">
         <div class="tw-py-2">
@@ -321,7 +321,7 @@
           <h6 class="h6-heading">.h6-heading</h6>
         </div>
       </div>
-      <h3 class="h2-heading tw-mt-12">Dark Theme Headers with links</h3>
+      <h3 class="h2-heading tw-mt-7">Dark Theme Headers with links</h3>
       <hr />
       <div class="dark-theme tw-bg-black">
         <div class="tw-py-2">
@@ -344,7 +344,7 @@
         </div>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Dark Theme Paragraphs</h3>
+      <h3 class="h2-heading tw-mt-7">Dark Theme Paragraphs</h3>
       <hr />
       <div class="dark-theme tw-bg-black">
         <div class="tw-py-2">
@@ -365,7 +365,7 @@
 
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Dark Theme Paragraphs with links</h3>
+      <h3 class="h2-heading tw-mt-7">Dark Theme Paragraphs with links</h3>
       <hr />
       <div class="dark-theme tw-bg-black">
         <div class="tw-py-2">
@@ -379,7 +379,7 @@
         </div>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Dark Theme Lists</h3>
+      <h3 class="h2-heading tw-mt-7">Dark Theme Lists</h3>
       <hr />
       <div class="dark-theme tw-bg-black">
         <div class="tw-py-2">
@@ -398,7 +398,7 @@
         </div>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Dark Theme Anchors</h3>
+      <h3 class="h2-heading tw-mt-7">Dark Theme Anchors</h3>
       <hr />
       <div class="dark-theme tw-bg-black">
         <a class="cta-link" href="">.cta-link</a>
@@ -407,13 +407,13 @@
         <a href="">link</a>
       </div>
 
-      <h2 class="h1-heading tw-mt-12">Buttons</h2>
+      <h2 class="h1-heading tw-mt-7">Buttons</h2>
       <hr class="hr-emphasis">
 
-      <h3 class="h2-heading tw-mt-12">Default</h3>
+      <h3 class="h2-heading tw-mt-7">Default</h3>
       <hr />
 
-      <div class="tw-mb-12">
+      <div class="tw-mb-7">
         <div class="tw-my-2">
           <button class="btn btn-primary">.btn-primary on <xmp class="tw-inline"><button></xmp></button>
           <button class="btn btn-primary" disabled>disabled .btn-primary on <xmp class="tw-inline"><button></xmp></button>
@@ -424,7 +424,7 @@
         </div>
       </div>
 
-      <div class="tw-mb-12">
+      <div class="tw-mb-7">
         <div class="tw-my-2">
           <button class="btn btn-secondary">.btn-secondary on <xmp class="tw-inline"><button></xmp></button>
           <button class="btn btn-secondary" disabled>disabled .btn-secondary on <xmp class="tw-inline"><button></xmp></button>
@@ -450,11 +450,11 @@
         </div>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Dark Theme</h3>
+      <h3 class="h2-heading tw-mt-7">Dark Theme</h3>
       <hr />
 
       <div class="tw-p-4 dark-theme tw-bg-black">
-        <div class="tw-mb-12">
+        <div class="tw-mb-7">
           <div class="tw-my-2">
             <button class="btn btn-primary">.btn-primary on <xmp class="tw-inline"><button></xmp></button>
             <button class="btn btn-primary" disabled>disabled .btn-primary on <xmp class="tw-inline"><button></xmp></button>
@@ -465,7 +465,7 @@
           </div>
         </div>
 
-        <div class="tw-mb-12">
+        <div class="tw-mb-7">
           <div class="tw-my-2">
             <button class="btn btn-secondary">.btn-secondary on <xmp class="tw-inline"><button></xmp></button>
             <button class="btn btn-secondary" disabled>disabled .btn-secondary on <xmp class="tw-inline"><button></xmp></button>
@@ -492,45 +492,45 @@
         </div>
       </div>
 
-      <h2 class="h1-heading tw-mt-12">Share Button Group</h2>
+      <h2 class="h1-heading tw-mt-7">Share Button Group</h2>
       <hr class="hr-emphasis">
 
-      <h3 class="h2-heading tw-mt-12">Full version</h3>
+      <h3 class="h2-heading tw-mt-7">Full version</h3>
       <hr>
 
-      <div class="tw-mb-12">
+      <div class="tw-mb-7">
         <div class="share-button-group-wrapper"></div>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Full Version & Stacked</h3>
+      <h3 class="h2-heading tw-mt-7">Full Version & Stacked</h3>
       <hr>
 
-      <div class="tw-mb-12">
+      <div class="tw-mb-7">
         <div class="share-button-group-wrapper" data-layout="stacked"></div>
       </div>
 
 
-      <h3 class="h2-heading tw-mt-12">Mini Version</h3>
+      <h3 class="h2-heading tw-mt-7">Mini Version</h3>
       <hr>
 
-      <div class="tw-mb-12">
+      <div class="tw-mb-7">
         <div class="share-button-group-wrapper" data-version="mini"></div>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Mini Version & Stacked</h3>
+      <h3 class="h2-heading tw-mt-7">Mini Version & Stacked</h3>
       <hr>
 
-      <div class="tw-mb-12">
+      <div class="tw-mb-7">
         <div class="share-button-group-wrapper" data-version="mini" data-layout="stacked"></div>
       </div>
 
-      <h2 class="h1-heading tw-mt-12">Dropdown Field</h2>
+      <h2 class="h1-heading tw-mt-7">Dropdown Field</h2>
       <hr class="hr-emphasis">
 
-      <h3 class="h2-heading tw-mt-12">Default</h3>
+      <h3 class="h2-heading tw-mt-7">Default</h3>
       <hr>
 
-      <div class="tw-mb-12">
+      <div class="tw-mb-7">
         <h4>Regular</h4>
         <select class="form-control">
           <option value="">Option 1</option>
@@ -540,7 +540,7 @@
         </select>
       </div>
 
-      <div class="tw-mb-12">
+      <div class="tw-mb-7">
         <h4>Large</h4>
         <select class="form-control form-control-lg">
           <option value="">Option 1</option>
@@ -550,11 +550,11 @@
         </select>
       </div>
 
-      <h3 class="h2-heading tw-mt-12">Dark Theme</h3>
+      <h3 class="h2-heading tw-mt-7">Dark Theme</h3>
       <hr>
 
       <div class="tw-p-4 dark-theme tw-bg-black">
-        <div class="tw-mb-12">
+        <div class="tw-mb-7">
           <h4>Regular</h4>
           <select class="form-control">
             <option value="">Option 1</option>

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "server": "python network-api/manage.py runserver 0.0.0.0:8000",
     "server:silent": "python network-api/manage.py runserver 0.0.0.0:8000 >> server.log 2>&1",
     "start": "docker-compose up",
-    "sync": "browser-sync start --proxy \"localhost:8000\" --reload-debounce 2000 --files \"./network-api/networkapi/**/*.html\" \"./network-api/networkapi/frontend/_css/*.css\" ",
+    "sync": "browser-sync start --proxy \"localhost:8000\" --reload-debounce 50 --files \"./network-api/networkapi/**/*.html\" \"./network-api/networkapi/frontend/_css/*.css\"",
+    "tailwind": "run-p tailwind:watch sync",
+    "tailwind:watch": "tailwindcss -i source/postcss/tailwind.css -o network-api/networkapi/frontend/_css/tailwind.compiled.css -w",
     "test:procfile": "node test/test-procfile.js",
     "test:eslint:js:pre": "prettier \"cypress/integration/*.js\" \"source/js/**/*.js\" \"source/js/**/*.jsx\" \"network-api/networkapi/wagtailcustomization/**/*.js\" ./*.js --write",
     "test:eslint:js": "eslint --config ./.eslintrc.json \"cypress/integration/*.js\" \"source/js/**/*.js\" \"source/js/**/*.jsx\" \"network-api/networkapi/wagtailcustomization/**/*.js\" ./*.js",
@@ -59,9 +61,7 @@
     "test": "run-s test:** build",
     "watch": "wait-on http://backend:8000/cms && run-s build:clean && run-p build:js:dev build:common watch:**",
     "watch:images": "chokidar \"source/images/**/*\" -c \"npm run build:images\"",
-    "watch:sass": "chokidar \"source/**/*.scss\" -c \"npm run build:sass\"",
-    "watch:html": "chokidar \"network-api/networkapi/**/*.html\" -c \"npm run build:sass\"",
-    "watch:tailwind": "chokidar \"tailwind.config.js\" -c \"npm run build:sass\""
+    "watch:sass": "chokidar \"source/**/*.scss\" -c \"npm run build:sass\""
   },
   "browserslist": [
     "> 1%",

--- a/source/postcss/tailwind.css
+++ b/source/postcss/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/source/sass/global.scss
+++ b/source/sass/global.scss
@@ -30,7 +30,7 @@ hr {
 }
 
 .hr-emphasis {
-  @apply tw-bg-black tw-border-0 tw-h-1 tw-mx-0 tw-my-8;
+  @apply tw-bg-black tw-border-0 tw-h-1 tw-mx-0 tw-my-6;
 }
 
 #hero {

--- a/source/sass/views/style-guide.scss
+++ b/source/sass/views/style-guide.scss
@@ -1,21 +1,3 @@
-.color-display {
-  border: 1px solid $gray-20;
-}
-
-.color-block {
-  border-bottom: 1px solid $gray-20;
-
-  @each $name, $value in map-merge($colors, $pni-colors) {
-    &.#{$name} {
-      background: $value;
-    }
-  }
-}
-
-.color-code {
-  color: $gray-60;
-}
-
 .form-control-lg {
   height: auto;
 }

--- a/tailwind.components.js
+++ b/tailwind.components.js
@@ -1,0 +1,54 @@
+const plugin = require("tailwindcss/plugin");
+module.exports = [
+  plugin(function ({ addComponents }) {
+    // Using Same breakpoints for containers as bootstrap
+    addComponents([
+      {
+        "@media (min-width: 576px)": {
+          ".container": {
+            maxWidth: "540px",
+          },
+        },
+      },
+      {
+        "@media (min-width: 768px)": {
+          ".container": {
+            maxWidth: "720px",
+          },
+        },
+      },
+      {
+        "@media (min-width: 992px)": {
+          ".container": {
+            maxWidth: "960px",
+          },
+        },
+      },
+      {
+        "@media (min-width: 1200px)": {
+          ".container": {
+            maxWidth: "1140px",
+          },
+        },
+      },
+      {
+        ".container": {
+          width: "100%",
+          paddingRight: "1rem",
+          paddingLeft: "1rem",
+          marginRight: "auto",
+          marginLeft: "auto",
+        },
+      },
+      // Adding rows to Tailwind CSS
+      {
+        ".row": {
+          display: "flex",
+          flexWrap: "wrap",
+          marginRight: "-1rem",
+          marginLeft: "-1rem",
+        },
+      },
+    ]);
+  }),
+];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,7 @@
+/* eslint-disable prettier/prettier */
 const colors = require("tailwindcss/colors");
 const plugin = require("tailwindcss/plugin");
+const componentPlugins = require("./tailwind.components");
 
 module.exports = {
   purge: ["./source/js/**/*.{js,jsx}", "./network-api/networkapi/**/*.html"],
@@ -8,7 +10,7 @@ module.exports = {
   important: true,
   corePlugins: {
     // overriding TW default container
-    container: false,
+    container: false
   },
   plugins: [
     plugin(function ({ addUtilities }) {
@@ -26,55 +28,7 @@ module.exports = {
       };
       addUtilities(newUtilities);
     }),
-    plugin(function ({ addComponents }) {
-      addComponents([
-        {
-          "@media (min-width: 576px)": {
-            ".container": {
-              maxWidth: "540px",
-            },
-          },
-        },
-        {
-          "@media (min-width: 768px)": {
-            ".container": {
-              maxWidth: "720px",
-            },
-          },
-        },
-        {
-          "@media (min-width: 992px)": {
-            ".container": {
-              maxWidth: "960px",
-            },
-          },
-        },
-        {
-          "@media (min-width: 1200px)": {
-            ".container": {
-              maxWidth: "1140px",
-            },
-          },
-        },
-        {
-          ".container": {
-            width: "100%",
-            paddingRight: "1rem",
-            paddingLeft: "1rem",
-            marginRight: "auto",
-            marginLeft: "auto",
-          },
-        },
-        {
-          ".row": {
-            display: "flex",
-            flexWrap: "wrap",
-            marginRight: "-1rem",
-            marginLeft: "-1rem",
-          },
-        },
-      ]);
-    }),
+    ...componentPlugins,
   ],
   theme: {
     extend: {
@@ -84,6 +38,18 @@ module.exports = {
       screens: {
         print: { raw: "print" },
       },
+    },
+    // Overriding default spacing
+    spacing: {
+      0: "0",
+      px: "1px",
+      1: "0.25rem",
+      2: "0.5rem",
+      3: "0.75rem",
+      4: "1rem",
+      5: "1.5rem",
+      6: "2rem",
+      7: "3rem",
     },
     // Renaming breakpoints temporary until we remove bootstrap usage
     screens: {


### PR DESCRIPTION
Redoing spacing units based on Figma design system, should be reviewed before people try to use tailwind for other tickets not related to the Tailwind Epic!

Also rebuilt the dev-environment for reloading HTML/tailwind changes.

On a separate terminal from the docker one, run `npm run tailwind` and trying changing the html files and their classes.
Changes should appear on `localhost:3000`

Old Default Spacing:
https://tailwindcss.com/docs/customizing-spacing

New Spacing: 
```
    spacing: {
      0: "0",
      px: "1px",
      1: "0.25rem",
      2: "0.5rem",
      3: "0.75rem",
      4: "1rem",
      5: "1.5rem",
      6: "2rem",
      7: "3rem",
    },
```