### PR TITLE
compensate for bad slug names caused by sync_locale_trees

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -705,7 +705,7 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
         try:
             original = get_original_by_slug(ProductPage, self.slug)
 
-        except ProductPage.DoesNotExist as error:
+        except ProductPage.DoesNotExist:
             """
             This may happen when a product was created, got localized,
             then the original product was deleted a new product with the
@@ -722,14 +722,13 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
 
             TODO: Remove this patch code once #7592 is addressed.
             """
-            slug = re.sub('(-\d+)+$', '', self.slug)
+            slug = re.sub('(-\\d+)+$', '', self.slug)
             original = get_original_by_slug(ProductPage, slug)
 
         if original is None:
             return self
 
         return original
-
 
     def get_or_create_votes(self):
         """

--- a/network-api/networkapi/wagtailpages/pagemodels/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/products.py
@@ -1,3 +1,4 @@
+import re
 import json
 
 from bs4 import BeautifulSoup
@@ -701,7 +702,34 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
 
     @property
     def original_product(self):
-        return get_original_by_slug(ProductPage, self.slug)
+        try:
+            original = get_original_by_slug(ProductPage, self.slug)
+
+        except ProductPage.DoesNotExist as error:
+            """
+            This may happen when a product was created, got localized,
+            then the original product was deleted a new product with the
+            same title (and thus, slug) gets created.
+
+            The old localizations are still around, so `sync_locale_trees`
+            will see a new page to set up aliases for, but their slug ends
+            up conflicting with the slugs for the original localized pages,
+            and so they get `-1` appended, meaning we can't find their
+            "original" equivalent using their slug: we need to rewrite
+            the slug to remove the number suffix first.
+
+            See: https://github.com/wagtail/wagtail/issues/7592
+
+            TODO: Remove this patch code once #7592 is addressed.
+            """
+            slug = re.sub('(-\d+)+$', '', self.slug)
+            original = get_original_by_slug(ProductPage, slug)
+
+        if original is None:
+            return self
+
+        return original
+
 
     def get_or_create_votes(self):
         """


### PR DESCRIPTION
Closes #7858 by "correcting" product slugs that might have a numerical suffix caused by the locale code.

See https://github.com/wagtail/wagtail/issues/7592

Testing: you'll probably have to do an `inv copy-prod-db` to confirm this works on our real data, rather than fake data.

Note that localized categories may not show all products, as aliased-but-unsynced products won't have any categories assigned, and so don't end up in any listing that filters on category.