### PR TITLE
make sure locale fallback for get_entries gets assigned to the correct variable

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/index.py
@@ -119,7 +119,7 @@ class IndexPage(FoundationMetadataPageMixin, RoutablePageMixin, Page):
         DEFAULT_LOCALE = Locale.objects.get(language_code=DEFAULT_LANGUAGE_CODE)
 
         if 'request' in context:
-            locale = get_locale_from_request(context.get('request'))
+            locale = get_locale_from_request(context['request'])
         else:
             locale = DEFAULT_LOCALE
 

--- a/network-api/networkapi/wagtailpages/pagemodels/index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/index.py
@@ -117,9 +117,14 @@ class IndexPage(FoundationMetadataPageMixin, RoutablePageMixin, Page):
         """
         DEFAULT_LANGUAGE_CODE = settings.LANGUAGE_CODE
         DEFAULT_LOCALE = Locale.objects.get(language_code=DEFAULT_LANGUAGE_CODE)
-        locale = get_locale_from_request(context.get('request', DEFAULT_LOCALE))
+
+        if 'request' in context:
+            locale = get_locale_from_request(context.get('request'))
+        else:
+            locale = DEFAULT_LOCALE
 
         entries = self.get_all_entries(locale)
+
         if hasattr(self, 'filtered'):
             entries = self.filter_entries(entries, context)
 


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7481

To test, you'll need a copy of the stage db, as `load_fake_data` does not have enough blog posts to reproduce this behaviour.

STR:
- load the `/blog` page
- click the "load more" button
- more entries should load.

Compared to the current behaviour on https://foundation.mozilla.org/blog where clicking the button causes a server error 500 on the Fetch url  (see dev tools "network tab" when clicking the button to confirm that error).