### PR TITLE
added new date format to match figma file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ### Installing Invoke
 
-We recommend that you install Invoke using [pipx](https://pypi.org/project/pipx/).
+We recommend that you install Invoke using [pipx](https://pypi.org/project/pipx/), but any Python package manager should work (pip, poetry, etc).
 
 ### Check your environment
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## How to Setup your Dev Environment with Docker
 
-**Requirements**: [Docker Desktop](https://www.docker.com/products/docker-desktop) (macOS and Windows) or [Docker CE](https://docs.docker.com/install/#supported-platforms) and [Docker Compose](https://docs.docker.com/compose/install/) (Linux), [Python 3](https://www.python.org/downloads/) with the [invoke](https://www.pyinvoke.org/installing.html) package installed globally, and [git](https://git-scm.com/).
+**Requirements**: Docker ([Docker Desktop](https://www.docker.com/products/docker-desktop) for macOS and Windows or [Docker Compose](https://docs.docker.com/compose/install/) for Linux), [Python 3](https://www.python.org/downloads/) with the [invoke](https://www.pyinvoke.org/installing.html) package installed globally, and [git](https://git-scm.com/).
 
 ### Installing Invoke
 

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
@@ -64,7 +64,7 @@
           {% endif %}
         </div>
         <div class="col-12 mt-3">
-          <p class="body-small">{% blocktrans with date=product.review_date|date:"SHORT_DATE_FORMAT" context "Short date format (e.g. 2003/12/31)" %}Review date: {{ date }}{% endblocktrans %}</p>
+          <p class="body-small">{% blocktrans with date=product.review_date|date:"DATE_FORMAT" context "Date format (e.g. Nov. 19, 2020)" %}Review date: {{ date }}{% endblocktrans %}</p>
         </div>
         <div class="col-12"><p class="body mb-0">{{product.blurb}}</p></div>
       </div>


### PR DESCRIPTION
Closes #7376 


**Link to sample test page**: https://foundation-s-7376-updat-3ideam.herokuapp.com/en/privacynotincluded/throw-build-shake-political-pull/

**Steps to test:** 

1. Visit the link above
2. Take a look at the date and it should be in the format of "Nov. 21, 2021" like requested.
3. If it appears correctly, testing is done! 


## Checklist



**Changes in Models:**
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?