### PR TITLE
make sure apt is up to date before install calls

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -145,6 +145,7 @@ jobs:
       run: npm ci
     - name: Install additional tooling
       run: |
+        sudo apt-get update
         sudo apt-get install -y gettext libgconf-2-4
     - name: Install Playwright
       run: npm run playwright:install

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -80,7 +80,9 @@ jobs:
     - name: Install Node Dependencies
       run: npm ci
     - name: Install additional tooling
-      run: sudo apt-get install -y gettext
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gettext
     - name: Preroll
       run: |
         npm run build
@@ -210,6 +212,7 @@ jobs:
       run: npm ci
     - name: Install additional tooling
       run: |
+        sudo apt-get update
         sudo apt-get install -y gettext libgconf-2-4
     - name: Install Playwright
       run: npm run playwright:install


### PR DESCRIPTION
This makes sure CI doesn't break on attempts to install `gettext` etc.