### PR TITLE
7390 dotted background bar

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
@@ -260,17 +260,7 @@
           </section>
         {% endif %}
 
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="container-fluid position-relative">
-  <div class="row dotted-section d-block d-sm-flex mx-0">
-    <div class="container">
-      <div class="row">
-        <div class="{{section_class}} mt-5 pt-3 bg-white product-section-padding-x">
-          {% if product.updates.count > 0 %}
+                  {% if product.updates.count > 0 %}
           <h3 class="h2-heading mb-4 mb-md-5">{% trans "News" %}</h3>
           {% endif %}
           {% if product.updates.count > 0 %}
@@ -313,16 +303,27 @@
             {% endfor %}
           </div>
 
-          {% if use_commento %}
-          <h3 class="h2-heading mb-4">{% trans "Comments" %}</h3>
-          <div id="commento"></div>
-          {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
 
+{% if use_commento %}
+
+<div class="container-fluid position-relative comment-section">
+  <div class="row dotted-section d-block d-sm-flex mx-0">
+    <div class="container">
+      <div class="row">
+        <div class="{{section_class}} mt-5 pt-3 bg-white comment-section-padding-x">
+
+        <h3 class="h2-heading mb-4">{% trans "Comments" %}</h3>
+        <div id="commento"></div>
         </div>
       </div>
     </div>
   </div>
 </div>
+{% endif %}
 
 {% endwith %}
 {% endblock %}

--- a/source/sass/buyers-guide/views/product.scss
+++ b/source/sass/buyers-guide/views/product.scss
@@ -108,7 +108,7 @@
   }
 }
 
-.product-section-padding-x {
+.comment-section-padding-x {
   padding-left: 18px;
   padding-right: 18px;
 


### PR DESCRIPTION
Closes #7390 


**Link to sample test page**: https://foundation-s-7390-dotte-mcfw2q.herokuapp.com/en/privacynotincluded/information-option-treatment-see-work-involve-sure-friend/

**Steps to test**:

1. Visit the test page above
2. Scroll down to the bottom, note that the dotted background bar is now behind "comments"
**Note:** Since commento does not load on review apps, the dotted background image is going to be touching the footer. However, commento will add a new element that is around ~300px, which will then add space in between the two items. 
3. If the dotted background looks OK, testing is complete! 


Screenshot with the "real" PNI comment form mocked in-place:

![image](https://user-images.githubusercontent.com/177243/134407183-30545d67-d74d-46a6-a023-8584add6935b.png)
