### PR TITLE
add CSRF token to the voting process

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
@@ -82,6 +82,7 @@
             <div class="creep-vote-target mb-5 mt-3 mt-md-4 p-5" data-product-name="{{product.title}}" data-product-type="{{product.product_type}}">
               <input type="hidden" name="productID" value="{{ product.id }}">
               <input type="hidden" name="votes" value='{{ product.get_voting_json | safe }}'>
+              {% csrf_token %}
             </div>
           </div>
         </div>

--- a/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
+++ b/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
@@ -85,7 +85,7 @@ class CreepVote extends Component {
     let method = `POST`;
     let credentials = `same-origin`;
     let headers = {
-      "X-CSRFToken": this.props.csrf,
+      "X-CSRFToken": this.props.csrfToken,
       "Content-Type": `application/json`,
     };
 

--- a/source/js/buyers-guide/inject-react/creep-vote.js
+++ b/source/js/buyers-guide/inject-react/creep-vote.js
@@ -13,6 +13,7 @@ export default (apps, siteUrl) => {
     let productName = element.dataset.productName;
     let productID = element.querySelector(`input[name=productID]`).value;
     let votesValue = element.querySelector(`input[name=votes]`).value;
+    let csrfToken = element.querySelector(`input[name=csrfmiddlewaretoken]`).value;
 
     let votes = {
       total: 0,
@@ -41,6 +42,7 @@ export default (apps, siteUrl) => {
             votes={votes}
             whenLoaded={() => resolve()}
             joinUsApiUrl={`${siteUrl}/api/campaign/signups/0/`}
+            csrfToken={csrfToken}
           />,
           element
         );


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7440 by ensuring that there is a Django csrf token available in the page source for our JS to tap into and send back to the server during the POST request.

STR for verifying it's broken on prod:
1. visit https://foundation.mozilla.org/en/privacynotincluded/nintendo-switch/
1. open dev tools, and open the network tab
1. clear your network tab's log so far
1. cast a creepiness vote 
1. look at the POST request made: it should be `403`, and if you click it and look at the request headers, it'll show `x-csrftoken: undefined` at the bottom of the header list
1. For double confirmation, reload the page, view-source, and confirm there is no string that contains `csrf` anywhere in the page source.

STR for verifying it's fixed in this patch:
1. open any PNI product in the review app
1. open dev tools, and open the network tab
1. clear your network tab's log so far
1. cast a creepiness vote 
1. look at the POST request made: it should be `200`, and if you click it and look at the request headers, it'll show `x-csrftoken: (some long string)` at the bottom of the header list
1. For double confirmation, reload the page, view-source, and confirm there is a hidden input element with name `csrfmiddlewaretoken` in the page source.