### PR TITLE
load search.js as module

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -20,14 +20,33 @@ const inDir = `./source/js/`;
 const outDir = `./network-api/networkapi/frontend/_js/`;
 
 const sources = {
-  main: `main.js`,
-  mozfest: `foundation/pages/mozfest/index.js`,
-  "callpower": `foundation/pages/callpower.js`,
-  "directory-listing-filters": `foundation/pages/directory-listing-filters.js`,
-  "bg-main": `buyers-guide/bg-main.js`,
-  "bg-search": `buyers-guide/search.js`,
-  polyfills: `polyfills.js`,
+  main: {
+    source: `main.js`,
+    react: true,
+  },
+  mozfest: {
+    source: `foundation/pages/mozfest/index.js`,
+    react: true,
+  },
+  "callpower": {
+    source: `foundation/pages/callpower.js`,
+  },
+  "directory-listing-filters": {
+    source: `foundation/pages/directory-listing-filters.js`,
+  },
+  "bg-main": {
+    source: `buyers-guide/bg-main.js`,
+    react: true,
+  },
+  "bg-search": {
+    source: `buyers-guide/search.js`,
+  },
+  polyfills: {
+    source: `polyfills.js`,
+  },
 };
+
+
 
 const base = {
   bundle: true,
@@ -41,11 +60,13 @@ const base = {
   define: {
     "process.env.NODE_ENV": JSON.stringify(mode),
   },
-  inject: [`esbuild.react.shim.js`],
 };
 
-Object.entries(sources).map(([name, source]) => {
+Object.entries(sources).map(([name, { source, react}]) => {
   const opts = Object.assign({}, base);
+  if (react) {
+    opts.inject = [`esbuild.react.shim.js`]
+  };
   opts.entryPoints = [path.join(inDir, source)];
   opts.outfile = `${path.join(outDir, name)}.compiled.js`;
   return build(opts);

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
@@ -4,7 +4,7 @@
 
 {% block additional_head_elements %}
   {{ block.super }}
-  <script src="{% static "_js/bg-search.compiled.js" %}" async="async" defer="defer"></script>
+  <script src="{% static "_js/bg-search.compiled.js" %}" async type="module"></script>
 {% endblock %}
 
 {% block bodyclass %}pni catalog{% endblock %}


### PR DESCRIPTION
No issue, but fixes a loading issue for search.js where it seemed to load when it shouldn't have been able to. On a whim I figured I'd try to explicitly load the file as a module, and turns out, that does the trick.