### PR TITLE
updated publication template links

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/fragments/publication_table_of_contents.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/publication_table_of_contents.html
@@ -36,7 +36,13 @@
               </div>
               <div class="col-8 ml-sm-3{% if not child.get_children_count %} d-flex align-items-center{% endif %}">
                 <h3 class="{% if child.get_children_count %}publication-chapter-title mb-4 {{% else %}m-0 {% endif %}">
+                  {% if not child.get_children_count %}
+                  <a href="{{ child.url }}" class="d-block {% if child.get_children_count %}mb-4{% endif %}">
                     {{ child.title }} {% if child.has_unpublished_changes %}🐣{% endif %}
+                  </a>
+                  {% else %}
+                    {{ child.title }} {% if child.has_unpublished_changes %}🐣{% endif %}
+                  {% endif %}
                 </h3>
                 {% for grandchild in child_page.grandchildren %}
                   <h4 class="d-sm-block d-none body">


### PR DESCRIPTION
Closes bug caused by #7161 where links to publication pages without any child pages would not render a link. 

What this fix does is check if the page has any child pages, if it does not, render a link to the single page. 
If the publication page has child pages, then only render links to the child pages like requested. 


**Link to sample test page**:
Publication with child article pages: https://foundation-s-fix-public-6gm86f.herokuapp.com/en/publication-page-with-child-article-pages/
Publication with chapter pages: https://foundation-s-fix-public-6gm86f.herokuapp.com/en/publication-page-with-chapter-pages/


## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible]

