### PR TITLE
restore all content_panels, after which we can decide which to filter out

### DIFF
--- a/network-api/networkapi/mozfest/models.py
+++ b/network-api/networkapi/mozfest/models.py
@@ -213,7 +213,7 @@ class MozfestHomepage(MozfestPrimaryPage):
     panel_count = len(parent_panels)
     n = panel_count - 1
 
-    all_panels = parent_panels[:n] + [
+    content_panels = parent_panels[:n] + [
         FieldPanel('cta_button_label'),
         FieldPanel('cta_button_destination'),
         FieldPanel('banner_heading'),
@@ -223,27 +223,6 @@ class MozfestHomepage(MozfestPrimaryPage):
         FieldPanel('banner_video_url'),
         StreamFieldPanel('banner_video'),
     ] + parent_panels[n:]
-
-    if banner_video_type == "hardcoded":
-        # Hide all the panels that aren't relevant for the video banner version of the MozFest Homepage
-        content_panels = [
-            field for field in all_panels
-            if field.field_name not in [
-                'banner', 'header', 'intro', 'banner_carousel', 'banner_guide_text', 'banner_cta_label',
-                'banner_video', 'banner_video_url',
-            ]
-        ]
-    elif banner_video_type == "featured":
-        # Hide all the panels that aren't relevant for the video banner version of the MozFest Homepage
-        content_panels = [
-            field for field in all_panels
-            if field.field_name not in [
-                'banner', 'banner_guide_text', 'banner_video_url', 'cta_button_destination',
-                'cta_button_label', 'header', 'hero_image', 'intro',
-            ]
-        ]
-    else:
-        content_panels = all_panels
 
     # Because we inherit from PrimaryPage, but the "use_wide_template" property does nothing
     # we should hide it and make sure we use the right template


### PR DESCRIPTION
Part 1 of https://github.com/mozilla/foundation.mozilla.org/issues/7883, restoring all mozfest homepage panels so that staff has control over the things they need control over while we figure out some better logic for filtering out "fields that shouldn't show when the video banner is in some specific mode".