### PR TITLE
fix the relocalized-url tag, and update some more templates to use it

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -31,7 +31,7 @@ from networkapi.wagtailpages.fields import ExtendedBoolean, ExtendedYesNoField
 from networkapi.wagtailpages.pagemodels.mixin.foundation_metadata import (
     FoundationMetadataPageMixin
 )
-from networkapi.wagtailpages.templatetags.localization import relocalized_url
+from networkapi.wagtailpages.templatetags.localization import relocalize_url
 from networkapi.wagtailpages.utils import insert_panels_after, get_locale_from_request
 
 # TODO: Move this util function
@@ -1482,7 +1482,7 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         # If no product is found, redirect to the BuyersGuide page
         locale = get_locale_from_request(request)
         product = get_object_or_404(ProductPage, slug=slug, locale=locale)
-        url = relocalized_url(product.url, locale.language_code)
+        url = relocalize_url(product.url, locale.language_code)
         return redirect(url)
 
     @route(r'^categories/(?P<slug>[\w\W]+)/', name='category-view')

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/bg_base.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/bg_base.html
@@ -85,15 +85,15 @@
       <div class="row">
         <div class="col">
           {% if pagetype == "product" or pagetype == "about" %}
-            <a class="multipage-link active" href="{% relocalized_url home_page.localized.url lang_code %}">{% trans "All" %}</a>
+            <a class="multipage-link active" href="{% relocalized_url home_page.localized.url %}">{% trans "All" %}</a>
           {% else %}
-            <a class="multipage-link {% if not category %} active{% endif %}" href="{% relocalized_url home_page.localized.url lang_code %}">{% trans "All" %}</a>
+            <a class="multipage-link {% if not category %} active{% endif %}" href="{% relocalized_url home_page.localized.url %}">{% trans "All" %}</a>
           {% endif %}
 
           {% for cat in categories %}
             {% with original=cat.original %}
             {% if original.published_product_page_count > 0 %}
-              {% localizedroutablepageurl home_page 'category-view' lang_code original.slug as cat_url %}
+              {% localizedroutablepageurl home_page 'category-view' original.slug as cat_url %}
               <a class="multipage-link {% check_active_category current_category cat %}{% if original.featured is True %} featured{% endif %}" href="{{ cat_url }}" data-name="{{ original.name }}">{{ cat.name }}</a>
             {% endif %}
             {% endwith %}

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/fragments/category_nav_links.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/fragments/category_nav_links.html
@@ -7,7 +7,7 @@
 {% for cat in sorted_categories %}
   {% with original=cat.original %}
   {% if cat.hidden == False and cat.published_product_page_count > 0 %}
-    {% localizedroutablepageurl home_page 'category-view' lang_code original.slug as cat_url %}
+    {% localizedroutablepageurl home_page 'category-view' original.slug as cat_url %}
     <a
       class="multipage-link {% check_active_category current_category cat %}{% if original.featured is True %} featured{% endif %}"
       href="{{ cat_url }}"

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/primary_nav.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/primary_nav.html
@@ -2,20 +2,19 @@
 
 {% load bg_nav_tags i18n localization %}
 
-{% get_current_language as lang_code %}
 
 {% block nav_logo %}
   <div class="d-flex align-items-center logo-section">
     <a href="/" class="moz-logo mb-0 mr-3"><span class="sr-only">Mozilla</span></a>
     <p class="mb-0 h3-heading flex-wrap">
-      <a class="link-back" href="{% relocalized_url home_page.url lang_code %}">{% trans "*privacy not included" context 'Buyer’s guide name. This can be localized. This is a reference to the “*batteries not included” mention on toys.' %}</a>
+      <a class="link-back" href="{% relocalized_url home_page.url %}">{% trans "*privacy not included" context 'Buyer’s guide name. This can be localized. This is a reference to the “*batteries not included” mention on toys.' %}</a>
     </p>
   </div>
 {% endblock %}
 
 {% block narrow_screen_nav_links %}
 {% url 'buyersguide-home' as home_url %}
-<div><a class="{% bg_active_nav request.get_full_path home_url %}" href="{% relocalized_url home_url lang_code %}">{% trans "Privacy Not Included" %}</a></div>
+<div><a class="{% bg_active_nav request.get_full_path home_url %}" href="{% relocalized_url home_url %}">{% trans "Privacy Not Included" %}</a></div>
 {% include "buyersguide/fragments/pni_nav_links.html" with pre="<div>" post="</div>" %}
 {% endblock %}
 

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
@@ -2,8 +2,6 @@
 
 {% load bg_selector_tags env l10n i18n localization static wagtailimages_tags %}
 
