### PR TITLE
New localization approach for Mozilla researched

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/fragments/research_details.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/research_details.html
@@ -11,7 +11,11 @@
     </div>
     <span class="body-small xsmall:tw-hidden medium:tw-inline"> | </span>
     <div class="mozilla-researched d-flex pb-2 tw-flex-2 medium:tw-px-2 ">
-      <a class="body-small time-researched" href="/privacynotincluded/about/methodology"> {% trans "Mozilla researched" context "This string is followed by a numerical value, to show the hours spent researching the product." %} </a>  <span class="body-small pl-1"> {{ time_researched }} {% trans "hours" %}</span>
+      {% blocktrans count count=time_researched with link_attrs='class="body-small time-researched" href="/privacynotincluded/about/methodology"' span_attrs='class="body-small pl-1"' trimmed %}
+        <a {{ link_attrs }}>Mozilla researched</a> <span {{ span_attrs }}>{{ time_researched }} hour</span>
+      {% plural %}
+        <a {{ link_attrs }}>Mozilla researched</a> <span {{ span_attrs }}>{{ time_researched }} hours</span>
+      {% endblocktrans %}
     </div>
   </div>
   <span class="body-small xsmall:tw-hidden large:tw-inline"> | </span>

--- a/network-api/networkapi/wagtailpages/templates/fragments/research_details.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/research_details.html
@@ -11,11 +11,13 @@
     </div>
     <span class="body-small xsmall:tw-hidden medium:tw-inline"> | </span>
     <div class="mozilla-researched d-flex pb-2 tw-flex-2 medium:tw-px-2 ">
-      {% blocktrans count count=time_researched with link_attrs='class="body-small time-researched" href="/privacynotincluded/about/methodology"' span_attrs='class="body-small pl-1"' trimmed %}
-        <a {{ link_attrs }}>Mozilla researched</a> <span {{ span_attrs }}>{{ time_researched }} hour</span>
-      {% plural %}
-        <a {{ link_attrs }}>Mozilla researched</a> <span {{ span_attrs }}>{{ time_researched }} hours</span>
-      {% endblocktrans %}
+      <span class="body-small">
+        {% blocktrans count count=time_researched with link_attrs='class="body-small time-researched" href="/privacynotincluded/about/methodology"' trimmed %}
+          <a {{ link_attrs }}>Mozilla researched</a> {{ time_researched }} hour
+        {% plural %}
+          <a {{ link_attrs }}>Mozilla researched</a> {{ time_researched }} hours
+        {% endblocktrans %}
+      </span>
     </div>
   </div>
   <span class="body-small xsmall:tw-hidden large:tw-inline"> | </span>


### PR DESCRIPTION
Hey @danielfmiranda, the localization approach in #7539 needed some changes to:
- Support plural forms on "hour"
- Allow localizers to move the link/the number of hours around in the sentence

Also now that all the context in included in one single string, I’ve removed the localization note.

However, this approach creates some styling issues when you move things around, e.g. in French with
`Mozilla a effectué <span %(span_attrs)s>%(time_researched)s heures</span> de <a %(link_attrs)s>recherches</a>`

in particular spaces added with CSS
<img width="623" alt="Capture d’écran 2021-10-04 à 12 24 14" src="https://user-images.githubusercontent.com/1294206/135835283-6bbe513f-ffc4-448b-ac71-16466963ffc4.png">

Could you have a look please?

Feel free to merge this PR into your branch, or use this branch as a follow up.