### PR TITLE
load search when the page loads, rather than when react is done

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -25,6 +25,7 @@ const sources = {
   "callpower": `foundation/pages/callpower.js`,
   "directory-listing-filters": `foundation/pages/directory-listing-filters.js`,
   "bg-main": `buyers-guide/bg-main.js`,
+  "bg-search": `buyers-guide/search.js`,
   polyfills: `polyfills.js`,
 };
 

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
@@ -1,6 +1,11 @@
 {% extends "buyersguide/bg_base.html" %}
 
-{% load env i18n static wagtailimages_tags cache bg_nav_tags %}
+{% load static env i18n static wagtailimages_tags cache bg_nav_tags %}
+
+{% block additional_head_elements %}
+  {{ block.super }}
+  <script src="{% static "_js/bg-search.compiled.js" %}" async defer></script>
+{% endblock %}
 
 {% block bodyclass %}pni catalog{% endblock %}
 

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -13,7 +13,6 @@ import injectMultipageNav from "../foundation/inject-react/multipage-nav.js";
 import primaryNav from "../primary-nav.js";
 
 import HomepageSlider from "./homepage-c-slider.js";
-import { SearchFilter, PNIToggle } from "./search.js";
 import AnalyticsEvents from "./analytics-events.js";
 import initializeSentry from "../common/sentry-config.js";
 
@@ -111,8 +110,6 @@ let main = {
   initPageSpecificScript() {
     if (document.querySelector(`body.pni.catalog`)) {
       HomepageSlider.init();
-      SearchFilter.init();
-      PNIToggle.init();
     }
   },
 };

