### PR TITLE
sort menu and settings submenu alphabetically

### DIFF
--- a/network-api/networkapi/wagtailpages/wagtail_hooks.py
+++ b/network-api/networkapi/wagtailpages/wagtail_hooks.py
@@ -171,3 +171,10 @@ def register_howto_menu_item():
         'How Do I Wagtail', reverse('how-do-i-wagtail'),
         name='howdoIwagtail', classnames='icon icon-help', order=900
     )
+
+@hooks.register('construct_main_menu')
+@hooks.register('construct_settings_menu')
+def construct_settings_menu(request, menu_items):
+    menu_items.sort(key=lambda x: x.name)
+    for order, item in enumerate(menu_items):
+        item.order = order


### PR DESCRIPTION
No associated issue, but this has been a long-standing gripe during dev work, where none of the menu items are sorted, and introducing new ones (due to wagtail updates or packages) just end up in completely random places.