### PR TITLE
hide the softwareproductpage child page type

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -1350,7 +1350,10 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
     """
 
     template = 'buyersguide/home.html'
-    subpage_types = [SoftwareProductPage, GeneralProductPage]
+    subpage_types = [
+        # SoftwareProductPage,
+        GeneralProductPage,
+    ]
 
     cutoff_date = models.DateField(
         'Product listing cutoff date',


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7392 by removing the `SoftwareProductPage` as valid child for the `BuyersGuidePage`. Or rather, commenting it off. This only affects how the admin behaves, and does not affect preexisting sofware products's on the website itself.

Log into the admin interface, navigate to the `privacy not included` page, and add a new child page. It should no longer offer the choice between general or software, and immediately open an edit interface for a general product page.