### PR TITLE
move 'manage block_inventory' to a cron job

### DIFF
--- a/release-steps.sh
+++ b/release-steps.sh
@@ -5,11 +5,5 @@ cd network-api
 # Django Migrations
 python ./manage.py migrate --no-input
 
-# Wagtail block inventory
-python ./manage.py block_inventory
-
-# Wagtail translations
-# TODO: May need to add in auto syncing using wagtail-localize in the future.
-
 # Clear cache for BuyersGuide
 python ./manage.py clear_cache


### PR DESCRIPTION
Closes #7760 by removing the `block_inventory` step from the release script.