### PR TITLE
7526 Headings with Sublinks in publications ToC are clickable

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/fragments/publication_table_of_contents.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/publication_table_of_contents.html
@@ -41,7 +41,11 @@
                     {{ child.title }} {% if child.has_unpublished_changes %}🐣{% endif %}
                   </a>
                   {% else %}
-                    {{ child.title }} {% if child.has_unpublished_changes %}🐣{% endif %}
+                    {% with grandchild=child_page.grandchildren.first %}
+                      <a href="{% if child.specific.intro_notes or child.specific.notes or child.specific.contents_title %}{{ child.url }}{% else %}{{grandchild.url}}{% endif %}" class="d-block mb-4">
+                        {{ child.title }} {% if child.has_unpublished_changes %}🐣{% endif %}
+                      </a>
+                    {% endwith %}
                   {% endif %}
                 </h3>
                 {% for ancestor in child_page.grandchildren %}


### PR DESCRIPTION
fix

Closes #7526 

![image](https://user-images.githubusercontent.com/2374073/135334542-c6d6ab66-6431-420a-90a7-37bc0fb4e671.png)

If there's a Section page that exists, if it has no content (no intro notes, notes or contents title), it should link to the first child page, if it has content, it should link to the Section page itself.

Heading should always have a link regardless if they have children pages or not