### PR TITLE
7918 - Add youtube regrets page extension to parent

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
@@ -400,7 +400,8 @@ class BanneredCampaignPage(PrimaryPage):
         'RedirectingPage',
         'PublicationPage',
         'OpportunityPage',
-        'ArticlePage'
+        'ArticlePage',
+        'YoutubeRegretsReporterExtensionPage'
     ]
 
     show_in_menus_default = True


### PR DESCRIPTION
Add youtube-regrets-extension page type to campaigns

For testing copying the staging db would help!

1.  find youtube regrets banner page on the CMS
2. Click `Add child page`
3.  Should be able to add extension page