### PR TITLE
Update search timing

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -25,6 +25,7 @@ const sources = {
   "callpower": `foundation/pages/callpower.js`,
   "directory-listing-filters": `foundation/pages/directory-listing-filters.js`,
   "bg-main": `buyers-guide/bg-main.js`,
+  "bg-search": `buyers-guide/search.js`,
   polyfills: `polyfills.js`,
 };
 

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
@@ -1,6 +1,11 @@
 {% extends "buyersguide/bg_base.html" %}
 
-{% load env i18n static wagtailimages_tags cache bg_nav_tags localization %}
+{% load static env i18n static wagtailimages_tags cache bg_nav_tags localization %}
+
+{% block additional_head_elements %}
+  {{ block.super }}
+  <script src="{% static "_js/bg-search.compiled.js" %}" async defer></script>
+{% endblock %}
 
 {% block bodyclass %}pni catalog{% endblock %}
 
@@ -53,11 +58,11 @@
             <span class="current-creepiness"></span>
           </span>
 
-          
+
         </div>
       </div>
       <div class="col-12 tw-mb-4 tw-px-0 tw-flex tw-items-end">
-        <a 
+        <a
          href="{% if current_category.parent %}{% localizedroutablepageurl home_page 'category-view' current_category.parent.slug  %}{% elif current_category %}{% localizedroutablepageurl home_page 'category-view' current_category.slug  %}{% else %}{% relocalized_url home_page.localized.url %}{% endif %}"
          data-name="{% if current_category.parent %}{{ current_category.parent.name }}{% elif current_category %}{{current_category.name}}{% else %}None{% endif %}"
          class="tw-capitalize tw-text-5xl tw-font-zilla category-header tw-mb-2 tw-text-black hover:tw-text-pni-blue tw-no-underline tw-cursor-pointer"
@@ -78,7 +83,7 @@
           <label for="product-filter-pni-toggle">{% trans "*privacy not included" %} </label>
         </span>
       </div>
-      
+
     </div>
     <div class="row px-0 tw-mb-4">
       <div class="tw-w-full">

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -13,7 +13,6 @@ import injectMultipageNav from "../foundation/inject-react/multipage-nav.js";
 import primaryNav from "../primary-nav.js";
 
 import HomepageSlider from "./homepage-c-slider.js";
-import { SearchFilter, PNIToggle } from "./search.js";
 import AnalyticsEvents from "./analytics-events.js";
 import initializeSentry from "../common/sentry-config.js";
 
@@ -111,8 +110,6 @@ let main = {
   initPageSpecificScript() {
     if (document.querySelector(`body.pni.catalog`)) {
       HomepageSlider.init();
-      SearchFilter.init();
-      PNIToggle.init();
     }
   },
 };

