### PR TITLE
Format Pulse profile ID as string

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_block.html
@@ -5,7 +5,7 @@
 <div class="col-lg-6 col-12 mb-5">
   <div class="person-card">
     <div class="thumbnail-wrapper">
-      <a href="https://www.mozillapulse.org/profile/{{ profile.profile_id }}" class="d-block headshot-container">
+      <a href="https://www.mozillapulse.org/profile/{{ profile.profile_id|stringformat:"s" }}" class="d-block headshot-container">
         <img
           src="{% if profile.thumbnail %}{{ profile.thumbnail }}{% else %}{% static "_images/fellowships/headshot/placeholder.jpg" %}{% endif %}"
           class="headshot"
@@ -13,7 +13,7 @@
       </a>
     </div>
     <div class="short-meta-wrapper">
-      <a class="h5-heading meta-block-name mb-0 d-block" href="https://www.mozillapulse.org/profile/{{ profile.profile_id }}">{{ profile.name }}
+      <a class="h5-heading meta-block-name mb-0 d-block" href="https://www.mozillapulse.org/profile/{{ profile.profile_id|stringformat:"s" }}">{{ profile.name }}
       </a>
       {% if profile.location %}<p class="d-flex align-items-center meta-block-location body-small my-2">{{ profile.location }}</p>{% endif %}
       <div class="social-icons">


### PR DESCRIPTION
Closes #7353

This forces the value to be treated as a string instead of a number, because `USE_THOUSAND_SEPARATOR` is set to true, and does apply the locale’s formatting rules to numbers.

Test page: https://foundation-s-thousand-s-zekjmo.herokuapp.com/en/campaigns/test-page/
