### PR TITLE
add the missing FilterField for localized snippet filtering

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -312,6 +312,7 @@ class Update(TranslatableMixin, index.Indexed, models.Model):
 
     search_fields = [
         index.SearchField('title', partial_match=True),
+        index.FilterField('locale_id'),
     ]
 
     translatable_fields = [


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7398

Without this fix, the server will throw the following error when DEBUG is set to True:

![image](https://user-images.githubusercontent.com/177243/134042111-f7a2597c-f76d-4799-bd25-b4312d252df1.png)

And thankfully the error just tells us what the solution is =)

(although I don't know why it just doesn't "do that" without us having to write code, if it already knows both what's wrong, and what the fix is...)



