### PR TITLE
Restore product filtering per language

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -77,7 +77,10 @@ def get_product_subset(cutoff_date, authenticated, key, products, language_code=
     to the system or not (authenticated users get to
     see all products, including draft products)
     """
-    products = products.filter(review_date__gte=cutoff_date)
+    products = products.filter(
+        review_date__gte=cutoff_date,
+        locale=Locale.objects.get(language_code=language_code)
+    )
     if not authenticated:
         products = products.live()
     products = sort_average(products)


### PR DESCRIPTION
Didn’t realize this filtering got removed from #7183, we actually need it to avoid showing each product 8 times on home/category pages: https://foundation-localize.herokuapp.com/en/privacynotincluded/categories/dating-apps/
(Not linking home, because requesting each product 8 times is making the app time out)