### PR TITLE
utm updating of download/email buttons working

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/regrets-reporter-landing-page/extension_hero.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/regrets-reporter-landing-page/extension_hero.html
@@ -12,12 +12,12 @@
                 </p>
                 <div class="btn-container tw-mt-1 tw-flex tw-flex-wrap tw-gap-4">
                     <a class="btn download-link-button download-link-button--firefox tw-bg-white tw-text-youtube-regrets-red"
-                        href="https://addons.mozilla.org/en-us/firefox/addon/regretsreporter/?utm_subscribed=&utm_medium=email&utm_source=email&utm_campaign=youtuberr2021&utm_content=kicker"
+                        href="https://addons.mozilla.org/en-us/firefox/addon/regretsreporter/"
                         target="_blank">
                         {% trans "Add to Firefox" %}
                     </a>
                     <a class="btn download-link-button download-link-button--chrome tw-bg-white tw-text-youtube-regrets-red"
-                        href="https://chrome.google.com/webstore/detail/regretsreporter/obpoeflheeknapimliioeoefbfaakefn?utm_medium=email&utm_source=email&utm_campaign=youtuberr2021&utm_content=kicker"
+                        href="https://chrome.google.com/webstore/detail/regretsreporter/obpoeflheeknapimliioeoefbfaakefn"
                         target="_blank">
                         {% trans "Add to Chrome" %}
                     </a>
@@ -25,7 +25,7 @@
                     {% trans "Mozilla built RegretsReporter to help you take back control of your YouTube recommendations and make YouTube better for everyone else." as translated_body %}
                     {% with subject=translated_subject body=translated_body %}
                         <a class="btn download-link-button download-link-button--email tw-bg-white tw-text-youtube-regrets-red tw-hidden"
-                            href="mailto:?subject={{ subject|urlencode }}&body={{ body|urlencode }}%0D%0A%0D%0Ahttps://addons.mozilla.org/en-us/firefox/addon/regretsreporter/?utm_subscribed=&utm_medium=email&utm_source=email&utm_campaign=youtuberr2021&utm_content=first_email%0D%0Ahttps://chrome.google.com/webstore/detail/regretsreporter/obpoeflheeknapimliioeoefbfaakefn?utm_medium=email&utm_source=email&utm_campaign=youtuberr2021&utm_content=first_email%0D%0Ahttps://foundation.mozilla.org/youtube/regretsreporter?utm_medium=email&utm_source=email&utm_campaign=youtuberr2021&utm_content=first_email"
+                            href="mailto:?subject={{ subject|urlencode }}&body={{ body|urlencode }}"
                             target="_blank">
                             {% trans "Send Reminder" %}
                         </a>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/regrets-reporter-landing-page/youtube_regrets_reporter_extension.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/regrets-reporter-landing-page/youtube_regrets_reporter_extension.html
@@ -8,10 +8,11 @@
 {% endblock %}
 
 {% block content_wrapped %}
-
+<div id='regrets-reporter-extension-page'>
   <!-- Hero Section with Buttons/Video -->
   {% include "./extension_hero.html" %}
   <!-- 3 col section with text -->
   {% include "./extension_text_columns.html" %}
+</div>
 
 {% endblock %}

--- a/source/js/foundation/pages/youtube-regrets/regrets-reporter/utm-buttons.js
+++ b/source/js/foundation/pages/youtube-regrets/regrets-reporter/utm-buttons.js
@@ -28,9 +28,12 @@ class regretsReporterUtmButtons {
       downloadBtn.href += params;
     });
 
+    // Encoding UTM params for mailto: links
+    const newParams = encodeURIComponent(params);
+
     const updatedEmailBtnUrls =
       emailReminderButton.href +
-      `%0D%0A%0D%0Ahttps://addons.mozilla.org/en-us/firefox/addon/regretsreporter/${params}%0D%0Ahttps://chrome.google.com/webstore/detail/regretsreporter/obpoeflheeknapimliioeoefbfaakefn${params}`;
+      `%0D%0A%0D%0Ahttps://addons.mozilla.org/en-us/firefox/addon/regretsreporter/${newParams}%0D%0Ahttps://chrome.google.com/webstore/detail/regretsreporter/obpoeflheeknapimliioeoefbfaakefn${newParams}`;
 
     emailReminderButton.href = updatedEmailBtnUrls;
   }

--- a/source/js/foundation/pages/youtube-regrets/regrets-reporter/utm-buttons.js
+++ b/source/js/foundation/pages/youtube-regrets/regrets-reporter/utm-buttons.js
@@ -1,0 +1,39 @@
+class regretsReporterUtmButtons {
+  constructor() {
+    this.checkForUtmParams();
+  }
+
+  checkForUtmParams() {
+    // Default UTM Parameters, if none are set.
+    let utmParams =
+      "?utm_medium=website&utm_source=landing_page&utm_campaign=youtuberr2021";
+
+    // If there are UTM parameters in URL, update string.
+    if (window.location.search) {
+      utmParams = window.location.search;
+    }
+
+    this.updateButtonURLs(utmParams);
+  }
+
+  updateButtonURLs(params) {
+    const downloadExtensionButtons = document.querySelectorAll(
+      `.download-link-button--firefox, .download-link-button--chrome`
+    );
+    const emailReminderButton = document.querySelector(
+      `.download-link-button--email`
+    );
+
+    downloadExtensionButtons.forEach(function (downloadBtn) {
+      downloadBtn.href += params;
+    });
+
+    const updatedEmailBtnUrls =
+      emailReminderButton.href +
+      `%0D%0A%0D%0Ahttps://addons.mozilla.org/en-us/firefox/addon/regretsreporter/${params}%0D%0Ahttps://chrome.google.com/webstore/detail/regretsreporter/obpoeflheeknapimliioeoefbfaakefn${params}`;
+
+    emailReminderButton.href = updatedEmailBtnUrls;
+  }
+}
+
+export default regretsReporterUtmButtons;

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -22,6 +22,7 @@ import MozfestHeroCarousels from "./components/mozfest-hero-carousel/mozfest-her
 import initializeSentry from "./common/sentry-config.js";
 import YouTubeRegretsTunnel from "./foundation/pages/youtube-regrets/intro-tunnel";
 import YouTubeRegretsBrowserExtension from "./foundation/pages/youtube-regrets/browser-extension";
+import RegretsReporterUtmButtons from "./foundation/pages/youtube-regrets/regrets-reporter/utm-buttons";
 import RegretsReporterTimeline from "./foundation/pages/youtube-regrets/regrets-reporter/timeline";
 import { bindEventHandlers as bindRegretsReporterEventHandlers } from "./foundation/pages/youtube-regrets/regrets-reporter";
 import { bindEventHandlers as bindDearInternetEventHandlers } from "./foundation/pages/dear-internet";
@@ -141,6 +142,10 @@ let main = {
       new YouTubeRegretsTunnel();
       new RegretsReporterTimeline();
       bindRegretsReporterEventHandlers();
+    }
+    // YouTube Regrets Reporter Extension Page
+    if (document.querySelector("#regrets-reporter-extension-page")) {
+      new RegretsReporterUtmButtons();
     }
 
     // Dear Internet page


### PR DESCRIPTION
Closes #7968 


**Steps to test**:

1. Please visit https://foundation-s-utm-button-v1xxrc.herokuapp.com/en/youtube/regretsreporter/
2. Hover or click on the download buttons, and they should append the default UTM parameters.
3. Revisit the page, this time appending the UTM parameters that you would like to test from the list sent by Lindsay.
4. Note the UTM parameters stay in the URL bar above, and are also appended to the download buttons respective download pages.