### PR TITLE
Fix 8020: Fix progress bars for MozFest hero carousel

### DIFF
--- a/source/sass/mozfest.scss
+++ b/source/sass/mozfest.scss
@@ -302,7 +302,7 @@ body.mozfest {
     }
   }
 
-  #view-mozfest-home {
+  &#view-mozfest-home {
     .swiper-hero-pagination {
       .swiper-pagination-bullet {
         @apply tw-block tw-w-full tw-rounded-full tw-overflow-hidden tw-relative tw-bg-white;


### PR DESCRIPTION
The swiper pagination scss has recently been changed: https://github.com/mozilla/foundation.mozilla.org/commit/b5e42ed1edcb012f3ce0cf92bb45d3aa6aaeb839#diff-a3ba203a3bd2eb770b069de5e4ab5bd73270b8b9c0d8995148969bd5eff4717eR305

As part of that change, the selector for the pagination indicators have
been nested inside the overall `body.mozfest` selector.

The existing `#view-mozfest-home` selector was therefore nested in the
above mentioned selector. In the markup, both selectors point to the
same element, while the SCSS rule suggested a nesting.

The nesting is fixed by prepending `&` to the `#view-mozfest-home` rule.
This creates one long highly specific (but correct) selector.

Closes #
Related PRs/issues #8020 

**Link to sample test page**:
https://mozillafestival.mofostaging.net/en/

## Checklist

_Remove unnecessary checks_

**Tests**
- [x] Is the code I'm adding covered by tests? -> no

**Changes in Models:**
- [x] Did I update or add new fake data? -> no
- [x] Did I squash my migration? -> no, no migrations
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team? -> no migrations

**Documentation:**
- [x] Is my code documented? -> no
- [x] Did I update the READMEs or wagtail documentation? -> no
