### PR TITLE
make sure we select a single blog index page by specifying locale

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/recent_blog_entries.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/recent_blog_entries.py
@@ -1,8 +1,12 @@
 from django.apps import apps
+from django.conf import settings
+from django.template.defaultfilters import slugify
+
 from wagtail.core import blocks
+from wagtail.core.models import Locale
 
 from ..blog.blog_category import BlogPageCategory
-from django.template.defaultfilters import slugify
+from networkapi.wagtailpages.utils import get_locale_from_request
 
 
 class RecentBlogEntries(blocks.StructBlock):
@@ -39,8 +43,10 @@ class RecentBlogEntries(blocks.StructBlock):
 
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
+
         BlogIndexPage = apps.get_model('wagtailpages.BlogIndexPage')
-        blogpage = BlogIndexPage.objects.get(title__iexact="blog")
+        locale = get_locale_from_request(context['request'])
+        blog_page = BlogIndexPage.objects.get(title__iexact="blog", locale=locale)
 
         tag = value.get("tag_filter", False)
         category = value.get("category_filter", False)
@@ -54,8 +60,8 @@ class RecentBlogEntries(blocks.StructBlock):
         if tag and not category:
             tag = slugify(tag)
             query = tag
-            blogpage.extract_tag_information(tag)
-            entries = blogpage.get_entries(context)
+            blog_page.extract_tag_information(tag)
+            entries = blog_page.get_entries(context)
 
         '''
         If category_filter is chosen at all, we want to load entries by category and
@@ -69,16 +75,16 @@ class RecentBlogEntries(blocks.StructBlock):
             try:
                 # verify this category exists, and set up a filter for it
                 category_object = BlogPageCategory.objects.get(name=category)
-                blogpage.extract_category_information(category_object.slug)
+                blog_page.extract_category_information(category_object.slug)
             except BlogPageCategory.DoesNotExist:
                 # do nothing
                 pass
 
         # get the entries based on prefiltering
-        entries = blogpage.get_entries(context)
+        entries = blog_page.get_entries(context)
 
         # Updates the href for the 'More from our blog' button
-        url = f"/{blogpage.slug}/{type}/{query}"
+        url = f"/{blog_page.slug}/{type}/{query}"
         context['more_entries_link'] = url
 
         # We only want to grab no more than the first 6 entries

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/recent_blog_entries.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/recent_blog_entries.py
@@ -1,9 +1,7 @@
 from django.apps import apps
-from django.conf import settings
 from django.template.defaultfilters import slugify
 
 from wagtail.core import blocks
-from wagtail.core.models import Locale
 
 from ..blog.blog_category import BlogPageCategory
 from networkapi.wagtailpages.utils import get_locale_from_request

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -36,6 +36,7 @@ from networkapi.wagtailpages.utils import insert_panels_after
 # TODO: Move this util function
 from networkapi.buyersguide.utils import get_category_og_image_upload_path
 from .mixin.snippets import LocalizedSnippet
+from networkapi.wagtailpages.utils import get_language_from_request
 
 TRACK_RECORD_CHOICES = [
     ('Great', 'Great'),
@@ -43,16 +44,6 @@ TRACK_RECORD_CHOICES = [
     ('Needs Improvement', 'Needs Improvement'),
     ('Bad', 'Bad')
 ]
-
-
-def get_language_code_from_request(request):
-    """
-    Accepts a request. Returns a language code (string) if there is one. Falls back to English.
-    """
-    language_code = settings.LANGUAGE_CODE
-    if hasattr(request, 'LANGUAGE_CODE'):
-        language_code = request.LANGUAGE_CODE
-    return language_code
 
 
 def get_categories_for_locale(language_code):
@@ -843,7 +834,7 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
         context['product'] = self
-        language_code = get_language_code_from_request(request)
+        language_code = get_language_from_request(request)
         context['categories'] = get_categories_for_locale(language_code)
         context['mediaUrl'] = settings.MEDIA_URL
         context['use_commento'] = settings.USE_COMMENTO
@@ -1494,7 +1485,7 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
     @route(r'^categories/(?P<slug>[\w\W]+)/', name='category-view')
     def categories_page(self, request, slug):
         context = self.get_context(request, bypass_products=True)
-        language_code = get_language_code_from_request(request)
+        language_code = get_language_from_request(request)
         locale_id = Locale.objects.get(language_code=language_code).id
         slug = slugify(slug)
 
@@ -1577,7 +1568,7 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
-        language_code = get_language_code_from_request(request)
+        language_code = get_language_from_request(request)
 
         authenticated = request.user.is_authenticated
         key = 'home_product_dicts_authed' if authenticated else 'home_product_dicts_live'

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -265,7 +265,7 @@ def language_code_to_iso_3166(language):
 
 
 def get_locale_from_request(request, check_path=False):
-    language_code = get_language_from_request(request, check_path);
+    language_code = get_language_from_request(request, check_path)
 
     try:
         return Locale.objects.get(language_code=language_code)

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -27,7 +27,7 @@ from django.utils.translation.trans_real import (
 from sentry_sdk import capture_exception
 
 from wagtail.images.models import Image
-from wagtail.core.models import Collection
+from wagtail.core.models import Collection, Locale
 
 
 def titlecase(s):
@@ -262,6 +262,15 @@ def language_code_to_iso_3166(language):
     if country:
         return language + '-' + country.upper()
     return language
+
+
+def get_locale_from_request(request, check_path=False):
+    language_code = get_language_from_request(request, check_path);
+
+    try:
+        return Locale.objects.get(language_code=language_code)
+    except Locale.DoesNotExist:
+        return Locale.objects.get(language_code=settings.language_code)
 
 
 def get_language_from_request(request, check_path=False):


### PR DESCRIPTION
```
<marcwalsh> Hello, Solana and I are both getting a 500 error when visiting https://www.mozillafestival.org/en/newsletter/ however the homepage loads without issue.
```

This was caused by selecting the Blog index without a locale, so it was getting eight results instead of one result, making `.get` crash out. 

STR: grab a copy of prod or staging, make sure to set the site settings back to `localhost` on port `8000` for foundation and `mozfest.localhost` on port 8000 for mozfest (probably restart to make those settings stick since they're network bindings, which don't like updating on the fly) and then try the http://mozfest.localhost:8000/en/newsletter/ url. It should now work, even if you change locale codes in that URL or switch languages in the lang picker in the page footer.