### PR TITLE
Fix/7463 index page seo assignments

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
@@ -171,7 +171,7 @@ class BlogIndexPage(IndexPage):
 
         return entries
 
-    def set_seo_fields_from_category(self, category: BlogPageCategory) -> None:
+    def set_seo_fields_from_category(self, category):
         if category.title:
             setattr(self, 'seo_title', category.title)
         elif category.name:


### PR DESCRIPTION
Closes https://github.com/mozilla/foundation.mozilla.org/issues/7463

**Link to sample test page - note view source**: view-source:https://foundation-s-fix-7463-i-clm4nc.mofostaging.net/en/blog/category/mozilla-festival/

View page source link above, category info still show in HTML header meta
