### PR TITLE
Ensure related posts are of the same locale

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
@@ -274,20 +274,16 @@ class BlogPage(FoundationMetadataPageMixin, Page):
                 )
             )
 
-    def save(self, *args, **kwargs):
-        """
-        Ensure that we've tried to fill in three related posts
-        for this blog post if fewer than three were set by staff
-        """
-        self.ensure_related_posts()
-        return super().save(*args, *kwargs)
-
     def clean(self):
         if self.hero_image and self.hero_video:
             raise ValidationError({
                 'hero_image': ValidationError("Please select a video OR an image for the hero section."),
                 'hero_video': ValidationError("Please select a video OR an image for the hero section.")
                 })
+
+        # Ensure that we've tried to fill in three related posts
+        # for this blog post if fewer than three were set by staff
+        self.ensure_related_posts()
 
         return super().clean()
 

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -179,9 +179,7 @@ def get_content_related_by_tag(page, result_count=3):
 
     for page_type in page_models_with_tags:
         # Get all pages that share tags with this page
-        related_pages = (
-            page_type.objects.filter(tags__in=own_tags).live()
-        )
+        related_pages = page_type.objects.filter(tags__in=own_tags).live()
 
         # Filter related pages to be of same locale as reference page
         if own_locale:

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -172,7 +172,6 @@ def get_content_related_by_tag(page, result_count=3):
 
     results = False
     own_tags = page.tags.all()
-
     own_locale = getattr(page, 'locale', None)
 
     for page_type in page_models_with_tags:

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -174,8 +174,10 @@ def get_content_related_by_tag(page, result_count=3):
     own_tags = page.tags.all()
 
     for page_type in page_models_with_tags:
-        # get all pages that share tags with this page
-        related_pages = page_type.objects.filter(tags__in=own_tags).live()
+        # Get all pages that share tags and locale  with this page
+        related_pages = (
+            page_type.objects.filter(tags__in=own_tags).filter(locale=page.locale).live()
+        )
 
         # Exlude "this page" from the result set for the page's own page type
         # so that we don't end up with "this page is most similar to itself".

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -172,11 +172,12 @@ def get_content_related_by_tag(page, result_count=3):
 
     results = False
     own_tags = page.tags.all()
+    own_locale = page.locale
 
     for page_type in page_models_with_tags:
         # Get all pages that share tags and locale  with this page
         related_pages = (
-            page_type.objects.filter(tags__in=own_tags).filter(locale=page.locale).live()
+            page_type.objects.filter(tags__in=own_tags).filter(locale=own_locale).live()
         )
 
         # Exlude "this page" from the result set for the page's own page type

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -173,9 +173,7 @@ def get_content_related_by_tag(page, result_count=3):
     results = False
     own_tags = page.tags.all()
 
-    own_locale = None
-    if hasattr(page, 'locale'):
-        own_locale = page.locale
+    own_locale = getattr(page, 'locale', None)
 
     for page_type in page_models_with_tags:
         # Get all pages that share tags with this page

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -172,7 +172,7 @@ def get_content_related_by_tag(page, result_count=3):
 
     results = False
     own_tags = page.tags.all()
-    own_locale = getattr(page, 'locale', None)
+    own_locale = page.locale
 
     for page_type in page_models_with_tags:
         # Get all pages that share tags with this page

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -172,13 +172,20 @@ def get_content_related_by_tag(page, result_count=3):
 
     results = False
     own_tags = page.tags.all()
-    own_locale = page.locale
+
+    own_locale = None
+    if hasattr(page, "locale"):
+        own_locale = page.locale
 
     for page_type in page_models_with_tags:
-        # Get all pages that share tags and locale  with this page
+        # Get all pages that share tags with this page
         related_pages = (
-            page_type.objects.filter(tags__in=own_tags).filter(locale=own_locale).live()
+            page_type.objects.filter(tags__in=own_tags).live()
         )
+
+        # Filter related pages to be of same locale as reference page
+        if own_locale:
+            related_pages = related_pages.filter(locale=own_locale)
 
         # Exlude "this page" from the result set for the page's own page type
         # so that we don't end up with "this page is most similar to itself".

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -174,7 +174,7 @@ def get_content_related_by_tag(page, result_count=3):
     own_tags = page.tags.all()
 
     own_locale = None
-    if hasattr(page, "locale"):
+    if hasattr(page, 'locale'):
         own_locale = page.locale
 
     for page_type in page_models_with_tags:


### PR DESCRIPTION
Before, it could happen that related pages would be returned that had a
different locale than the reference page.

If a reference page would have a fairly unique combination of tags, it could
happen that all related pages would be different locales of the
reference page.

This is now prevented by filtering related pages to be of the same
locale as the reference page.

Closes #7991 
Related PRs/issues #

**Link to sample test page**:


## Checklist

_Remove unnecessary checks_

**Tests**
- [x] Is the code I'm adding covered by tests? No

**Changes in Models:**
- [x] Did I update or add new fake data? No
- [x] Did I squash my migration? No migrations added
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team? Yes (no migrations)

**Documentation:**
- [x] Is my code documented? The comment is updated. 
- [x] Did I update the READMEs or wagtail documentation? No