-{% get_current_language as lang_code %}
-
 {% block head_extra %}
   <meta property="og:title" content="{% blocktrans context "This can be localized. This is a reference to the “*batteries not included” mention on toys." %}privacy not included - {{ product.title }}{% endblocktrans %}" />
   <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}" />
@@ -299,7 +297,7 @@
             {% for related_product_page in product.related_product_pages.all %}
             {% with related_product=related_product_page.related_product.localized %}
             <div class="related-product col-6 col-md-3 mb-3 mb-md-0">
-              <a class="d-block{% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url lang_code %}">
+              <a class="d-block{% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url %}">
                 <div class="img-container">
                   {% image related_product.image width-600 as img %}
                   <img

--- a/network-api/networkapi/wagtailpages/templates/fragments/buyersguide_item.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/buyersguide_item.html
@@ -1,7 +1,5 @@
 {% load static i18n wagtailimages_tags localization %}
 
-{% get_current_language as lang_code %}
-
 <figure class="product-box d-flex flex-column justify-content-between{% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}{% if product.privacy_ding %} privacy-ding{% endif%}" data-creepiness="{{ product.creepiness }}">
   <div class="top-left-badge-container">
       {% if product.privacy_ding %}
@@ -16,7 +14,7 @@
 
   {% include "fragments/adult_content_badge.html" with product=product %}
 
-  <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="{% relocalized_url product.url lang_code %}">
+  <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="{% relocalized_url product.url %}">
     <picture class="product-thumbnail">
       <source
         {% image product.image fill-360x360 as img_1x %}
@@ -33,7 +31,7 @@
   </a>
 
   <figcaption class="d-block mt-md-2 text-left">
-    <a class="product-links" href="{% relocalized_url product.url lang_code %}">
+    <a class="product-links" href="{% relocalized_url product.url %}">
       <div class="product-company body-small">{{product.company}}</div>
       <div class="product-name body">{{product.title}}</div>
     </a>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
@@ -1,6 +1,6 @@
 {% extends "./generic_card.html" %}
 
-{% load wagtailcore_tags wagtailroutablepage_tags class_tags blog_tags i18n %}
+{% load wagtailcore_tags wagtailroutablepage_tags class_tags blog_tags i18n localization %}
 
 {% block card_type %}blog-card{% endblock %}
 
@@ -13,23 +13,13 @@ each blog page's dominant tag)
 
 {% block tags %}
   {% if hide_classifiers != True %}
