### PR TITLE
[7434] remove spurious HTML class preventing share links from working

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/article_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/article_page.html
@@ -50,7 +50,7 @@
   <div class="container my-5">
     <div class="row pt-5">
       <div class="col-sm-8 offset-sm-2 pt-4">
-        <div class="pb-4 share-button-group-wrapper">
+        <div class="pb-4">
           <div class="share-button-group-wrapper d-print-none" data-share-text="{% blocktrans with title=page.title %}{{ title }} by @mozilla{% endblocktrans %}" data-link="{{ request.scheme }}://{{ request.get_host }}{{ request.get_full_path }}"></div>
         </div>
       </div>


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7438

**Link to sample test page**: https://foundation-s-fix-7438-s-uu72sg.mofostaging.net/en/publication-page-with-chapter-pages/mind-drive-pull-throw-truth-until-wind-trouble-fill-sense-foreign-official-care-heavy-capital/fixed-title-article-page/

The links at the bottom of the page should now work:
![Screenshot from 2021-09-30 17-30-12](https://user-images.githubusercontent.com/3485411/135494879-5014302e-4c4f-4198-a688-846795a361bc.png)


