### PR TITLE
Update and rename 0048_auto_20211101_1811.py to 0049_auto_20211101_1811.py

### DIFF
--- a/network-api/networkapi/wagtailpages/migrations/0049_auto_20211101_1811.py
+++ b/network-api/networkapi/wagtailpages/migrations/0049_auto_20211101_1811.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailpages', '0047_auto_20211027_0017'),
+        ('wagtailpages', '0048_auto_20211103_1531'),
     ]
 
     operations = [


### PR DESCRIPTION
there were two 0048 migrations somehow, one from 18 hours ago, and one from 2 hours ago, I updated the 2-hours-ago one to become 0049 and point to the older 0048 as dependency.