-    {% if filtered and root %}
-      <ul class="list-unstyled mt-3 mb-0">
-      {% for tag in page.specific.tags.all %}
-        <li class="d-inline-block text-capitalize">
-          <a href="{% routablepageurl root.specific "entries_by_tag" tag.slug %}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
-        </li>
-      {% endfor %}
-      </ul>
-    {% else %}
-      {% with category=page.specific.category.first %}
-      {% if category %}
-        {% get_root_or_page as parent_page %}
-          {# If we have a "root" context variable, we know this card is generated on an index page (or index page subroute) #}
-          <a class="h6-heading d-block mt-3 mb-0" href="{% routablepageurl parent_page "entries_by_category" category.slug %}">{{ category }}</a>
-        {% endif %}
-      {% endwith %}
-    {% endif %}
+    {% with category=page.specific.category.first %}
+    {% if category %}
+      {% get_root_or_page as parent_page %}
+        {# If we have a "root" context variable, we know this card is generated on an index page (or index page subroute) #}
+        <a class="h6-heading d-block mt-3 mb-0" href="{% routablepageurl parent_page "entries_by_category" category.slug %}">{{ category }}</a>
+      {% endif %}
+    {% endwith %}
   {% endif %}
 {% endblock %}
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_index_feature.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_index_feature.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags i18n %}
+{% load wagtailimages_tags i18n localization %}
 
 {% comment %}
   This template is similar to the featured_blogs.html code *and* the card.html
@@ -15,11 +15,11 @@
 <div class="d-flex flex-column flex-1 key-item mx-2 mx-md-4 p-3">
   <p class="h6-heading mb-2">
     {% for category in blog.specific.category.all %}
-    <a href="/blog/category/{{category.slug}}">{{ category }}</a>{% if not forloop.last %}, {% endif %}
+    <a href="/blog/category/{{category.slug}}">{{ category.localized }}</a>{% if not forloop.last %}, {% endif %}
     {% endfor %}
   </p>
   <h5 class="mb-2 h3-heading">
-    <a href="{{blog.url}}">{{blog.title}}</a>
+    <a href="{% relocalized_url blog.localized.url %}">{{blog.localized.title}}</a>
   </h5>
   <p class="body-small mb-2">
     {% if blog.author %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -1,13 +1,13 @@
-{% load wagtailcore_tags wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags localization %}
 
 <div class="entry-card {% block card_type %}{% endblock %} col-6 col-md-4 mb-5">
   <div class="card-image">
-    <a href="{{ page.url }}">
+    <a href="{% relocalized_url page.localized.url %}">
       {% image page.specific.get_meta_image fill-400x225 %}
     </a>
   </div>
   {% block tags %}{% endblock %}
-  <a class="h4-heading d-inline-block my-2" href={{ page.url }}>{{ page.title }}</a>
+  <a class="h4-heading d-inline-block my-2" href="{% relocalized_url page.localized.url %}">{{ page.title }}</a>
   <p class="body-small my-0">
     {% block byline %}{% endblock %}
   </p>

--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -5,6 +5,7 @@ from django import template
 from django.conf import settings
 from django.utils.translation import get_language_info
 from wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags import routablepageurl
+from networkapi.wagtailpages.utils import get_language_from_request
 
 register = template.Library()
 
@@ -54,8 +55,10 @@ def get_unlocalized_url(page, locale):
 
 
 # Force-relocalize a URL
-@register.simple_tag()
-def relocalized_url(url, locale_code):
+@register.simple_tag(takes_context=True)
+def relocalized_url(context, url):
+    request = context['request']
+    locale_code = get_language_from_request(request);
     if locale_code == DEFAULT_LOCALE_CODE:
         return url
     return url.replace(f'/{DEFAULT_LOCALE_CODE}/', f'/{locale_code}/')
@@ -63,9 +66,9 @@ def relocalized_url(url, locale_code):
 
 # Overcome a limitation of the routablepageurl tag
 @register.simple_tag(takes_context=True)
-def localizedroutablepageurl(context, page, url_name, locale_code, *args, **kwargs):
+def localizedroutablepageurl(context, page, url_name, *args, **kwargs):
     url = relocalized_url(
-        routablepageurl(context, page, url_name, *args, **kwargs),
-        locale_code,
+        context,
+        routablepageurl(context, page, url_name, *args, **kwargs)
     )
     return url

--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -58,7 +58,7 @@ def get_unlocalized_url(page, locale):
 @register.simple_tag(takes_context=True)
 def relocalized_url(context, url):
     request = context['request']
-    locale_code = get_language_from_request(request);
+    locale_code = get_language_from_request(request, True)
     if locale_code == DEFAULT_LOCALE_CODE:
         return url
     return url.replace(f'/{DEFAULT_LOCALE_CODE}/', f'/{locale_code}/')

--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -54,14 +54,19 @@ def get_unlocalized_url(page, locale):
     return page.get_url().replace(f'/{locale}/', '/', 1)
 
 
-# Force-relocalize a URL
-@register.simple_tag(takes_context=True)
-def relocalized_url(context, url):
-    request = context['request']
-    locale_code = get_language_from_request(request, True)
+def relocalize_url(url, locale_code):
     if locale_code == DEFAULT_LOCALE_CODE:
         return url
     return url.replace(f'/{DEFAULT_LOCALE_CODE}/', f'/{locale_code}/')
+
+
+# Force-relocalize a URL
+@register.simple_tag(takes_context=True)
+def relocalized_url(context, url, locale_code=None):
+    if locale_code is None:
+        request = context['request']
+        locale_code = get_language_from_request(request, True)
+    return relocalize_url(url, locale_code)
 
 
 # Overcome a limitation of the routablepageurl tag

--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -62,10 +62,9 @@ def relocalize_url(url, locale_code):
 
 # Force-relocalize a URL
 @register.simple_tag(takes_context=True)
-def relocalized_url(context, url, locale_code=None):
-    if locale_code is None:
-        request = context['request']
-        locale_code = get_language_from_request(request, True)
+def relocalized_url(context, url):
+    request = context['request']
+    locale_code = get_language_from_request(request, True)
     return relocalize_url(url, locale_code)
 
 


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/6965 while also fixing up the `relocalized_url` template tag necessary for resolving that issue.

Closes https://github.com/mozilla/foundation.mozilla.org/issues/7233 because of the widened scope.

The STR will require grabbing a copy of the most recent production data, so that you have real localized content to test on.

- when on `/de/` the http://localhost:8000/blog index page should link to `/de/` links for all cards rather than `/en/`
- same for the http://localhost:8000/campaigns index page.
- the PNI homepage should have categories and products that all link to the correct locale (`en` on EN, `de` on DE, etc)
- the PNI "all" category and logo should point to the homepage on the current locale
- "related products" for PNI products should have URLs for the current locale
- the homepage should also point to `/de/` things when on http://localhost:8000/de/ etc.

Also note that the blog card has had the code for "showing tags" removed, since we haven't exposed that in years and we're already working on taging tags out (for UI purposes).