### PR TITLE
added word breaks to make sure links do not overflow.

### DIFF
--- a/source/sass/wagtail/blocks/rich-text.scss
+++ b/source/sass/wagtail/blocks/rich-text.scss
@@ -16,4 +16,11 @@
       */
     margin-top: 1rem;
   }
+  // Making sure that long links do not run off the page.
+  .content-block,
+  .rich-text-block {
+    a {
+      word-wrap: break-word;
+    }
+  }
 }


### PR DESCRIPTION
Closes #7351

**Link to sample test page**: https://foundation-s-link-overf-lhi9bz.herokuapp.com/en/publication-page-with-child-article-pages/fixed-title-article-page/

**Steps to test**:

1. Visit the link above, which is a page where I have copied and pasted the same "References" section that was producing the bug.
2. Verify that there is no longer the ability to scroll to the right on mobile widths.
3. If so, and everything else looks correct, testing is complete!

This is a fix for the bug in which links in content blocks of publication pages are overflowing and causing the page to be wider than the actual content. 

Since this is only occuring in the "rich text" blogs of article/publication pages and everything else is working correctly, I have added a new CSS rule stating that links that go beyond the page width should break and stay within the container. 