### PR TITLE
improve the copy script to automatically find the right container names

### DIFF
--- a/copy-db.js
+++ b/copy-db.js
@@ -22,28 +22,61 @@ const DUMP_FILE = `${ROLE}.db.archive`;
 const DB_FLAGS = `-hpostgres -Ufoundation`;
 
 /**
- * ...
+ * Exec a command and return its output as plain string
  */
 function run(cmd, ignoreThrows = false, opts = {}) {
   try {
-    return execSync(cmd, opts);
+    return execSync(cmd, opts).toString();
   } catch (e) {
     if (ignoreThrows) return e.toString();
-    throw e;
+    process.exit(1);
   }
 }
 
 /**
- * ...
+ * Run a command in the postgres docker container
  */
-function docker(cmd, ignoreThrows = false) {
-  cmd = `docker exec foundationmozillaorg_postgres_1 ${cmd}`;
+function postgres(cmd, ignoreThrows = false) {
+  cmd = `docker exec ${IMAGE_NAMES.POSTGRES} ${cmd}`;
   return run(cmd, ignoreThrows);
 }
 
+function getContainerNames() {
+  return run(`docker ps`)
+    .split(`\n`)
+    .map((v) => v.match(/\s(\S+)$/g))
+    .filter(Boolean)
+    .map((v) => v[0].trim())
+    .reduce((a, v) => {
+      if (!v) return a;
+      if (v.includes(`backend`)) a.BACKEND = v;
+      if (v.includes(`postgres`)) a.POSTGRES = v;
+      return a;
+    }, {});
+}
+
+function stopContainers() {
+  const IMAGE_NAMES = getContainerNames();
+
+  const backend = IMAGE_NAMES.BACKEND;
+  if (backend) {
+    console.log(`Stopping ${backend}`);
+    run(`docker stop ${backend}`, true, silent);
+  }
+
+  const postgres = IMAGE_NAMES.POSTGRES;
+  if (postgres) {
+    console.log(`Stopping ${postgres}`);
+    run(`docker stop ${postgres}`, true, silent);
+  }
+}
+
+// ======================== //
+//  Our script starts here  //
+// ======================== //
+
 console.log(`Making sure no docker containers are running...`);
-run(`docker-compose down`, true, silent);
-run(`docker-compose down`, true, silent);
+stopContainers();
 
 console.log(`Starting postgres docker image...`);
 run(`docker-compose up -d postgres`, true, silent);
@@ -51,28 +84,31 @@ run(`docker-compose up -d postgres`, true, silent);
 console.log(`Starting backend docker image...`);
 run(`docker-compose up -d backend`, true, silent);
 
+console.log(`Getting running image names...`);
+const IMAGE_NAMES = getContainerNames();
+
 console.log(`Downloading ${APP} database (this may take a while)...`);
 if (!fs.existsSync(DUMP_FILE)) {
-  docker(`pg_dump -F c ${DATABASE_URL} > ${DUMP_FILE}`);
+  postgres(`pg_dump -F c ${DATABASE_URL} > ${DUMP_FILE}`);
 }
 
 console.log(`Resetting db...`);
-docker(`dropdb ${DB_FLAGS} --if-exists wagtail`);
-docker(`createdb ${DB_FLAGS} wagtail`);
+postgres(`dropdb ${DB_FLAGS} --if-exists wagtail --force`);
+postgres(`createdb ${DB_FLAGS} wagtail`);
 
 console.log(`Building user roles...`);
 [ROLE, `datastudio`, `datagrip-cade`].forEach((role) =>
-  docker(`createuser ${DB_FLAGS} -s ${role}`, true)
+  postgres(`createuser ${DB_FLAGS} -s ${role}`, true)
 );
 
 console.log(`Importing snapshot...`);
-run(`docker cp ${DUMP_FILE} foundationmozillaorg_postgres_1:/`);
-docker(`pg_restore ${DB_FLAGS} -dwagtail ${DUMP_FILE}`);
+run(`docker cp ${DUMP_FILE} ${IMAGE_NAMES.POSTGRES}:/`);
+postgres(`pg_restore ${DB_FLAGS} -dwagtail ${DUMP_FILE}`);
 
 console.log(`Creating admin:admin superuser account...`);
 run(
   [
-    `docker exec foundationmozillaorg_backend_1`,
+    `docker exec ${IMAGE_NAMES.BACKEND}`,
     `./dockerpythonvenv/bin/python network-api/manage.py shell -c`,
     `"from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@example.com', 'admin')"`,
   ].join(` `),


### PR DESCRIPTION
No associated issue, this makes the copy script look for the container names based on `docker ps`, so it no longer has any hardcoded container names. It also now force-drops the db, so that even if the database is in use (even if it's not, but there's some .lock file somewhere in the postgres docker image) things keep working.