### PR TITLE
create a database copying script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ translations_github_commit_*
 
 # Localization testing SSH keys
 wagtail-localize-key*
+
+# Database copies
+*.db.archive

--- a/copy-db.js
+++ b/copy-db.js
@@ -66,7 +66,7 @@ console.log(`Building user roles...`);
 );
 
 console.log(`Importing snapshot...`);
-run(`docker cp ${DUMP_FILE} foundation_postgres_1:/`);
+run(`docker cp ${DUMP_FILE} foundationmozillaorg_postgres_1:/`);
 docker(`pg_restore ${DB_FLAGS} -dwagtail ${DUMP_FILE}`);
 
 console.log(`Creating admin:admin superuser account...`);

--- a/copy-db.js
+++ b/copy-db.js
@@ -1,0 +1,87 @@
+const fs = require("fs");
+const { execSync } = require(`child_process`);
+
+const keepDatabase = process.argv.includes(`--keep`);
+const silent = { stdio: [`ignore`, `ignore`, `ignore`] };
+const PROD_APP = `foundation-mozilla-org`;
+const STAGE_APP = `foundation-mofostaging-net`;
+const APP = process.argv.includes(`--prod`) ? PROD_APP : STAGE_APP;
+
+if (APP === STAGE_APP) {
+  console.log(
+    `Running db copy for staging, run with --prod to run for production`
+  );
+}
+
+const HEROKU_OUTPUT = run(`heroku config:get DATABASE_URL -a ${APP}`);
+const HEROKU_TEXT = HEROKU_OUTPUT.toString().replaceAll(`\n`, ` `);
+const URL_START = HEROKU_TEXT.indexOf(`postgres://`);
+const DATABASE_URL = HEROKU_TEXT.substring(URL_START).trim();
+const ROLE = DATABASE_URL.match(/postgres:\/\/([^:]+):/)[1];
+const DUMP_FILE = `${ROLE}.db.archive`;
+const DB_FLAGS = `-hpostgres -Ufoundation`;
+
+/**
+ * ...
+ */
+function run(cmd, ignoreThrows = false, opts = {}) {
+  try {
+    return execSync(cmd, opts);
+  } catch (e) {
+    if (ignoreThrows) return e.toString();
+    throw e;
+  }
+}
+
+/**
+ * ...
+ */
+function docker(cmd, ignoreThrows = false) {
+  cmd = `docker exec foundation_postgres_1 ${cmd}`;
+  return run(cmd, ignoreThrows);
+}
+
+console.log(`Starting postgres docker image...`);
+run(`docker-compose up -d postgres`, true, silent);
+
+console.log(`Starting backend docker image...`);
+run(`docker-compose up -d backend`, true, silent);
+
+console.log(`Downloading ${APP} database (this may take a while)...`);
+if (!fs.existsSync(DUMP_FILE)) {
+  docker(`pg_dump -F c ${DATABASE_URL} > ${DUMP_FILE}`);
+}
+
+console.log(`Resetting db...`);
+docker(`dropdb ${DB_FLAGS} --if-exists wagtail`);
+docker(`createdb ${DB_FLAGS} wagtail`);
+
+console.log(`Building user roles...`);
+[ROLE, `datastudio`, `datagrip-cade`].forEach((role) =>
+  docker(`createuser ${DB_FLAGS} -s ${role}`, true)
+);
+
+console.log(`Importing snapshot...`);
+run(`docker cp ${DUMP_FILE} foundation_postgres_1:/`);
+docker(`pg_restore ${DB_FLAGS} -dwagtail ${DUMP_FILE}`);
+
+console.log(`Creating admin:admin superuser account...`);
+run(
+  [
+    `docker exec foundation_backend_1`,
+    `./dockerpythonvenv/bin/python network-api/manage.py shell -c`,
+    `"from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@example.com', 'admin')"`,
+  ].join(` `)
+),
+  true,
+  silent;
+
+console.log(`Stopping docker images...`);
+run(`docker-compose down`, true, silent);
+
+if (!keepDatabase) {
+  console.log(`Running cleanup`);
+  fs.unlinkSync(DUMP_FILE);
+}
+
+console.log(`All done.`);

