### PR TITLE
implemented coil on mozfest site

### DIFF
--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -2,7 +2,9 @@
 {% load wagtailcore_tags wagtailimages_tags homepage_tags card_tags wagtailmetadata_tags custom_image_tags i18n static %}
 
 
-{% block web_monetization %}{% endblock %}
+{% block web_monetization %}
+  <meta name="monetization" content="$ilp.uphold.com/aKpM9kwnGBy4">
+{% endblock %}
 
 
 {% block ga_identifier %}


### PR DESCRIPTION
Closes #8124

Using https://github.com/mozilla/foundation.mozilla.org/pull/7704 for reference, it appears that we just needed to add the monetization meta tag to the mozfest-base page in order to enable it. 

