### PR TITLE
update wagtail to 2.14.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,11 +21,11 @@ python-slugify
 requests
 social-auth-app-django
 wagtail-airtable
-wagtail==2.13.1
+wagtail==2.14.1
 wagtail-factories
 wagtail-localize==1.0rc4
-wagtail-localize-git==0.9.3
-wagtail-inventory==1.3
+wagtail-localize-git==0.10.0
+wagtail-inventory
 wagtailmedia
 wagtail-metadata
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -231,7 +231,7 @@ urllib3[secure]==1.26.6
     #   requests
     #   scout-apm
     #   sentry-sdk
-wagtail==2.13.1
+wagtail==2.14.1
     # via
     #   -r requirements.in
     #   wagtail-airtable
@@ -254,7 +254,7 @@ wagtail-localize==1.0rc4
     # via
     #   -r requirements.in
     #   wagtail-localize-git
-wagtail-localize-git==0.9.3
+wagtail-localize-git==0.10.0
     # via -r requirements.in
 wagtail-metadata==3.4.0
     # via -r requirements.in


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7503

STR:
- checkout main
- run `inv new-env`
- checkout this branch
- run `inv catchup` (which will uplift the local testing db)
- run `inv test-python` to verify there are no errors

STR part 2:
- checkout main
- run `inv new-env`
- set up your local db to be a copy of the staging or production database
- checkout this branch
- run `inv catchup` (which will now apply to "real" data)
- run `docker-compose up` and poke around the CMS and pages a bit to make sure nothing broke

@TheoChevalier I've added you as reviewer mostly for the localize-ness, I had to updated wagtail-localize-git to 0.10.0 but as far as I can tell that should have been fine.