### PR TITLE
Contingency fix for translatable CTAs

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
@@ -313,7 +313,9 @@ class CampaignPage(MiniSiteNameSpace):
         TranslatableField('search_description'),
         SynchronizedField('search_image'),
         # Content tab fields
-        TranslatableField('cta'),
+
+        # Contingency fix while https://github.com/mozilla/foundation.mozilla.org/pull/7777 is sorted out
+        # TranslatableField('cta'),
         TranslatableField('title'),
         TranslatableField('header'),
         SynchronizedField('narrowed_page_content'),


### PR DESCRIPTION
Emergency fix for #7771 in order to unblock translation of petition pages (minus snippets).

@Pomax Can we get this live Monday or Tuesday, in order to be ready for Wednesday launch?

Thanks!