### PR TITLE
Add character limit widget to blog titles & homepage headline

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -19,6 +19,7 @@ from .mixin.foundation_metadata import FoundationMetadataPageMixin
 
 # TODO:  https://github.com/mozilla/foundation.mozilla.org/issues/2362
 from ..donation_modal import DonationModals  # noqa: F401
+from ..utils import TitleWidget
 
 
 class NewsPage(PrimaryPage):
@@ -759,7 +760,10 @@ class Homepage(FoundationMetadataPageMixin, Page):
     content_panels = Page.content_panels + [
         MultiFieldPanel(
           [
-            FieldPanel('hero_headline'),
+            FieldPanel(
+                'hero_headline',
+                widget=TitleWidget(attrs={"class": "max-length-warning", "data-max-length": 60})
+                ),
             FieldPanel('hero_button_text'),
             FieldPanel('hero_button_url'),
             ImageChooserPanel('hero_image'),

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
@@ -27,7 +27,8 @@ from ..mixin.foundation_metadata import FoundationMetadataPageMixin
 
 from ...utils import (
     set_main_site_nav_information,
-    get_content_related_by_tag
+    get_content_related_by_tag,
+    TitleWidget
 )
 
 from .blog_category import BlogPageCategory
@@ -142,7 +143,12 @@ class BlogPage(FoundationMetadataPageMixin, Page):
 
     related_post_count = 3
 
-    content_panels = Page.content_panels + [
+    content_panels = [
+        FieldPanel(
+            'title',
+            classname='full title',
+            widget=TitleWidget(attrs={"class": "max-length-warning", "data-max-length": 60})
+        ),
         MultiFieldPanel(
             [
                 InlinePanel('authors', label='Author', min_num=1)


### PR DESCRIPTION
Closes #7560, but in reality, addresses #4984

- [x] Edit the "Title" field on a blog page, the widget should appear and turn red when adding more than 60 characters.
Can be tested on https://foundation-s-blog-title-cltt2f.herokuapp.com/cms/pages/13/edit/
<img width="1643" alt="Capture d’écran 2021-10-05 à 13 56 44" src="https://user-images.githubusercontent.com/1294206/136020932-b174bff1-776e-4464-87ce-cfc3c399d1de.png">

- [x] Edit the "Hero headline" field on the homepage, the widget should appear and turn red when adding more than 60 characters.
Can be tested on https://foundation-s-blog-title-cltt2f.herokuapp.com/cms/pages/3/edit/
<img width="1356" alt="Capture d’écran 2021-10-05 à 14 07 10" src="https://user-images.githubusercontent.com/1294206/136020963-469bde3a-ec25-4b52-b654-75f9bb698e47.png">
