### PR TITLE
make sure the product-in-category check works

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -608,6 +608,10 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
         related_name='votes',
     )
 
+    def get_product_categories(self):
+        # Weed out possible NULL values from product categories having been deleted.
+        return self.product_categories.filter(category__isnull=False)
+
     @classmethod
     def map_import_fields(cls):
         mappings = {

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/catalog.html
@@ -109,14 +109,14 @@
       {# User is not logged in. Return cached results. 24 hour caching applied. #}
       {% cache 86400 pni_home_page template_cache_key_fragment %}
         {% for product in products %}
-          {% prod_in_cat product category as matched %}
+          {% product_in_category product category as matched %}
           {% include "../fragments/buyersguide_item.html" with product=product.localized matched=matched %}
         {% endfor %}
       {% endcache %}
     {% else %}
       {# User is logged in. Don't cache their results so they can see live and draft products here. #}
       {% for product in products %}
-        {% prod_in_cat product category as matched %}
+        {% product_in_category product category as matched %}
         {% include "../fragments/buyersguide_item.html" with product=product.localized matched=matched %}
       {% endfor %}
     {% endif %}

--- a/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
@@ -23,11 +23,12 @@ def bg_active_nav(current, target):
     return 'active' if urlparse(current).path == urlparse(target).path else ''
 
 
-@register.simple_tag(name='prod_in_cat')
-def prod_in_cat(productpage, categorySlug):
+@register.simple_tag(name='product_in_category')
+def product_in_category(productpage, categorySlug):
     if categorySlug == "":
         return True
-    return categorySlug in [cat.category.slug for cat in productpage.product_categories.all()]
+    categories = productpage.get_product_categories()
+    return categorySlug in [cat.category.slug for cat in categories]
 
 
 """


### PR DESCRIPTION
Closes #7775 by making sure product pages can yield a list of categories that have `None` entries filtered out.

## Verify problem:

- check out `main`
- copy the staging db,
- `docker-compose up`
- load http://localhost:8000/en/privacynotincluded/categories/wearables
- load http://localhost:8000/cms in a separate tab
- load the snippets -> buyers guide category snippets
- delete the "fitnes trackers (sort order 11)" entry
- reload the wearables page

This should show an error `'NoneType' object has no attribute 'slug'`, with a stack trace ending in

```
/app/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py, line 30, in prod_in_cat
    return categorySlug in [cat.category.slug for cat in productpage.product_categories.all()] …
/app/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py, line 30, in <listcomp>
    return categorySlug in [cat.category.slug for cat in productpage.product_categories.all()] …
```

## Verify fix:

- `docker-compose down`
- check out this branch
- copy the staging db again (file should still be there, so that should be fast)
- `docker-compose up`
- load http://localhost:8000/en/privacynotincluded/categories/wearables
- confirm it works again
- load http://localhost:8000/cms in a separate tab
- load the snippets -> buyers guide category snippets
- delete the "fitnes trackers (sort order 11)" entry
- reload the wearables page

This should now work fine.