### PR TITLE
Fix makemessages command for JS

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -32,10 +32,13 @@ locale_abstraction_instructions_js = " ".join(
     [
         "makemessages",
         "-d djangojs",
+        "--all",
         "--keep-pot",
         "--no-wrap",
         "--ignore=node_modules",
         "--ignore=dockerpythonvenv/*",
+        "--ignore=network-api",
+        "--ignore=cypress",
     ]
 )
 


### PR DESCRIPTION
Closes #7297

Makes `inv makemessages` run again + excluding a couple more dirs to silence warnings in log and avoid referencing compiled JS files in .po files