--- a/copy-db.js
+++ b/copy-db.js
@@ -71,10 +71,11 @@ run(
     `docker exec foundation_backend_1`,
     `./dockerpythonvenv/bin/python network-api/manage.py shell -c`,
     `"from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@example.com', 'admin')"`,
-  ].join(` `)
-),
+  ].join(` `),
   true,
-  silent;
+  silent
+);
+
 
 console.log(`Stopping docker images...`);
 run(`docker-compose down`, true, silent);

--- a/copy-db.js
+++ b/copy-db.js
@@ -37,7 +37,7 @@ function run(cmd, ignoreThrows = false, opts = {}) {
  * ...
  */
 function docker(cmd, ignoreThrows = false) {
-  cmd = `docker exec foundation_postgres_1 ${cmd}`;
+  cmd = `docker exec foundationmozillaorg_postgres_1 ${cmd}`;
   return run(cmd, ignoreThrows);
 }
 
@@ -72,7 +72,7 @@ docker(`pg_restore ${DB_FLAGS} -dwagtail ${DUMP_FILE}`);
 console.log(`Creating admin:admin superuser account...`);
 run(
   [
-    `docker exec foundation_backend_1`,
+    `docker exec foundationmozillaorg_backend_1`,
     `./dockerpythonvenv/bin/python network-api/manage.py shell -c`,
     `"from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@example.com', 'admin')"`,
   ].join(` `),

--- a/copy-db.js
+++ b/copy-db.js
@@ -41,6 +41,10 @@ function docker(cmd, ignoreThrows = false) {
   return run(cmd, ignoreThrows);
 }
 
+console.log(`Making sure no docker containers are running...`);
+run(`docker-compose down`, true, silent);
+run(`docker-compose down`, true, silent);
+
 console.log(`Starting postgres docker image...`);
 run(`docker-compose up -d postgres`, true, silent);
 

--- a/copy-db.js
+++ b/copy-db.js
@@ -76,7 +76,6 @@ run(
   silent
 );
 
-
 console.log(`Stopping docker images...`);
 run(`docker-compose down`, true, silent);
 

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -113,10 +113,12 @@ Use `invoke npm update`.
 
 Requirements:
 
-- [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
 - Heroku Account with membership on the Mozilla team (ask in #mofo-engineering on Slack)
+- [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) - remember to run `heroku login` after installation finishes.
 
 You can copy the staging database using `inv copy-stage-db`, or the production database using `inv copy-prod-db`.
+
+**Note** that this script requires that docker is not already ready running, as this script requires exclusive database access. You can ensure that this is the case by running `docker-compose down` twice in the repo's root directory. The first time should show all running containers getting shut down, the second should confirm that there is nothing to take down anymore.
 
 For more control, you can also manually invoke `node copy-db.js`, which has the following behavior:
 

--- a/tasks.py
+++ b/tasks.py
@@ -186,6 +186,18 @@ def npm_install(ctx):
         ctx.run("docker-compose run --rm watch-static-files npm install")
 
 
+@task(aliases=["copy-stage-db"])
+def copy_staging_database(ctx):
+    with ctx.cd(ROOT):
+        ctx.run("node copy-db.js")
+
+
+@task(aliases=["copy-prod-db"])
+def copy_production_database(ctx):
+    with ctx.cd(ROOT):
+        ctx.run("node copy-db.js --prod")
+
+
 # Django shorthands
 @task(aliases=["docker-manage"])
 def manage(ctx, command):


### PR DESCRIPTION
No related issue: this adds a new script to our repo to make database copying easier, as well as two new invoke commands, `inv copy-stage-db` and `inv copy-prod-db`, with associated docs updates.

This does require you have the Heroku CLI utility installed, so that we don't need to start stage/prod credentials anywhere, and can just pull them from heroku automatically, provided you have access to the staging and prod apps.

(If you need to install the heroku CLI first, remember to run `heroku login` before running this script, which will kick off a browser based login process)