### PR TITLE
make sure to unescape HTML entities before slugifying

### DIFF
--- a/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
+++ b/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py
@@ -1,4 +1,5 @@
 import re
+import html
 from django import template
 from django.utils.text import slugify
 from django.utils.html import strip_tags
@@ -56,7 +57,7 @@ def add_id_attribute(match):
     anchor = ''
 
     if int(n) < 4:
-        id = slugify(strip_tags(text_content))
+        id = slugify(strip_tags(html.unescape(text_content)))
         anchor = f'<a class="fragment-id" id="{id}"></a>'
 
     return f'<h{hsuffix}>{anchor}{text_content}</h{n}>'


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7349 by applying `html.unescape` to the text content before stripping tags and slugifying.

STR:
- load the admin
- load the test blog post and change the first heading in the body to `it's working`
- publish and view the page
- inspect the heading in dev tools: it should now contain an `<a id="its-working">` rather than the `<a id="itx27s-working">` we would be generating without this fix