### PR TITLE
updated use of extended_yes_no / removed old 'show_value_as_symbol' flag

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/fragments/product_criterion.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/product_criterion.html
@@ -2,7 +2,7 @@
 
 {% if value != hide_value %}
 <section class="criterion {% if no_border %}no-border{% endif%} {% if ding %}show-ding{% endif %} {% if class %}{{class}}{% endif %}" {% if ding %}aria-label="{% trans "This section requires attention." %}"{% endif %}>
-  {% include "./product_criterion_primary_info.html"  with  show_value_as_symbol=show_value_as_symbol  label=label  value=value rich_text_value=rich_text_value %}
+  {% include "./product_criterion_primary_info.html"  with  label=label  value=value rich_text_value=rich_text_value %}
 
   {% if help != None and help != "" %}
     {% if rich_help_text %}

--- a/network-api/networkapi/wagtailpages/templates/fragments/product_criterion_primary_info.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/product_criterion_primary_info.html
@@ -1,4 +1,4 @@
-{% load i18n static wagtailcore_tags %}
+{% load i18n static wagtailcore_tags bg_selector_tags %}
 
 <div class="primary-info">
     <h3 class="tw-mb-4 tw-font-zilla tw-text-2xl tw-leading-7 tw-flex tw-items-center tw-flex-wrap">
@@ -14,34 +14,8 @@
         {{ value|richtext }}
       </div>
     {% else %}
-    <p class="rating pni-product-smaller-body mb-0">
-      {% if value == "Can’t Determine" or value == "CD"%}
-        {% if show_value_as_symbol %}
-        <img src="{% static "_images/buyers-guide/score/icon-unknown.svg" %}" alt="{% trans "Can’t determine" context "Unknown rating" %}">
-        {% else %}
-        {% trans "Can’t Determine" context "Unknown rating" %}
-        {% endif %}
-      {% elif value == "NA" %}
-        {% trans "Not Applicable" %}
-      {% elif value == "Yes" %}
-        {% if show_value_as_symbol %}
-        <img src="{% static "_images/buyers-guide/score/icon-yes.svg" %}" alt="{% trans "Yes" %}">
-        {% else %}
-        {% trans "Yes" %}
-        {% endif %}
-      {% elif value == "No" %}
-        {% if show_value_as_symbol %}
-        <img src="{% static "_images/buyers-guide/score/icon-no.svg" %}" alt="{% trans "No" %}">
-        {% else %}
-        {% trans "No" %}
-        {% endif %}
-      {% else %}
-        {% if show_value_as_symbol %}
-        <img src="{% get_static_prefix %}_images/buyers-guide/score/icon-{{value|lower}}.svg" alt="{{value}}">
-        {% else %}
-        {{ value }}
-        {% endif %}
-      {% endif %}
-    </p>
+      <p class="rating pni-product-smaller-body mb-0">
+        {% trans value|extended_yes_no context value|extended_yes_no %}
+      </p>
   {% endif %}
 </div>

--- a/network-api/networkapi/wagtailpages/templates/fragments/product_tab.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/product_tab.html
@@ -95,7 +95,7 @@
 
                     {% if product.product_type == 'general' %}
                     {% trans "User-friendly privacy information?" as user_friendly_privacy_policy %}
-                    {% include "fragments/product_criterion.html"  with  label=user_friendly_privacy_policy  value=product.user_friendly_privacy_policy|extended_yes_no   help=product.user_friendly_privacy_policy_helptext  %}
+                    {% include "fragments/product_criterion.html"  with  label=user_friendly_privacy_policy  value=product.user_friendly_privacy_policy help=product.user_friendly_privacy_policy_helptext  %}
                     {% endif %}
 
                     {% trans "Links to privacy information" as privacy_policy_links %}
@@ -107,7 +107,7 @@
                     {% blocktrans with url=min_sec_url|add:"#minimum-security-standards" asvar minimum_security_standards trimmed %}
                     Does this product meet our <span class="tw-ml-1"></span> <a id="mss-link" class="" href="{{ url }}">Minimum Security Standards</a>?
                     {% endblocktrans %}
-                    {% include "fragments/product_criterion.html"  with  show_value_as_symbol=False   value=product.meets_minimum_security_standards|yes_no   help=""   label=minimum_security_standards|safe   ding=product.show_ding_for_minimum_security_standards info=min_sec_url  %}
+                    {% include "fragments/product_criterion.html"  with  value=product.meets_minimum_security_standards|yes_no   help=""   label=minimum_security_standards|safe   ding=product.show_ding_for_minimum_security_standards info=min_sec_url  %}
 
                     {% trans "Encryption"              as encryption %}
                     {% trans "Security updates"        as security_updates %}
@@ -115,23 +115,22 @@
                     {% trans "Manages vulnerabilities" as manages_vulnerabilities %}
                     {% trans "Privacy policy"          as privacy_policy %}
 
