### PR TITLE
7293 - Fixed centering images from tailwind preflight configs

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
@@ -27,7 +27,7 @@
     <div class="row">
       <div class="col-12 col-lg-10 offset-lg-1 product-header-content {% if product.privacy_ding %}show-privacy-ding{% endif %}">
         <img
-          class="thumb-border"
+          class="thumb-border tw-mx-auto"
           width="250"
           {% image product.image width-250 as img %}
           src="{{ img.url }}"


### PR DESCRIPTION
Closes #7293

![image](https://user-images.githubusercontent.com/2374073/132387563-72361d36-1aaf-4a88-b455-53331fd84a45.png)

Check if the projects images are centered and if they are any other odd behaviors with images in privacy not included