### PR TITLE
always determine serve-locale from the URL first, cookies/etc second

### DIFF
--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -65,7 +65,7 @@ def relocalize_url(url, locale_code):
 @register.simple_tag(takes_context=True)
 def relocalized_url(context, url):
     request = context['request']
-    locale_code = get_language_from_request(request, True)
+    locale_code = get_language_from_request(request)
     return relocalize_url(url, locale_code)
 
 

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -264,7 +264,7 @@ def language_code_to_iso_3166(language):
     return language
 
 
-def get_locale_from_request(request, check_path=False):
+def get_locale_from_request(request, check_path=True):
     language_code = get_language_from_request(request, check_path)
 
     try:
@@ -273,7 +273,7 @@ def get_locale_from_request(request, check_path=False):
         return Locale.objects.get(language_code=settings.language_code)
 
 
-def get_language_from_request(request, check_path=False):
+def get_language_from_request(request, check_path=True):
     """
     Replacement for django.utils.translation.get_language_from_request.
     The portion of code that is modified is identified below with a comment.


### PR DESCRIPTION
Part one of a fix for https://github.com/mozilla/foundation.mozilla.org/issues/7122

This switches over the locale resolution to check URL first, cookie/headers second, so that at least we can be sure that the correct locale is active.