### PR TITLE
7878 - opening of new tab rather than directing users away from mozil…

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/buyersguide/contest.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/contest.html
@@ -71,8 +71,8 @@
               “*privacy not included competition" will constitute your entry into this Contest (the <strong>“Entry”</strong>).
           </p>
           <p>
-            If you do not have a Twitter or Instagram account, you can visit <a href="https://twitter.com">https://twitter.com</a> or
-            <a href="https://www.instagram.com">https://www.instagram.com</a> and create a Twitter or Instagram account according to
+            If you do not have a Twitter or Instagram account, you can visit <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="https://twitter.com (opens is a new tab)">https://twitter.com</a> or
+            <a href="https://www.instagram.com" target="_blank" rel="noopener noreferrer" aria-label="https://www.instagram.com (opens is a new tab)">https://www.instagram.com</a> and create a Twitter or Instagram account according to
             the instructions on the website. Creating a Twitter or Instagram account is free. Please note that you must agree to comply
             with the Twitter and/or Instagram Terms of Service in order to create accounts with those services.
           </p>

--- a/network-api/networkapi/wagtailpages/templates/fragments/product_privacy.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/product_privacy.html
@@ -7,7 +7,7 @@
     {% for link in links %}
       <li class="pni-product-helptext">
         {% if link.url != "" %}
-        <a class="privacy-policy-link" href="{{ link.url }}">{{ link.label }}</a>
+        <a class="privacy-policy-link" href="{{ link.url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ link.label }} (opens is a new tab)">{{ link.label }}</a>
         {% else %}
         <span>{{ link.label }}</span>
         {% endif %}


### PR DESCRIPTION
While it appears that most links that take users to external sites in the Buyer's Guide / PNI are in the entry data rather than hard coded, there were a few instances that were in the code. This PR makes the links open in a new tab safely while informing users with screen readers via aria-label.

Related PRs/issues #7878

