### PR TITLE
incorrect back reference

### DIFF
--- a/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
+++ b/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
@@ -25,7 +25,7 @@ __original__html__ = RichText.__html__
 # 1. "everything after the h" for the opening tag
 # 2. the heading number
 # 3. the tag's text content
-heading_re = r"<h((\d)[^>]*)>(.+?)</h\2>"
+heading_re = r"<h((\d)[^>]*)>(.+?)<\/h\2>"
 
 
 def add_id_attribute(match):

--- a/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
+++ b/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
@@ -25,7 +25,7 @@ __original__html__ = RichText.__html__
 # 1. "everything after the h" for the opening tag
 # 2. the heading number
 # 3. the tag's text content
-heading_re = r"<h((\d)[^>]*)>(.+?)</h\1>"
+heading_re = r"<h((\d)[^>]*)>(.+?)</h\2>"
 
 
 def add_id_attribute(match):


### PR DESCRIPTION
Addresses part one of #7347 by fixing the heading-linking code we have in place. This was using the wrong back-reference `\1` on in the regex `<h((\d)[^>]*)>(.+?)<\/h\1>`, which matches the first group: `((\d)[^>]*)`. As long as there are no attributes, this will be equivalent to matching the heading number, but once there's an attribute like in `<h2 data-block-key="...">` it will match "everything between the `h` and `>`" so it starts looking for the closing tag `</h2 data-block-key="...">` and obviously that is going to fail. Instead it should use the second group as backreference, which is only the `(\d)` part.