### PR TITLE
Moved consts inside of functions to prevent runtime/migration conflicts

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/mixin/snippets.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/mixin/snippets.py
@@ -1,8 +1,6 @@
 from django.conf import settings
 from wagtail.core.models import Locale
 
-DEFAULT_LOCALE = Locale.objects.get(language_code=settings.LANGUAGE_CODE)
-
 
 class LocalizedSnippet():
     def __init__(self, *args, **kwargs):
@@ -10,8 +8,9 @@ class LocalizedSnippet():
 
     @property
     def original(self):
+        DEFAULT_LOCALE = Locale.objects.get(language_code=settings.LANGUAGE_CODE)
+
         try:
             return self.get_translation(DEFAULT_LOCALE)
         except AttributeError:
             return self
-

--- a/network-api/networkapi/wagtailpages/pagemodels/mixin/snippets.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/mixin/snippets.py
@@ -3,12 +3,17 @@ from wagtail.core.models import Locale
 
 
 class LocalizedSnippet():
+
+    DEFAULT_LOCALE = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if self.DEFAULT_LOCALE is None:
+            self.DEFAULT_LOCALE = Locale.objects.get(language_code=settings.LANGUAGE_CODE)
 
     @property
     def original(self):
-        DEFAULT_LOCALE = Locale.objects.get(language_code=settings.LANGUAGE_CODE)
+        DEFAULT_LOCALE = Locale.objects.get(language_code=self.DEFAULT_LOCALE)
 
         try:
             return self.get_translation(DEFAULT_LOCALE)

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -43,16 +43,13 @@ TRACK_RECORD_CHOICES = [
     ('Needs Improvement', 'Needs Improvement'),
     ('Bad', 'Bad')
 ]
-DEFAULT_LANGUAGE_CODE = settings.LANGUAGE_CODE
-DEFAULT_LOCALE = Locale.objects.get(language_code=DEFAULT_LANGUAGE_CODE)
-DEFAULT_LOCALE_ID = DEFAULT_LOCALE.id
 
 
 def get_language_code_from_request(request):
     """
     Accepts a request. Returns a language code (string) if there is one. Falls back to English.
     """
-    language_code = DEFAULT_LANGUAGE_CODE
+    language_code = settings.LANGUAGE_CODE
     if hasattr(request, 'LANGUAGE_CODE'):
         language_code = request.LANGUAGE_CODE
     return language_code
@@ -64,6 +61,9 @@ def get_categories_for_locale(language_code):
     with their localized counterpart, where possible, so that we don't
     end up with an incomplete category list due to missing locale records.
     """
+    DEFAULT_LANGUAGE_CODE = settings.LANGUAGE_CODE
+    DEFAULT_LOCALE = Locale.objects.get(language_code=DEFAULT_LANGUAGE_CODE)
+
     default_locale_list = BuyersGuideProductCategory.objects.filter(
         hidden=False,
         locale=DEFAULT_LOCALE,
@@ -1489,6 +1489,9 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         language_code = get_language_code_from_request(request)
         locale_id = Locale.objects.get(language_code=language_code).id
         slug = slugify(slug)
+
+        DEFAULT_LOCALE = Locale.objects.get(language_code=settings.LANGUAGE_CODE)
+        DEFAULT_LOCALE_ID = DEFAULT_LOCALE.id
 
         # because we may be working with localized content, and the slug
         # will always be our english slug, we need to find the english


### PR DESCRIPTION
This introduces some not-so-DRY code, but it's minimal and thought this would be OK considering our timeframe today. 

Kept the consts as local consts in each function too keep this PR as small as possible. 