### PR TITLE
updated border to render mobile buttons correctly

### DIFF
--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -258,7 +258,7 @@
           display: inline-block;
           margin: 10px 0;
           padding-bottom: 0;
-          border-width: 3px;
+          border-width: 0px 0px 3px 0px;
           color: $white;
 
           @include hover-focus-active {


### PR DESCRIPTION
Closes #7195 


**Link to sample test page**: https://foundation-s-7195-mobil-wqnmrs.herokuapp.com/en/

**Steps to test**:

1. Visit https://foundation-s-7195-mobil-wqnmrs.herokuapp.com/en/
2. Resize the window to mobile width
3. Click the menu icon in the top left of the page
4. The links that then appear underneath, should have a white border on the bottom if active or hovered over. The rest of them should just be white text.
<img width="376" alt="Screen Shot 2021-08-16 at 12 03 30 PM" src="https://user-images.githubusercontent.com/18314510/129616225-7465ca02-29fd-482f-91c8-9d0f807e9e7c.png">

5. If the links appear correctly, testing is done! 


## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/master/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations)
