### PR TITLE
take CSRF out of the page template for PNI products

### DIFF
--- a/network-api/networkapi/templates/api/csrf.html
+++ b/network-api/networkapi/templates/api/csrf.html
@@ -1,0 +1,1 @@
+{% csrf_token %}

--- a/network-api/networkapi/urls.py
+++ b/network-api/networkapi/urls.py
@@ -1,9 +1,10 @@
 from django.conf import settings
-from django.urls import path, re_path, include
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponse
+from django.shortcuts import render
+from django.urls import path, re_path, include
 from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
@@ -59,6 +60,9 @@ urlpatterns = list(filter(None, [
 
     # social-sign-on routes so that Google auth works
     re_path(r'^soc/', include('social_django.urls', namespace='social')),
+
+    # CSRF endpoint
+    re_path(r'^api/csrf/', lambda request: render(request, 'api/csrf.html')),
 
     # network API routes:
 

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/product_page.html
@@ -106,7 +106,6 @@
             <div class="creep-vote-target mb-5 mt-3 mt-md-4 p-5" data-product-name="{{product.title}}" data-product-type="{{product.product_type}}">
               <input type="hidden" name="productID" value="{{ product.id }}">
               <input type="hidden" name="votes" value='{{ product.get_voting_json | safe }}'>
-              {% csrf_token %}
             </div>
         </div>
       </div>

--- a/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
+++ b/source/js/buyers-guide/components/creep-vote/creep-vote.jsx
@@ -44,15 +44,14 @@ class CreepVote extends Component {
     sessionStorage.setItem("subscribed", subscribed);
 
     return {
-      totalVotes,
       creepiness: 50,
-      hasMoved: false,
+      csrfToken: ``,
       didVote: false,
-      majority: {
-        creepiness: creepinessId,
-      },
-      subscribed,
+      hasMoved: false,
+      majority: { creepiness: creepinessId },
       showNewsletter: false,
+      subscribed,
+      totalVotes,
       voteCount,
     };
   }
@@ -61,6 +60,17 @@ class CreepVote extends Component {
     if (this.props.whenLoaded) {
       this.props.whenLoaded();
     }
+
+    // voting requires a CSRF token, which we can request on a dedicated API route
+    fetch(`/api/csrf/`)
+      .then((res) => res.text())
+      .then((html) => {
+        const d = document.createElement(`div`);
+        d.innerHTML = html
+        this.setState({
+          csrfToken: d.querySelector(`input`).value,
+        });
+      });
   }
 
   showVoteResult() {
@@ -86,7 +96,7 @@ class CreepVote extends Component {
     let method = `POST`;
     let credentials = `same-origin`;
     let headers = {
-      "X-CSRFToken": this.props.csrfToken,
+      "X-CSRFToken": this.state.csrfToken,
       "Content-Type": `application/json`,
     };
 
@@ -198,7 +208,6 @@ class CreepVote extends Component {
           flowText={getText(
             `Now that you’re on a roll, why not join Mozilla? We’re not creepy (we promise). We actually fight back against creepy. And we need more people like you.`
           )}
-          csrfToken={this.props.joinUsCSRF}
           apiUrl={this.props.joinUsApiUrl}
           handleSignUp={(successState) => this.handleSignUp(successState)}
         />

--- a/source/js/buyers-guide/inject-react/creep-vote.js
+++ b/source/js/buyers-guide/inject-react/creep-vote.js
@@ -32,7 +32,7 @@ export default (apps, siteUrl) => {
     }
 
     apps.push(
-      new Promise(async (resolve) => {
+      new Promise((resolve) => {
         ReactDOM.render(
           <CreepVote
             productType={productType}

--- a/source/js/buyers-guide/inject-react/creep-vote.js
+++ b/source/js/buyers-guide/inject-react/creep-vote.js
@@ -13,9 +13,6 @@ export default (apps, siteUrl) => {
     let productName = element.dataset.productName;
     let productID = element.querySelector(`input[name=productID]`).value;
     let votesValue = element.querySelector(`input[name=votes]`).value;
-    let csrfToken = element.querySelector(
-      `input[name=csrfmiddlewaretoken]`
-    ).value;
 
     let votes = {
       total: 0,
@@ -35,7 +32,7 @@ export default (apps, siteUrl) => {
     }
 
     apps.push(
-      new Promise((resolve) => {
+      new Promise(async (resolve) => {
         ReactDOM.render(
           <CreepVote
             productType={productType}
@@ -44,7 +41,6 @@ export default (apps, siteUrl) => {
             votes={votes}
             whenLoaded={() => resolve()}
             joinUsApiUrl={`${siteUrl}/api/campaign/signups/0/`}
-            csrfToken={csrfToken}
           />,
           element
         );

--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -259,8 +259,8 @@ class JoinUs extends Component {
    */
   renderFlowHeading() {
     return [
-      <h2 className="h3-heading text-center">{this.props.flowHeading}</h2>,
-      <p className="text-center">{this.props.flowText}</p>,
+      <h2 className="h3-heading text-center" key={`flowheading`}>{this.props.flowHeading}</h2>,
+      <p className="text-center" key={`flowheadingpara`}>{this.props.flowText}</p>,
     ];
   }
 


### PR DESCRIPTION
Closes #7880 by moving the csrf token to its own API endpoint, that the PNI voting JS can fetch, parse, extract the text out of (I opted to keep it `{% csrf_token %}` rather than `{{csrf_token}}` just because the former makes it just that tiny bit more annoying to write a script that gets the value out, compared to just responding with an immediately-usable string) and then add into the voting POST request.

With this, PNI products should no longer need cache exemption, nor should they cause cloudflare to set a "this user wants uncached content" cookie.

Testing wise: voting should work =)

Hit up https://foundation-s-separate-v-zw6hz3.herokuapp.com/en/privacynotincluded, pick a product, and verify that the voting slider part renders, and that you can vote after moving it, with the vote count going up as you pile on the votes.