--- a/source/js/buyers-guide/search.js
+++ b/source/js/buyers-guide/search.js
@@ -1,95 +1,123 @@
-const ALL_PRODUCTS = document.querySelectorAll(`figure.product-box`);
-const NO_RESULTS_NOTICE = document.getElementById(
-  `product-filter-no-results-notice`
-);
-const FILTERS = [`company`, `name`, `blurb`, `worst-case`];
-const SORTS = [`name`, `company`, `blurb`];
-const SUBMIT_PRODUCT = document.querySelector(".recommend-product");
-const CREEPINESS_FACE = document.querySelector(".creep-o-meter-information");
-const categoryTitle = document.querySelector(`.category-title`);
-const toggle = document.querySelector(`#product-filter-pni-toggle`);
+/**
+ * ...docs go here...
+ */
+(function setupFilters() {
+  const ALL_PRODUCTS = document.querySelectorAll(`figure.product-box`);
+  const NO_RESULTS_NOTICE = document.getElementById(
+    `product-filter-no-results-notice`
+  );
+  const FILTERS = [`company`, `name`, `blurb`, `worst-case`];
+  const SORTS = [`name`, `company`, `blurb`];
+  const SUBMIT_PRODUCT = document.querySelector(".recommend-product");
+  const CREEPINESS_FACE = document.querySelector(".creep-o-meter-information");
+  const categoryTitle = document.querySelector(`.category-title`);
+  const toggle = document.querySelector(`#product-filter-pni-toggle`);
 
-const SearchFilter = {
-  init: () => {
-    const searchBar = document.querySelector(`#product-filter-search`);
+  const SearchFilter = {
+    init: () => {
+      const searchBar = document.querySelector(`#product-filter-search`);
 
-    if (!searchBar) {
-      return console.warn(
-        `Could not find the PNI search bar. Search will not be available.`
-      );
-    }
-
-    const searchInput = (SearchFilter.searchInput =
-      searchBar.querySelector(`input`));
-
-    searchInput.addEventListener(`input`, (evt) => {
-      const searchText = searchInput.value.trim();
-
-      if (searchText) {
-        searchBar.classList.add(`has-content`);
-
-        SearchFilter.filter(searchText);
+      if (!searchBar) {
+        return console.warn(
+          `Could not find the PNI search bar. Search will not be available.`
+        );
       }
-    });
 
-    const clear = searchBar.querySelector(`.clear-icon`);
-    if (!clear) {
-      return console.warn(
-        `Could not find the PNI search input clear icon. Search will work, but clearing will not.`
-      );
-    }
+      const searchInput = (SearchFilter.searchInput =
+        searchBar.querySelector(`input`));
 
-    const clearText = () => {
-      searchBar.classList.remove(`has-content`);
-      searchInput.value = ``;
-      searchInput.focus();
-      ALL_PRODUCTS.forEach((product) => {
-        product.classList.remove(`d-none`);
-        product.classList.add(`d-flex`);
+      searchInput.addEventListener(`input`, (evt) => {
+        const searchText = searchInput.value.trim();
+
+        if (searchText) {
+          searchBar.classList.add(`has-content`);
+
+          SearchFilter.filter(searchText);
+        }
       });
 
-      history.replaceState(
-        {
-          ...history.state,
-          search: "",
-        },
-        SearchFilter.getTitle(categoryTitle.value.trim()),
-        location.href
-      );
+      const clear = searchBar.querySelector(`.clear-icon`);
+      if (!clear) {
+        return console.warn(
+          `Could not find the PNI search input clear icon. Search will work, but clearing will not.`
+        );
+      }
 
-      SearchFilter.sortOnCreepiness();
-      SearchFilter.moveCreepyFace();
-    };
+      const clearText = () => {
+        searchBar.classList.remove(`has-content`);
+        searchInput.value = ``;
+        searchInput.focus();
+        ALL_PRODUCTS.forEach((product) => {
+          product.classList.remove(`d-none`);
+          product.classList.add(`d-flex`);
+        });
 
-    clear.addEventListener(`click`, (evt) => {
-      evt.preventDefault();
-      clearText();
-    });
+        history.replaceState(
+          {
+            ...history.state,
+            search: "",
+          },
+          SearchFilter.getTitle(categoryTitle.value.trim()),
+          location.href
+        );
 
-    const navLinks = document.querySelectorAll(`#multipage-nav a`);
+        SearchFilter.sortOnCreepiness();
+        SearchFilter.moveCreepyFace();
+      };
 
-    for (const nav of navLinks) {
-      nav.addEventListener("click", (evt) => {
-        evt.stopPropagation();
-
-        if (evt.shiftKey || evt.metaKey || evt.ctrlKey || evt.altKey) {
-          return;
-        }
-
+      clear.addEventListener(`click`, (evt) => {
         evt.preventDefault();
+        clearText();
+      });
 
-        document
-          .querySelector(`#multipage-nav a.active`)
-          .classList.remove(`active`);
+      const navLinks = document.querySelectorAll(`#multipage-nav a`);
 
-        evt.target.classList.add(`active`);
+      for (const nav of navLinks) {
+        nav.addEventListener("click", (evt) => {
+          evt.stopPropagation();
 
-        if (evt.target.dataset.name) {
+          if (evt.shiftKey || evt.metaKey || evt.ctrlKey || evt.altKey) {
+            return;
+          }
+
+          evt.preventDefault();
+
+          document
+            .querySelector(`#multipage-nav a.active`)
+            .classList.remove(`active`);
+
+          evt.target.classList.add(`active`);
+
+          if (evt.target.dataset.name) {
+            clearText();
+            history.pushState(
+              {
+                title: SearchFilter.getTitle(evt.target.dataset.name),
+                category: evt.target.dataset.name,
+                search: "",
+                filter: history.state.filter,
+              },
+              SearchFilter.getTitle(evt.target.dataset.name),
+              evt.target.href
+            );
+
+            document.title = SearchFilter.getTitle(evt.target.dataset.name);
+            SearchFilter.filterCategory(evt.target.dataset.name);
+          }
+        });
+      }
+
+      document
+        .querySelector(`.go-back-to-all-link`)
+        .addEventListener("click", (evt) => {
+          evt.stopPropagation();
+          evt.preventDefault();
+
           clearText();
           history.pushState(
             {
-              title: SearchFilter.getTitle(evt.target.dataset.name),
-              category: evt.target.dataset.name,
+              title: SearchFilter.getTitle("None"),
+              category: "None",
               search: "",
               filter: history.state.filter,
             },
@@ -97,66 +125,73 @@ const SearchFilter = {
             evt.target.href
           );
 
-          document.title = SearchFilter.getTitle(evt.target.dataset.name);
-          SearchFilter.filterCategory(evt.target.dataset.name);
+          document
+            .querySelector(`#multipage-nav a.active`)
+            .classList.remove(`active`);
+
+          document
+            .querySelector(`#multipage-nav a[data-name="None"]`)
+            .classList.add(`active`);
+
+          SearchFilter.filterCategory("None");
+        });
+
+      window.addEventListener(`popstate`, (event) => {
+        const { state } = event;
+        if (!state) return; // if it's a "real" back, we shouldn't need to do anything
+
+        const { title, category } = state;
+        document.title = title;
+
+        if (!history.state.search) {
+          SearchFilter.clearCategories();
+          SearchFilter.filterCategory(category);
+          searchBar.classList.remove(`has-content`);
+          searchInput.value = ``;
+
+          document
+            .querySelector(`#multipage-nav a.active`)
+            .classList.remove(`active`);
+
+          document
+            .querySelector(`#multipage-nav a[data-name="${category}"]`)
+            .classList.add(`active`);
+        } else {
+          SearchFilter.filterCategory(category);
+          searchBar.classList.add(`has-content`);
+          searchInput.value = history.state.search;
+          SearchFilter.filter(history.state.search);
+        }
+
+        if (history.state.filter) {
+          toggle.checked = history.state.filter;
+
+          if (history.state.filter) {
+            document.body.classList.add(`show-ding-only`);
+          } else {
+            document.body.classList.remove(`show-ding-only`);
+          }
         }
       });
-    }
 
-    document
-      .querySelector(`.go-back-to-all-link`)
-      .addEventListener("click", (evt) => {
-        evt.stopPropagation();
-        evt.preventDefault();
+      history.replaceState(
+        {
+          title: SearchFilter.getTitle(categoryTitle.value.trim()),
+          category: categoryTitle.value.trim(),
+          search: history.state.search || "",
+          filter: history.state.filter,
+        },
+        SearchFilter.getTitle(categoryTitle.value.trim()),
+        location.href
+      );
 
-        clearText();
-        history.pushState(
-          {
-            title: SearchFilter.getTitle("None"),
-            category: "None",
-            search: "",
-            filter: history.state.filter,
-          },
-          SearchFilter.getTitle(evt.target.dataset.name),
-          evt.target.href
-        );
-
-        document
-          .querySelector(`#multipage-nav a.active`)
-          .classList.remove(`active`);
-
-        document
-          .querySelector(`#multipage-nav a[data-name="None"]`)
-          .classList.add(`active`);
-
-        SearchFilter.filterCategory("None");
-      });
-
-    window.addEventListener(`popstate`, (event) => {
-      const { state } = event;
-      if (!state) return; // if it's a "real" back, we shouldn't need to do anything
-
-      const { title, category } = state;
-      document.title = title;
-
-      if (!history.state.search) {
-        SearchFilter.clearCategories();
-        SearchFilter.filterCategory(category);
-        searchBar.classList.remove(`has-content`);
-        searchInput.value = ``;
-
-        document
-          .querySelector(`#multipage-nav a.active`)
-          .classList.remove(`active`);
-
-        document
-          .querySelector(`#multipage-nav a[data-name="${category}"]`)
-          .classList.add(`active`);
-      } else {
-        SearchFilter.filterCategory(category);
+      if (history.state.search) {
         searchBar.classList.add(`has-content`);
         searchInput.value = history.state.search;
         SearchFilter.filter(history.state.search);
+      } else {
+        searchBar.classList.remove(`has-content`);
+        searchInput.value = ``;
       }
 
       if (history.state.filter) {
@@ -168,246 +203,218 @@ const SearchFilter = {
           document.body.classList.remove(`show-ding-only`);
         }
       }
-    });
+    },
 
-    history.replaceState(
-      {
-        title: SearchFilter.getTitle(categoryTitle.value.trim()),
-        category: categoryTitle.value.trim(),
-        search: history.state.search || "",
-        filter: history.state.filter,
-      },
-      SearchFilter.getTitle(categoryTitle.value.trim()),
-      location.href
-    );
+    clearCategories: () => {
+      SearchFilter.filterCategory("None");
 
-    if (history.state.search) {
-      searchBar.classList.add(`has-content`);
-      searchInput.value = history.state.search;
-      SearchFilter.filter(history.state.search);
-    } else {
-      searchBar.classList.remove(`has-content`);
-      searchInput.value = ``;
-    }
+      document
+        .querySelector(`#multipage-nav a.active`)
+        .classList.remove(`active`);
+      document
+        .querySelector(`#multipage-nav a[data-name="None"]`)
+        .classList.add(`active`);
+    },
 
-    if (history.state.filter) {
-      toggle.checked = history.state.filter;
-
-      if (history.state.filter) {
-        document.body.classList.add(`show-ding-only`);
-      } else {
-        document.body.classList.remove(`show-ding-only`);
+    getTitle: (category) => {
+      if (category == "None")
+        return document.querySelector('meta[name="pni-home-title"]').content;
+      else {
+        return `${category} | ${
+          document.querySelector('meta[name="pni-category-title"]').content
+        }`;
       }
-    }
-  },
+    },
 
-  clearCategories: () => {
-    SearchFilter.filterCategory("None");
-
-    document
-      .querySelector(`#multipage-nav a.active`)
-      .classList.remove(`active`);
-    document
-      .querySelector(`#multipage-nav a[data-name="None"]`)
-      .classList.add(`active`);
-  },
-
-  getTitle: (category) => {
-    if (category == "None")
-      return document.querySelector('meta[name="pni-home-title"]').content;
-    else {
-      return `${category} | ${
-        document.querySelector('meta[name="pni-category-title"]').content
-      }`;
-    }
-  },
-
-  moveCreepyFace: () => {
-    // When searching, check to see how many products are still visible
-    // If there are no visible products, there are "no search results"
-    // And when there are no search results, do not show the creepo-meter-face
-    if (document.querySelectorAll(".product-box:not(.d-none)").length) {
-      // If there are search results, show the creepo-meter-face
-      CREEPINESS_FACE.classList.remove("d-none");
-    } else {
-      // If there are no search results, hide the creepo-meter-face
-      CREEPINESS_FACE.classList.add("d-none");
-    }
-  },
-
-  filter: (text) => {
-    // remove category filters
-    SearchFilter.clearCategories();
-
-    document
-      .querySelector(`#multipage-nav a.active`)
-      .classList.remove(`active`);
-    document
-      .querySelector(`#multipage-nav a[data-name="None"]`)
-      .classList.add(`active`);
-
-    ALL_PRODUCTS.forEach((product) => {
-      if (SearchFilter.test(product, text)) {
-        product.classList.remove(`d-none`);
-        product.classList.add(`d-flex`);
+    moveCreepyFace: () => {
+      // When searching, check to see how many products are still visible
+      // If there are no visible products, there are "no search results"
+      // And when there are no search results, do not show the creepo-meter-face
+      if (document.querySelectorAll(".product-box:not(.d-none)").length) {
+        // If there are search results, show the creepo-meter-face
+        CREEPINESS_FACE.classList.remove("d-none");
       } else {
-        product.classList.add(`d-none`);
-        product.classList.remove(`d-flex`);
+        // If there are no search results, hide the creepo-meter-face
+        CREEPINESS_FACE.classList.add("d-none");
       }
-    });
+    },
 
-    history.replaceState(
-      {
-        ...history.state,
-        search: text,
-      },
-      SearchFilter.getTitle(categoryTitle.value.trim()),
-      location.href
-    );
+    filter: (text) => {
+      // remove category filters
+      SearchFilter.clearCategories();
 
-    SearchFilter.sortProducts();
+      document
+        .querySelector(`#multipage-nav a.active`)
+        .classList.remove(`active`);
+      document
+        .querySelector(`#multipage-nav a[data-name="None"]`)
+        .classList.add(`active`);
 
-    SearchFilter.moveCreepyFace();
-    SearchFilter.checkForEmptyNotice();
-  },
-
-  sortProducts: () => {
-    const container = document.querySelector(`.product-box-list`);
-    const list = [...container.querySelectorAll(`.product-box`)];
-
-    list.sort((a, b) => {
-      for (field of SORTS) {
-        const qs = `.product-${field}`;
-        const [propertyA, propertyB] = [
-          a.querySelector(qs),
-          b.querySelector(qs),
-        ];
-        const [propertyNameA, propertyNameB] = [
-          (propertyA.value || propertyA.textContent).toLowerCase(),
-          (propertyB.value || propertyB.textContent).toLowerCase(),
-        ];
-
-        if (
-          propertyNameA !== propertyNameB ||
-          field === SORTS[SORTS.length - 1]
-        ) {
-          return propertyNameA < propertyNameB
-            ? -1
-            : propertyNameA > propertyNameB
-            ? 1
-            : 0;
+      ALL_PRODUCTS.forEach((product) => {
+        if (SearchFilter.test(product, text)) {
+          product.classList.remove(`d-none`);
+          product.classList.add(`d-flex`);
+        } else {
+          product.classList.add(`d-none`);
+          product.classList.remove(`d-flex`);
         }
-      }
-    });
-
-    list.forEach((p) => container.append(p));
-  },
-
-  sortOnCreepiness: () => {
-    const container = document.querySelector(`.product-box-list`);
-    const list = [...container.querySelectorAll(`.product-box`)];
-    const creepVal = (e) => parseFloat(e.dataset.creepiness);
-    list
-      .sort((a, b) => creepVal(a) - creepVal(b))
-      .forEach((p) => container.append(p));
-  },
-
-  filterCategory: (category) => {
-    ALL_PRODUCTS.forEach((product) => {
-      if (SearchFilter.testCategories(product, category)) {
-        product.classList.remove(`d-none`);
-        product.classList.add(`d-flex`);
-      } else {
-        product.classList.add(`d-none`);
-        product.classList.remove(`d-flex`);
-      }
-    });
-
-    categoryTitle.value = category;
-    SearchFilter.sortOnCreepiness();
-    SearchFilter.moveCreepyFace();
-    SearchFilter.checkForEmptyNotice();
-  },
-
-  checkForEmptyNotice: () => {
-    let qs = `figure.product-box:not(.d-none)`;
-
-    if (document.body.classList.contains(`show-ding-only`)) {
-      qs = `${qs}.privacy-ding`;
-    }
-
-    const results = document.querySelectorAll(qs);
-    const count = results.length;
-    if (count === 0) {
-      NO_RESULTS_NOTICE.classList.remove(`d-none`);
-      SUBMIT_PRODUCT.classList.add("d-none");
-    } else {
-      NO_RESULTS_NOTICE.classList.add(`d-none`);
-      SUBMIT_PRODUCT.classList.remove("d-none");
-    }
-  },
-
-  test: (product, text) => {
-    text = text.toLowerCase(); // Note that this is absolutely not true for all languages, but it's true for us.
-    let qs, data, field;
-
-    for (field of FILTERS) {
-      qs = `.product-${field}`;
-      data = product.querySelector(qs);
-      data = (data.value || data.textContent).toLowerCase();
-      if (data.indexOf(text) !== -1) {
-        return true;
-      }
-    }
-
-    return false;
-  },
-
-  testCategories: (product, category) => {
-    if (category === "None") {
-      return true;
-    }
-
-    const productCategories = Array.from(
-      product.querySelectorAll(".product-categories")
-    );
-
-    return productCategories.map((c) => c.value.trim()).includes(category);
-  },
-};
-
-const PNIToggle = {
-  init: () => {
-    if (!toggle) {
-      return console.warn(
-        `Could not find the PNI filter checkbox. PNI filtering will not be available.`
-      );
-    }
-
-    toggle.addEventListener(`change`, (evt) => {
-      const filter = evt.target.checked;
+      });
 
       history.replaceState(
         {
           ...history.state,
-          filter,
+          search: text,
         },
         SearchFilter.getTitle(categoryTitle.value.trim()),
         location.href
       );
 
-      if (filter) {
-        document.body.classList.add(`show-ding-only`);
+      SearchFilter.sortProducts();
+
+      SearchFilter.moveCreepyFace();
+      SearchFilter.checkForEmptyNotice();
+    },
+
+    sortProducts: () => {
+      const container = document.querySelector(`.product-box-list`);
+      const list = [...container.querySelectorAll(`.product-box`)];
+
+      list.sort((a, b) => {
+        for (field of SORTS) {
+          const qs = `.product-${field}`;
+          const [propertyA, propertyB] = [
+            a.querySelector(qs),
+            b.querySelector(qs),
+          ];
+          const [propertyNameA, propertyNameB] = [
+            (propertyA.value || propertyA.textContent).toLowerCase(),
+            (propertyB.value || propertyB.textContent).toLowerCase(),
+          ];
+
+          if (
+            propertyNameA !== propertyNameB ||
+            field === SORTS[SORTS.length - 1]
+          ) {
+            return propertyNameA < propertyNameB
+              ? -1
+              : propertyNameA > propertyNameB
+              ? 1
+              : 0;
+          }
+        }
+      });
+
+      list.forEach((p) => container.append(p));
+    },
+
+    sortOnCreepiness: () => {
+      const container = document.querySelector(`.product-box-list`);
+      const list = [...container.querySelectorAll(`.product-box`)];
+      const creepVal = (e) => parseFloat(e.dataset.creepiness);
+      list
+        .sort((a, b) => creepVal(a) - creepVal(b))
+        .forEach((p) => container.append(p));
+    },
+
+    filterCategory: (category) => {
+      ALL_PRODUCTS.forEach((product) => {
+        if (SearchFilter.testCategories(product, category)) {
+          product.classList.remove(`d-none`);
+          product.classList.add(`d-flex`);
+        } else {
+          product.classList.add(`d-none`);
+          product.classList.remove(`d-flex`);
+        }
+      });
+
+      categoryTitle.value = category;
+      SearchFilter.sortOnCreepiness();
+      SearchFilter.moveCreepyFace();
+      SearchFilter.checkForEmptyNotice();
+    },
+
+    checkForEmptyNotice: () => {
+      let qs = `figure.product-box:not(.d-none)`;
+
+      if (document.body.classList.contains(`show-ding-only`)) {
+        qs = `${qs}.privacy-ding`;
+      }
+
+      const results = document.querySelectorAll(qs);
+      const count = results.length;
+      if (count === 0) {
+        NO_RESULTS_NOTICE.classList.remove(`d-none`);
+        SUBMIT_PRODUCT.classList.add("d-none");
       } else {
-        document.body.classList.remove(`show-ding-only`);
+        NO_RESULTS_NOTICE.classList.add(`d-none`);
+        SUBMIT_PRODUCT.classList.remove("d-none");
+      }
+    },
+
+    test: (product, text) => {
+      text = text.toLowerCase(); // Note that this is absolutely not true for all languages, but it's true for us.
+      let qs, data, field;
+
+      for (field of FILTERS) {
+        qs = `.product-${field}`;
+        data = product.querySelector(qs);
+        data = (data.value || data.textContent).toLowerCase();
+        if (data.indexOf(text) !== -1) {
+          return true;
+        }
       }
 
-      if (SearchFilter.searchInput.value.trim()) {
-        SearchFilter.searchInput.focus();
-        SearchFilter.checkForEmptyNotice();
-      }
-    });
-  },
-};
+      return false;
+    },
 
-export { SearchFilter, PNIToggle };
+    testCategories: (product, category) => {
+      if (category === "None") {
+        return true;
+      }
+
+      const productCategories = Array.from(
+        product.querySelectorAll(".product-categories")
+      );
+
+      return productCategories.map((c) => c.value.trim()).includes(category);
+    },
+  };
+
+  const PNIToggle = {
+    init: () => {
+      if (!toggle) {
+        return console.warn(
+          `Could not find the PNI filter checkbox. PNI filtering will not be available.`
+        );
+      }
+
+      toggle.addEventListener(`change`, (evt) => {
+        const filter = evt.target.checked;
+
+        history.replaceState(
+          {
+            ...history.state,
+            filter,
+          },
+          SearchFilter.getTitle(categoryTitle.value.trim()),
+          location.href
+        );
+
+        if (filter) {
+          document.body.classList.add(`show-ding-only`);
+        } else {
+          document.body.classList.remove(`show-ding-only`);
+        }
+
+        if (SearchFilter.searchInput.value.trim()) {
+          SearchFilter.searchInput.focus();
+          SearchFilter.checkForEmptyNotice();
+        }
+      });
+    },
+  };
+
+  // bootstrap both searching and privacy-ding-filtering
+  SearchFilter.init();
+  PNIToggle.init();
+})();


### PR DESCRIPTION
Closes #7667

This updates the build so that search.js ends up as "its own file" in the frontend/js dir, getting loaded as part of the `<head>` payload for catalog pages (PNI homepage + category pages) with `async defer` so that it can be used as soon as the page DOM is ready for reading.

Note that you'll want to hide whitespace for reviewing file changes in this case: https://github.com/mozilla/foundation.mozilla.org/pull/7709/files?diff=unified&w=1

Also note that this will need a "redo" for the search.js file itself, once #7649 has landed.

Test URL: https://foundation-s-externaliz-0hxqyx.herokuapp.com/en/privacynotincluded/