--- a/source/js/buyers-guide/search.js
+++ b/source/js/buyers-guide/search.js
@@ -1,104 +1,195 @@
-const ALL_PRODUCTS = document.querySelectorAll(`figure.product-box`);
-const NO_RESULTS_NOTICE = document.getElementById(
-  `product-filter-no-results-notice`
-);
-const FILTERS = [`company`, `name`, `blurb`, `worst-case`];
-const SORTS = [`name`, `company`, `blurb`];
-const SUBMIT_PRODUCT = document.querySelector(".recommend-product");
-const CREEPINESS_FACE = document.querySelector(".creep-o-meter-information");
-const categoryTitle = document.querySelector(`.category-title`);
-const parentTitle = document.querySelector(`.parent-title`);
-const toggle = document.querySelector(`#product-filter-pni-toggle`);
-const subcategories = document.querySelectorAll(`.subcategories`);
+/**
+ * Set up PNI search functionality, as well as the PNI "ding" toggle.
+ */
+(function setupFilters() {
 
-const SearchFilter = {
-  init: () => {
-    const searchBar = document.querySelector(`#product-filter-search`);
+  // static values used throughout this code
+  const ALL_PRODUCTS = document.querySelectorAll(`figure.product-box`);
+  const NO_RESULTS_NOTICE = document.getElementById(
+    `product-filter-no-results-notice`
+  );
+  const FILTERS = [`company`, `name`, `blurb`, `worst-case`];
+  const SORTS = [`name`, `company`, `blurb`];
+  const SUBMIT_PRODUCT = document.querySelector(".recommend-product");
+  const CREEPINESS_FACE = document.querySelector(".creep-o-meter-information");
+  const categoryTitle = document.querySelector(`.category-title`);
+  const parentTitle = document.querySelector(`.parent-title`);
+  const toggle = document.querySelector(`#product-filter-pni-toggle`);
+  const subcategories = document.querySelectorAll(`.subcategories`);
 
-    if (!searchBar) {
-      return console.warn(
-        `Could not find the PNI search bar. Search will not be available.`
-      );
-    }
+  // TODO: turn this into a static class rather than plain JS object.
+  const SearchFilter = {
+    init: () => {
+      const searchBar = document.querySelector(`#product-filter-search`);
 
-    const searchInput = (SearchFilter.searchInput =
-      searchBar.querySelector(`input`));
-
-    searchInput.addEventListener(`input`, (evt) => {
-      const searchText = searchInput.value.trim();
-
-      if (searchText) {
-        searchBar.classList.add(`has-content`);
-        SearchFilter.filter(searchText);
+      if (!searchBar) {
+        return console.warn(
+          `Could not find the PNI search bar. Search will not be available.`
+        );
       }
-    });
 
-    const clear = searchBar.querySelector(`.clear-icon`);
-    if (!clear) {
-      return console.warn(
-        `Could not find the PNI search input clear icon. Search will work, but clearing will not.`
-      );
-    }
+      const searchInput = (SearchFilter.searchInput =
+        searchBar.querySelector(`input`));
 
-    const clearText = () => {
-      searchBar.classList.remove(`has-content`);
-      searchInput.value = ``;
-      searchInput.focus();
-      ALL_PRODUCTS.forEach((product) => {
-        product.classList.remove(`d-none`);
-        product.classList.add(`d-flex`);
+      searchInput.addEventListener(`input`, (evt) => {
+        const searchText = searchInput.value.trim();
+
+        if (searchText) {
+          searchBar.classList.add(`has-content`);
+          SearchFilter.filter(searchText);
+        }
       });
 
-      history.replaceState(
-        {
-          ...history.state,
-          search: "",
-        },
-        SearchFilter.getTitle(categoryTitle.value.trim()),
-        location.href
+      const clear = searchBar.querySelector(`.clear-icon`);
+      if (!clear) {
+        return console.warn(
+          `Could not find the PNI search input clear icon. Search will work, but clearing will not.`
+        );
+      }
+
+      const clearText = () => {
+        searchBar.classList.remove(`has-content`);
+        searchInput.value = ``;
+        searchInput.focus();
+        ALL_PRODUCTS.forEach((product) => {
+          product.classList.remove(`d-none`);
+          product.classList.add(`d-flex`);
+        });
+
+        history.replaceState(
+          {
+            ...history.state,
+            search: "",
+          },
+          SearchFilter.getTitle(categoryTitle.value.trim()),
+          location.href
+        );
+
+        SearchFilter.sortOnCreepiness();
+        SearchFilter.moveCreepyFace();
+      };
+
+      clear.addEventListener(`click`, (evt) => {
+        evt.preventDefault();
+        SearchFilter.filterSubcategory("None");
+        SearchFilter.updateHeader("None", null);
+        clearText();
+      });
+
+      const navLinks = document.querySelectorAll(
+        `#multipage-nav a,.category-header`
       );
 
-      SearchFilter.sortOnCreepiness();
-      SearchFilter.moveCreepyFace();
-    };
+      for (const nav of navLinks) {
+        nav.addEventListener("click", (evt) => {
+          evt.stopPropagation();
 
-    clear.addEventListener(`click`, (evt) => {
-      evt.preventDefault();
-      SearchFilter.filterSubcategory("None");
-      SearchFilter.updateHeader("None", null);
-      clearText();
-    });
+          if (evt.shiftKey || evt.metaKey || evt.ctrlKey || evt.altKey) {
+            return;
+          }
 
-    const navLinks = document.querySelectorAll(
-      `#multipage-nav a,.category-header`
-    );
+          evt.preventDefault();
 
-    for (const nav of navLinks) {
-      nav.addEventListener("click", (evt) => {
-        evt.stopPropagation();
-
-        if (evt.shiftKey || evt.metaKey || evt.ctrlKey || evt.altKey) {
-          return;
-        }
-
-        evt.preventDefault();
-
-        document
-          .querySelector(`#multipage-nav a.active`)
-          .classList.remove(`active`);
-
-        if (evt.target.dataset.name) {
           document
-            .querySelector(
-              `#multipage-nav a[data-name="${evt.target.dataset.name}"]`
-            )
-            .classList.add(`active`);
+            .querySelector(`#multipage-nav a.active`)
+            .classList.remove(`active`);
+
+          if (evt.target.dataset.name) {
+            document
+              .querySelector(
+                `#multipage-nav a[data-name="${evt.target.dataset.name}"]`
+              )
+              .classList.add(`active`);
+
+            clearText();
+            history.pushState(
+              {
+                title: SearchFilter.getTitle(evt.target.dataset.name),
+                category: evt.target.dataset.name,
+                parent: "",
+                search: "",
+                filter: history.state?.filter,
+              },
+              SearchFilter.getTitle(evt.target.dataset.name),
+              evt.target.href
+            );
+
+            document.title = SearchFilter.getTitle(evt.target.dataset.name);
+            SearchFilter.filterSubcategory(evt.target.dataset.name);
+            SearchFilter.toggleSubcategory(true);
+            SearchFilter.updateHeader(evt.target.dataset.name, "");
+            SearchFilter.filterCategory(evt.target.dataset.name);
+          }
+        });
+      }
+
+      for (const subcategory of subcategories) {
+        subcategory.addEventListener("click", (evt) => {
+          evt.stopPropagation();
+
+          if (evt.shiftKey || evt.metaKey || evt.ctrlKey || evt.altKey) {
+            return;
+          }
+
+          evt.preventDefault();
+
+          let href;
+
+          if (evt.target.dataset.name) {
+            clearText();
+            if (categoryTitle.value.trim() !== evt.target.dataset.name) {
+              categoryTitle.value = evt.target.dataset.name;
+              parentTitle.value = evt.target.dataset.parent;
+              href = evt.target.href;
+              SearchFilter.toggleSubcategory();
+              SearchFilter.highlightParent();
+            } else {
+              categoryTitle.value = evt.target.dataset.parent;
+              parentTitle.value = "";
+              href = document.querySelector(
+                `#multipage-nav a[data-name="${evt.target.dataset.parent}"]`
+              ).href;
+              SearchFilter.toggleSubcategory(true);
+            }
+
+            history.pushState(
+              {
+                title: SearchFilter.getTitle(evt.target.dataset.name),
+                category: categoryTitle.value.trim(),
+                parent: parentTitle.value.trim(),
+                search: "",
+                filter: history.state?.filter,
+              },
+              SearchFilter.getTitle(evt.target.dataset.name),
+              href
+            );
+
+            document.title = SearchFilter.getTitle(categoryTitle.value.trim());
+            SearchFilter.updateHeader(
+              categoryTitle.value.trim(),
+              parentTitle.value.trim()
+            );
+            SearchFilter.filterCategory(categoryTitle.value.trim());
+          }
+        });
+      }
+
+      document
+        .querySelector(`.go-back-to-all-link`)
+        .addEventListener("click", (evt) => {
+          evt.stopPropagation();
+
+          if (evt.shiftKey || evt.metaKey || evt.ctrlKey || evt.altKey) {
+            return;
+          }
+
+          evt.preventDefault();
 
           clearText();
           history.pushState(
             {
-              title: SearchFilter.getTitle(evt.target.dataset.name),
-              category: evt.target.dataset.name,
+              title: SearchFilter.getTitle("None"),
+              category: "None",
               parent: "",
               search: "",
               filter: history.state?.filter,
@@ -107,141 +198,89 @@ const SearchFilter = {
             evt.target.href
           );
 
-          document.title = SearchFilter.getTitle(evt.target.dataset.name);
-          SearchFilter.filterSubcategory(evt.target.dataset.name);
-          SearchFilter.toggleSubcategory(true);
-          SearchFilter.updateHeader(evt.target.dataset.name, "");
-          SearchFilter.filterCategory(evt.target.dataset.name);
-        }
-      });
-    }
-
-    for (const subcategory of subcategories) {
-      subcategory.addEventListener("click", (evt) => {
-        evt.stopPropagation();
-
-        if (evt.shiftKey || evt.metaKey || evt.ctrlKey || evt.altKey) {
-          return;
-        }
-
-        evt.preventDefault();
-
-        let href;
-
-        if (evt.target.dataset.name) {
-          clearText();
-          if (categoryTitle.value.trim() !== evt.target.dataset.name) {
-            categoryTitle.value = evt.target.dataset.name;
-            parentTitle.value = evt.target.dataset.parent;
-            href = evt.target.href;
-            SearchFilter.toggleSubcategory();
-            SearchFilter.highlightParent();
-          } else {
-            categoryTitle.value = evt.target.dataset.parent;
-            parentTitle.value = "";
-            href = document.querySelector(
-              `#multipage-nav a[data-name="${evt.target.dataset.parent}"]`
-            ).href;
-            SearchFilter.toggleSubcategory(true);
-          }
-
-          history.pushState(
-            {
-              title: SearchFilter.getTitle(evt.target.dataset.name),
-              category: categoryTitle.value.trim(),
-              parent: parentTitle.value.trim(),
-              search: "",
-              filter: history.state?.filter,
-            },
-            SearchFilter.getTitle(evt.target.dataset.name),
-            href
-          );
-
-          document.title = SearchFilter.getTitle(categoryTitle.value.trim());
-          SearchFilter.updateHeader(
-            categoryTitle.value.trim(),
-            parentTitle.value.trim()
-          );
-          SearchFilter.filterCategory(categoryTitle.value.trim());
-        }
-      });
-    }
-
-    document
-      .querySelector(`.go-back-to-all-link`)
-      .addEventListener("click", (evt) => {
-        evt.stopPropagation();
-
-        if (evt.shiftKey || evt.metaKey || evt.ctrlKey || evt.altKey) {
-          return;
-        }
-
-        evt.preventDefault();
-
-        clearText();
-        history.pushState(
-          {
-            title: SearchFilter.getTitle("None"),
-            category: "None",
-            parent: "",
-            search: "",
-            filter: history.state?.filter,
-          },
-          SearchFilter.getTitle(evt.target.dataset.name),
-          evt.target.href
-        );
-
-        document
-          .querySelector(`#multipage-nav a.active`)
-          .classList.remove(`active`);
-
-        document
-          .querySelector(`#multipage-nav a[data-name="None"]`)
-          .classList.add(`active`);
-
-        SearchFilter.filterCategory("None");
-        parentTitle.value = "";
-      });
-
-    window.addEventListener(`popstate`, (event) => {
-      const { state } = event;
-      if (!state) return; // if it's a "real" back, we shouldn't need to do anything
-
-      const { title, category, parent } = state;
-      document.title = title;
-
-      if (!history.state?.search) {
-        SearchFilter.clearCategories();
-        categoryTitle.value = category;
-        parentTitle.value = parent;
-
-        searchBar.classList.remove(`has-content`);
-        searchInput.value = ``;
-
-        if (parent) {
-          SearchFilter.highlightParent();
-          SearchFilter.toggleSubcategory();
-        } else {
           document
             .querySelector(`#multipage-nav a.active`)
             .classList.remove(`active`);
 
           document
-            .querySelector(`#multipage-nav a[data-name="${category}"]`)
+            .querySelector(`#multipage-nav a[data-name="None"]`)
             .classList.add(`active`);
 
+          SearchFilter.filterCategory("None");
+          parentTitle.value = "";
+        });
+
+      window.addEventListener(`popstate`, (event) => {
+        const { state } = event;
+        if (!state) return; // if it's a "real" back, we shouldn't need to do anything
+
+        const { title, category, parent } = state;
+        document.title = title;
+
+        if (!history.state?.search) {
+          SearchFilter.clearCategories();
+          categoryTitle.value = category;
+          parentTitle.value = parent;
+
+          searchBar.classList.remove(`has-content`);
+          searchInput.value = ``;
+
+          if (parent) {
+            SearchFilter.highlightParent();
+            SearchFilter.toggleSubcategory();
+          } else {
+            document
+              .querySelector(`#multipage-nav a.active`)
+              .classList.remove(`active`);
+
+            document
+              .querySelector(`#multipage-nav a[data-name="${category}"]`)
+              .classList.add(`active`);
+
+            SearchFilter.toggleSubcategory(true);
+          }
+        } else {
           SearchFilter.toggleSubcategory(true);
+          searchBar.classList.add(`has-content`);
+          searchInput.value = history.state?.search;
+          SearchFilter.filter(history.state?.search);
         }
-      } else {
-        SearchFilter.toggleSubcategory(true);
+
+        SearchFilter.filterCategory(category);
+        SearchFilter.filterSubcategory(category);
+        SearchFilter.updateHeader(category, parent);
+
+        if (history.state?.filter) {
+          toggle.checked = history.state?.filter;
+
+          if (history.state?.filter) {
+            document.body.classList.add(`show-ding-only`);
+          } else {
+            document.body.classList.remove(`show-ding-only`);
+          }
+        }
+      });
+
+      history.replaceState(
+        {
+          title: SearchFilter.getTitle(categoryTitle.value.trim()),
+          category: categoryTitle.value.trim(),
+          parent: parentTitle.value.trim(),
+          search: history.state?.search ?? "",
+          filter: history.state?.filter,
+        },
+        SearchFilter.getTitle(categoryTitle.value.trim()),
+        location.href
+      );
+
+      if (history.state?.search) {
         searchBar.classList.add(`has-content`);
         searchInput.value = history.state?.search;
         SearchFilter.filter(history.state?.search);
+      } else {
+        searchBar.classList.remove(`has-content`);
+        searchInput.value = ``;
       }
-
-      SearchFilter.filterCategory(category);
-      SearchFilter.filterSubcategory(category);
-      SearchFilter.updateHeader(category, parent);
 
       if (history.state?.filter) {
         toggle.checked = history.state?.filter;
@@ -252,338 +291,315 @@ const SearchFilter = {
           document.body.classList.remove(`show-ding-only`);
         }
       }
-    });
+    },
 
-    history.replaceState(
-      {
-        title: SearchFilter.getTitle(categoryTitle.value.trim()),
-        category: categoryTitle.value.trim(),
-        parent: parentTitle.value.trim(),
-        search: history.state?.search ?? "",
-        filter: history.state?.filter,
-      },
-      SearchFilter.getTitle(categoryTitle.value.trim()),
-      location.href
-    );
+    clearCategories: () => {
+      SearchFilter.filterCategory("None");
+      parentTitle.value = null;
 
-    if (history.state?.search) {
-      searchBar.classList.add(`has-content`);
-      searchInput.value = history.state?.search;
-      SearchFilter.filter(history.state?.search);
-    } else {
-      searchBar.classList.remove(`has-content`);
-      searchInput.value = ``;
-    }
-
-    if (history.state?.filter) {
-      toggle.checked = history.state?.filter;
-
-      if (history.state?.filter) {
-        document.body.classList.add(`show-ding-only`);
-      } else {
-        document.body.classList.remove(`show-ding-only`);
+      if (document.querySelector(`#multipage-nav a.active`)) {
+        document
+          .querySelector(`#multipage-nav a.active`)
+          .classList.remove(`active`);
+        document
+          .querySelector(`#multipage-nav a[data-name="None"]`)
+          .classList.add(`active`);
       }
-    }
-  },
+    },
 
-  clearCategories: () => {
-    SearchFilter.filterCategory("None");
-    parentTitle.value = null;
+    updateHeader: (category, parent) => {
+      if (parent) {
+        document.querySelector(".category-header").textContent = parent;
+        document.querySelector(".category-header").dataset.name = parent;
+        document.querySelector(".category-header").href =
+          document.querySelector(
+            `#multipage-nav a[data-name="${parent}"]`
+          ).href;
+      } else {
+        const header = category === "None" ? "All" : category;
+        document.querySelector(".category-header").textContent = header;
+        document.querySelector(".category-header").dataset.name = category;
+        document.querySelector(".category-header").href =
+          document.querySelector(
+            `#multipage-nav a[data-name="${category}"]`
+          ).href;
+      }
+    },
 
-    if (document.querySelector(`#multipage-nav a.active`)) {
-      document
-        .querySelector(`#multipage-nav a.active`)
-        .classList.remove(`active`);
+    filterSubcategory: (category) => {
+      for (const subcategory of subcategories) {
+        if (subcategory.dataset.parent === category) {
+          subcategory.classList.remove(`tw-hidden`);
+        } else {
+          subcategory.classList.add(`tw-hidden`);
+        }
+      }
+    },
+
+    getTitle: (category) => {
+      if (category == "None")
+        return document.querySelector('meta[name="pni-home-title"]').content;
+      else {
+        return `${category} | ${
+          document.querySelector('meta[name="pni-category-title"]').content
+        }`;
+      }
+    },
+
+    moveCreepyFace: () => {
+      // When searching, check to see how many products are still visible
+      // If there are no visible products, there are "no search results"
+      // And when there are no search results, do not show the creepo-meter-face
+      if (document.querySelectorAll(".product-box:not(.d-none)").length) {
+        // If there are search results, show the creepo-meter-face
+        CREEPINESS_FACE.classList.remove("d-none");
+      } else {
+        // If there are no search results, hide the creepo-meter-face
+        CREEPINESS_FACE.classList.add("d-none");
+      }
+    },
+
+    filter: (text) => {
+      // remove category filters
+      SearchFilter.clearCategories();
+      SearchFilter.toggleSubcategory(true);
+      SearchFilter.filterSubcategory("None");
+      SearchFilter.updateHeader("None", null);
+
+      if (document.querySelector(`#multipage-nav a.active`)) {
+        document
+          .querySelector(`#multipage-nav a.active`)
+          .classList.remove(`active`);
+      }
+
       document
         .querySelector(`#multipage-nav a[data-name="None"]`)
         .classList.add(`active`);
-    }
-  },
 
-  updateHeader: (category, parent) => {
-    if (parent) {
-      document.querySelector(".category-header").textContent = parent;
-      document.querySelector(".category-header").dataset.name = parent;
-      document.querySelector(".category-header").href = document.querySelector(
-        `#multipage-nav a[data-name="${parent}"]`
-      ).href;
-    } else {
-      const header = category === "None" ? "All" : category;
-      document.querySelector(".category-header").textContent = header;
-      document.querySelector(".category-header").dataset.name = category;
-      document.querySelector(".category-header").href = document.querySelector(
-        `#multipage-nav a[data-name="${category}"]`
-      ).href;
-    }
-  },
-
-  filterSubcategory: (category) => {
-    for (const subcategory of subcategories) {
-      if (subcategory.dataset.parent === category) {
-        subcategory.classList.remove(`tw-hidden`);
-      } else {
-        subcategory.classList.add(`tw-hidden`);
-      }
-    }
-  },
-
-  getTitle: (category) => {
-    if (category == "None")
-      return document.querySelector('meta[name="pni-home-title"]').content;
-    else {
-      return `${category} | ${
-        document.querySelector('meta[name="pni-category-title"]').content
-      }`;
-    }
-  },
-
-  moveCreepyFace: () => {
-    // When searching, check to see how many products are still visible
-    // If there are no visible products, there are "no search results"
-    // And when there are no search results, do not show the creepo-meter-face
-    if (document.querySelectorAll(".product-box:not(.d-none)").length) {
-      // If there are search results, show the creepo-meter-face
-      CREEPINESS_FACE.classList.remove("d-none");
-    } else {
-      // If there are no search results, hide the creepo-meter-face
-      CREEPINESS_FACE.classList.add("d-none");
-    }
-  },
-
-  filter: (text) => {
-    // remove category filters
-    SearchFilter.clearCategories();
-    SearchFilter.toggleSubcategory(true);
-    SearchFilter.filterSubcategory("None");
-    SearchFilter.updateHeader("None", null);
-
-    if (document.querySelector(`#multipage-nav a.active`)) {
-      document
-        .querySelector(`#multipage-nav a.active`)
-        .classList.remove(`active`);
-    }
-
-    document
-      .querySelector(`#multipage-nav a[data-name="None"]`)
-      .classList.add(`active`);
-
-    ALL_PRODUCTS.forEach((product) => {
-      if (SearchFilter.test(product, text)) {
-        product.classList.remove(`d-none`);
-        product.classList.add(`d-flex`);
-      } else {
-        product.classList.add(`d-none`);
-        product.classList.remove(`d-flex`);
-      }
-    });
-
-    history.replaceState(
-      {
-        ...history.state,
-        search: text,
-      },
-      SearchFilter.getTitle(categoryTitle.value.trim()),
-      location.href
-    );
-
-    SearchFilter.sortProducts();
-
-    SearchFilter.moveCreepyFace();
-    SearchFilter.checkForEmptyNotice();
-  },
-
-  sortProducts: () => {
-    const container = document.querySelector(`.product-box-list`);
-    const list = [...container.querySelectorAll(`.product-box`)];
-
-    list.sort((a, b) => {
-      for (field of SORTS) {
-        const qs = `.product-${field}`;
-        const [propertyA, propertyB] = [
-          a.querySelector(qs),
-          b.querySelector(qs),
-        ];
-        const [propertyNameA, propertyNameB] = [
-          (propertyA.value || propertyA.textContent).toLowerCase(),
-          (propertyB.value || propertyB.textContent).toLowerCase(),
-        ];
-
-        if (
-          propertyNameA !== propertyNameB ||
-          field === SORTS[SORTS.length - 1]
-        ) {
-          return propertyNameA < propertyNameB
-            ? -1
-            : propertyNameA > propertyNameB
-            ? 1
-            : 0;
+      ALL_PRODUCTS.forEach((product) => {
+        if (SearchFilter.test(product, text)) {
+          product.classList.remove(`d-none`);
+          product.classList.add(`d-flex`);
+        } else {
+          product.classList.add(`d-none`);
+          product.classList.remove(`d-flex`);
         }
-      }
-    });
-
-    list.forEach((p) => container.append(p));
-  },
-
-  sortOnCreepiness: () => {
-    const container = document.querySelector(`.product-box-list`);
-    const list = [...container.querySelectorAll(`.product-box`)];
-    const creepVal = (e) => parseFloat(e.dataset.creepiness);
-    list
-      .sort((a, b) => creepVal(a) - creepVal(b))
-      .forEach((p) => container.append(p));
-  },
-
-  filterCategory: (category) => {
-    ALL_PRODUCTS.forEach((product) => {
-      if (SearchFilter.testCategories(product, category)) {
-        product.classList.remove(`d-none`);
-        product.classList.add(`d-flex`);
-      } else {
-        product.classList.add(`d-none`);
-        product.classList.remove(`d-flex`);
-      }
-    });
-
-    categoryTitle.value = category;
-    SearchFilter.sortOnCreepiness();
-    SearchFilter.moveCreepyFace();
-    SearchFilter.checkForEmptyNotice();
-  },
-
-  highlightParent: () => {
-    if (document.querySelector(`#multipage-nav a.active`)) {
-      document
-        .querySelector(`#multipage-nav a.active`)
-        .classList.remove(`active`);
-    }
-
-    document
-      .querySelector(
-        `#multipage-nav a[data-name="${parentTitle.value.trim()}"]`
-      )
-      .classList.add(`active`);
-  },
-
-  toggleSubcategory: (clear = false) => {
-    const activeClasses = [
-      "active",
-      "tw-bg-gray-80",
-      "tw-text-white",
-      "tw-border-gray-80",
-    ];
-    const defaultClasses = [
-      "hover:tw-border-pni-lilac",
-      "hover:tw-bg-pni-lilac",
-      "tw-text-gray-60",
-      "tw-border-gray-20",
-      "tw-bg-white",
-    ];
-
-    if (document.querySelector(`a.subcategories.active`)) {
-      document
-        .querySelector(`a.subcategories.active`)
-        .classList.add(...defaultClasses);
-      document
-        .querySelector(`a.subcategories.active`)
-        .classList.remove(...activeClasses);
-    }
-
-    if (clear) {
-      return;
-    }
-
-    document
-      .querySelector(
-        `a.subcategories[data-name="${categoryTitle.value.trim()}"]`
-      )
-      .classList.add(...activeClasses);
-
-    document
-      .querySelector(
-        `a.subcategories[data-name="${categoryTitle.value.trim()}"]`
-      )
-      .classList.remove(...defaultClasses);
-  },
-
-  checkForEmptyNotice: () => {
-    let qs = `figure.product-box:not(.d-none)`;
-
-    if (document.body.classList.contains(`show-ding-only`)) {
-      qs = `${qs}.privacy-ding`;
-    }
-
-    const results = document.querySelectorAll(qs);
-    const count = results.length;
-    if (count === 0) {
-      NO_RESULTS_NOTICE.classList.remove(`d-none`);
-      SUBMIT_PRODUCT.classList.add("d-none");
-    } else {
-      NO_RESULTS_NOTICE.classList.add(`d-none`);
-      SUBMIT_PRODUCT.classList.remove("d-none");
-    }
-  },
-
-  test: (product, text) => {
-    text = text.toLowerCase(); // Note that this is absolutely not true for all languages, but it's true for us.
-    let qs, data, field;
-
-    for (field of FILTERS) {
-      qs = `.product-${field}`;
-      data = product.querySelector(qs);
-      data = (data.value || data.textContent).toLowerCase();
-      if (data.indexOf(text) !== -1) {
-        return true;
-      }
-    }
-
-    return false;
-  },
-
-  testCategories: (product, category) => {
-    if (category === "None") {
-      return true;
-    }
-
-    const productCategories = Array.from(
-      product.querySelectorAll(".product-categories")
-    );
-
-    return productCategories.map((c) => c.value.trim()).includes(category);
-  },
-};
-
-const PNIToggle = {
-  init: () => {
-    if (!toggle) {
-      return console.warn(
-        `Could not find the PNI filter checkbox. PNI filtering will not be available.`
-      );
-    }
-
-    toggle.addEventListener(`change`, (evt) => {
-      const filter = evt.target.checked;
+      });
 
       history.replaceState(
         {
           ...history.state,
-          filter,
+          search: text,
         },
         SearchFilter.getTitle(categoryTitle.value.trim()),
         location.href
       );
 
-      if (filter) {
-        document.body.classList.add(`show-ding-only`);
+      SearchFilter.sortProducts();
+
+      SearchFilter.moveCreepyFace();
+      SearchFilter.checkForEmptyNotice();
+    },
+
+    sortProducts: () => {
+      const container = document.querySelector(`.product-box-list`);
+      const list = [...container.querySelectorAll(`.product-box`)];
+
+      list.sort((a, b) => {
+        for (field of SORTS) {
+          const qs = `.product-${field}`;
+          const [propertyA, propertyB] = [
+            a.querySelector(qs),
+            b.querySelector(qs),
+          ];
+          const [propertyNameA, propertyNameB] = [
+            (propertyA.value || propertyA.textContent).toLowerCase(),
+            (propertyB.value || propertyB.textContent).toLowerCase(),
+          ];
+
+          if (
+            propertyNameA !== propertyNameB ||
+            field === SORTS[SORTS.length - 1]
+          ) {
+            return propertyNameA < propertyNameB
+              ? -1
+              : propertyNameA > propertyNameB
+              ? 1
+              : 0;
+          }
+        }
+      });
+
+      list.forEach((p) => container.append(p));
+    },
+
+    sortOnCreepiness: () => {
+      const container = document.querySelector(`.product-box-list`);
+      const list = [...container.querySelectorAll(`.product-box`)];
+      const creepVal = (e) => parseFloat(e.dataset.creepiness);
+      list
+        .sort((a, b) => creepVal(a) - creepVal(b))
+        .forEach((p) => container.append(p));
+    },
+
+    filterCategory: (category) => {
+      ALL_PRODUCTS.forEach((product) => {
+        if (SearchFilter.testCategories(product, category)) {
+          product.classList.remove(`d-none`);
+          product.classList.add(`d-flex`);
+        } else {
+          product.classList.add(`d-none`);
+          product.classList.remove(`d-flex`);
+        }
+      });
+
+      categoryTitle.value = category;
+      SearchFilter.sortOnCreepiness();
+      SearchFilter.moveCreepyFace();
+      SearchFilter.checkForEmptyNotice();
+    },
+
+    highlightParent: () => {
+      if (document.querySelector(`#multipage-nav a.active`)) {
+        document
+          .querySelector(`#multipage-nav a.active`)
+          .classList.remove(`active`);
+      }
+
+      document
+        .querySelector(
+          `#multipage-nav a[data-name="${parentTitle.value.trim()}"]`
+        )
+        .classList.add(`active`);
+    },
+
+    toggleSubcategory: (clear = false) => {
+      const activeClasses = [
+        "active",
+        "tw-bg-gray-80",
+        "tw-text-white",
+        "tw-border-gray-80",
+      ];
+      const defaultClasses = [
+        "hover:tw-border-pni-lilac",
+        "hover:tw-bg-pni-lilac",
+        "tw-text-gray-60",
+        "tw-border-gray-20",
+        "tw-bg-white",
+      ];
+
+      if (document.querySelector(`a.subcategories.active`)) {
+        document
+          .querySelector(`a.subcategories.active`)
+          .classList.add(...defaultClasses);
+        document
+          .querySelector(`a.subcategories.active`)
+          .classList.remove(...activeClasses);
+      }
+
+      if (clear) {
+        return;
+      }
+
+      document
+        .querySelector(
+          `a.subcategories[data-name="${categoryTitle.value.trim()}"]`
+        )
+        .classList.add(...activeClasses);
+
+      document
+        .querySelector(
+          `a.subcategories[data-name="${categoryTitle.value.trim()}"]`
+        )
+        .classList.remove(...defaultClasses);
+    },
+
+    checkForEmptyNotice: () => {
+      let qs = `figure.product-box:not(.d-none)`;
+
+      if (document.body.classList.contains(`show-ding-only`)) {
+        qs = `${qs}.privacy-ding`;
+      }
+
+      const results = document.querySelectorAll(qs);
+      const count = results.length;
+      if (count === 0) {
+        NO_RESULTS_NOTICE.classList.remove(`d-none`);
+        SUBMIT_PRODUCT.classList.add("d-none");
       } else {
-        document.body.classList.remove(`show-ding-only`);
+        NO_RESULTS_NOTICE.classList.add(`d-none`);
+        SUBMIT_PRODUCT.classList.remove("d-none");
+      }
+    },
+
+    test: (product, text) => {
+      text = text.toLowerCase(); // Note that this is absolutely not true for all languages, but it's true for us.
+      let qs, data, field;
+
+      for (field of FILTERS) {
+        qs = `.product-${field}`;
+        data = product.querySelector(qs);
+        data = (data.value || data.textContent).toLowerCase();
+        if (data.indexOf(text) !== -1) {
+          return true;
+        }
       }
 
-      if (SearchFilter.searchInput.value.trim()) {
-        SearchFilter.searchInput.focus();
-        SearchFilter.checkForEmptyNotice();
-      }
-    });
-  },
-};
+      return false;
+    },
 
-export { SearchFilter, PNIToggle };
+    testCategories: (product, category) => {
+      if (category === "None") {
+        return true;
+      }
+
+      const productCategories = Array.from(
+        product.querySelectorAll(".product-categories")
+      );
+
+      return productCategories.map((c) => c.value.trim()).includes(category);
+    },
+  };
+
+  // TODO: turn this into a static class as well
+  const PNIToggle = {
+    init: () => {
+      if (!toggle) {
+        return console.warn(
+          `Could not find the PNI filter checkbox. PNI filtering will not be available.`
+        );
+      }
+
+      toggle.addEventListener(`change`, (evt) => {
+        const filter = evt.target.checked;
+
+        // TODO: this might be an A/B testing opportunity to see
+        //       whether users assume this toggle is a navigation
+        //       action or not?
+        history.replaceState(
+          {
+            ...history.state,
+            filter,
+          },
+          SearchFilter.getTitle(categoryTitle.value.trim()),
+          location.href
+        );
+
+        if (filter) {
+          document.body.classList.add(`show-ding-only`);
+        } else {
+          document.body.classList.remove(`show-ding-only`);
+        }
+
+        if (SearchFilter.searchInput.value.trim()) {
+          SearchFilter.searchInput.focus();
+          SearchFilter.checkForEmptyNotice();
+        }
+      });
+    },
+  };
+
+  // bootstrap both searching and privacy-ding-filtering
+  SearchFilter.init();
+  PNIToggle.init();
+})();


### PR DESCRIPTION
Closes #7667
Supercedes #7709

This updates the build so that search.js ends up as "its own file" in the frontend/js dir, getting loaded as part of the `<head>` payload for catalog pages (PNI homepage + category pages) with `async defer` so that it can be used as soon as the page DOM is ready for reading.

Note that you'll want to hide whitespace for reviewing file changes in this case: https://github.com/mozilla/foundation.mozilla.org/pull/7741/files?diff=unified&w=1

Test URL: (review app pending)