### PR TITLE
8243 - MozFest Home Page Fix

### DIFF
--- a/source/js/components/pulse-project-list/pulse-project-list.jsx
+++ b/source/js/components/pulse-project-list/pulse-project-list.jsx
@@ -66,6 +66,7 @@ class PulseProjectList extends Component {
   // Giving users ability to link to pulse objects using an anchor link
   // and having it render in the right place after recieving data.
   scrollToLinkedPulseObject() {
+    if (window.location.hash === "#/") return;
     const linkedPulseObject = document.querySelector(window.location.hash);
     linkedPulseObject?.scrollIntoView();
   }


### PR DESCRIPTION
Closes #8243 

The main problem was the pulse project list is trying to scroll to view because the tito component adds `#` to the current URL. This causes an error and makes the rest of the JS fail.
STR:
* Have a page that contains the following streamfields:
1. Tito Widget
2. Pulse Project List
3. Current Event Slider

* Make sure the current event slider works

https://mozfest-foundation-s-8243-mozfe-h2umsc.mofostaging.net/en