### PR TITLE
Fix wagtail-localize crash when there’s a search description on PNI products

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -778,7 +778,6 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
         SynchronizedField('search_image'),
         # Content tab fields
         TranslatableField('title'),
-        TranslatableField('search_description'),
         SynchronizedField('privacy_ding'),
         SynchronizedField('adult_content'),
         SynchronizedField('uses_wifi'),


### PR DESCRIPTION
Closes #7519

The field was duplicated, making wagtail-localize duplicate the translation, and crashing because of that.

Was able to confirm it fixes it for Signal with a copy of the staging db (hat tip to you)