-                    {% include "fragments/product_criterion.html"  with  show_value_as_symbol=False  value=product.uses_encryption                          help=product.uses_encryption_helptext         label=encryption               %}
-                    {% include "fragments/product_criterion.html"  with  show_value_as_symbol=False  value=product.strong_password                          help=product.strong_password_helptext         label=strong_password          %}
-                    {% include "fragments/product_criterion.html"  with  show_value_as_symbol=False  value=product.security_updates                         help=product.security_updates_helptext        label=security_updates         %}
-                    {% include "fragments/product_criterion.html"  with  show_value_as_symbol=False  value=product.manage_vulnerabilities                   help=product.manage_vulnerabilities_helptext  label=manages_vulnerabilities  rich_help_text=True %}
-                    {% include "fragments/product_criterion.html"  with  show_value_as_symbol=False  value=product.privacy_policy                           help=product.privacy_policy_helptext          label=privacy_policy           %}
+                    {% include "fragments/product_criterion.html"  with  value=product.uses_encryption                          help=product.uses_encryption_helptext         label=encryption               %}
+                    {% include "fragments/product_criterion.html"  with  value=product.strong_password                          help=product.strong_password_helptext         label=strong_password          %}
+                    {% include "fragments/product_criterion.html"  with  value=product.security_updates                         help=product.security_updates_helptext        label=security_updates         %}
+                    {% include "fragments/product_criterion.html"  with  value=product.manage_vulnerabilities                   help=product.manage_vulnerabilities_helptext  label=manages_vulnerabilities  rich_help_text=True %}
+                    {% include "fragments/product_criterion.html"  with  value=product.privacy_policy                           help=product.privacy_policy_helptext          label=privacy_policy           %}
                 </div>
 
                 <div class="tw-w-full tw-flex-shrink-0 medium:tw-px-7" data-product-label="2">
                     {% if product.product_type == 'general' %}
                     <section class="criterion-group">
-                        {% with product.uses_ai|extended_yes_no as uses_ai %}
                         {% trans "Does the product use AI?" as uses_ai_label %}
-                        {% include "fragments/product_criterion.html"  with  label=uses_ai_label  value=uses_ai info="/privacynotincluded/about/methodology" help=product.ai_helptext rich_help_text=True  %}
+                        {% include "fragments/product_criterion.html"  with  label=uses_ai_label  value=product.uses_ai info="/privacynotincluded/about/methodology" help=product.ai_helptext rich_help_text=True  %}
 
                         {% if product.uses_ai != "No" %}
                         {% trans "Is this AI untrustworthy?" as ai_is_untrustworthy_label %}
-                        {% include "fragments/product_criterion.html"  with  label=ai_is_untrustworthy_label  value=product.ai_is_untrustworthy|extended_yes_no ding=product.ai_is_untrustworthy_ding  %}
+                        {% include "fragments/product_criterion.html"  with  label=ai_is_untrustworthy_label  value=product.ai_is_untrustworthy ding=product.ai_is_untrustworthy_ding  %}
 
                         <section class="criterion">
                             <div class="primary-info">
@@ -143,13 +142,12 @@
                         </section>
 
                         {% trans "Is the company transparent about how the AI works?" as ai_is_transparent %}
-                        {% include "fragments/product_criterion.html"  with  label=ai_is_transparent  value=product.ai_is_transparent|extended_yes_no help=product.ai_is_transparent_helptext rich_help_text=True %}
+                        {% include "fragments/product_criterion.html"  with  label=ai_is_transparent  value=product.ai_is_transparent help=product.ai_is_transparent_helptext rich_help_text=True %}
 
                         {% trans "Does the user have control over the AI features?" as ai_can_user_control %}
-                        {% include "fragments/product_criterion.html"  with  label=ai_can_user_control  value=product.ai_can_user_control|extended_yes_no help=product.ai_can_user_control_helptext rich_help_text=True %}
+                        {% include "fragments/product_criterion.html"  with  label=ai_can_user_control  value=product.ai_can_user_control help=product.ai_can_user_control_helptext rich_help_text=True %}
 
                         {% endif %}
-                        {% endwith %}
                     </section>
                     {% endif %}
                 </div>

--- a/network-api/networkapi/wagtailpages/templates/fragments/software_product_privacy.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/software_product_privacy.html
@@ -8,5 +8,5 @@
   {% include "./product_criterion.html"  with  label=handles_recordings_how       value=product.handles_recordings_how     %}
 {% endif %}
 
-{% include "./product_criterion.html"  with  label=recording_alert              value=product.recording_alert|extended_yes_no               help=product.recording_alert_helptext               %}
-{% include "./product_criterion.html"  with  label=medical_privacy_compliant    value=product.medical_privacy_compliant|extended_boolean    help=product.medical_privacy_compliant_helptext     %}
+{% include "./product_criterion.html"  with  label=recording_alert              value=product.recording_alert              help=product.recording_alert_helptext               %}
+{% include "./product_criterion.html"  with  label=medical_privacy_compliant    value=product.medical_privacy_compliant    help=product.medical_privacy_compliant_helptext     %}

--- a/network-api/networkapi/wagtailpages/templatetags/bg_selector_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/bg_selector_tags.py
@@ -15,17 +15,6 @@ def yes_no(value):
 
 
 @register.filter
-def extended_boolean(value):
-    if value == 'Yes':
-        return gettext('Yes')
-    if value == 'No':
-        return gettext('No')
-    if value == 'U':
-        return gettext('Unknown')
-    return value
-
-
-@register.filter
 def extended_yes_no(value):
     """Converts quad-state to human readable string"""
     if value == 'CD':
@@ -36,6 +25,8 @@ def extended_yes_no(value):
         return gettext('Yes')
     if value == 'No':
         return gettext('No')
+    if value == 'U':
+        return gettext('Unknown')
     return value
 
 


### PR DESCRIPTION
Closes #7757
Related PRs/issues #

**Link to sample test page**: https://foundation-s-updated-ex-igw1dr.mofostaging.net/en/privacynotincluded/consumer-home-light-carry-contain-force/

**Steps to test**:

1. Visit the test site linked above
2. Scroll down to the "security/privacy/ai" tabs.
3. Click around, everything should look the same as before
4. If everything is behaving as expected, testing is complete!
