### PR TITLE
Localize category bubble

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
@@ -54,7 +54,7 @@
             {% with category=cat.category %}
               {% localizedroutablepageurl home_page 'category-view' category.slug as cat_url %}
               <a href="{{cat_url}}" class="tw-no-underline tw-text-gray-60 border tw-border-gray-20 tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3]">
-                {{category.name}}
+                {{category.localized.name}}
               </a>
             {% endwith %}
           {% endfor %}


### PR DESCRIPTION
Related issue: #7374

Noticed the category name in the bubble was appearing in English, it was just a `.localized` missing

<img width="309" alt="Capture d’écran 2021-10-05 à 19 48 49" src="https://user-images.githubusercontent.com/1294206/136076816-504f1107-8ce8-4b55-a030-c9ba07b71e37.png">
