### PR TITLE
Refactor moment.js code to plain JS

### DIFF
--- a/source/js/components/news/news.jsx
+++ b/source/js/components/news/news.jsx
@@ -98,7 +98,7 @@ class News extends Component {
     };
 
     const startYear = 2016;
-    const currentYear = moment().year();
+    const currentYear = new Date().getFullYear();
 
     let year = startYear;
     let newsByYear = [];

--- a/source/js/components/news/news.jsx
+++ b/source/js/components/news/news.jsx
@@ -47,6 +47,14 @@ class News extends Component {
 
   render() {
     let blurb = (newsItem, hasHR = true) => {
+      let formattedDate = new Date(newsItem.date).toLocaleDateString(
+        navigator.language || `en-US`,
+        {
+          month: "long",
+          year: "numeric",
+        }
+      );
+
       return (
         <div key={newsItem.headline}>
           <div className="mb-3 news-item">
@@ -60,7 +68,7 @@ class News extends Component {
             </h3>
             <p className="h6-heading">
               {newsItem.author && <span>by {newsItem.author} on </span>}
-              {moment(newsItem.date, `YYYY-MM-DD`).format(`MMMM YYYY`)}
+              {formattedDate}
             </p>
           </div>
           {hasHR && <hr />}

--- a/source/js/components/news/news.jsx
+++ b/source/js/components/news/news.jsx
@@ -46,9 +46,11 @@ class News extends Component {
   }
 
   render() {
+    const currentLanguage = getCurrentLanguage();
+
     let blurb = (newsItem, hasHR = true) => {
-      let formattedDate = new Date(newsItem.date).toLocaleDateString(
-        navigator.language || `en-US`,
+      let formattedPublishDate  = new Date(newsItem.date).toLocaleDateString(
+        currentLanguage|| `en-US`,
         {
           month: "long",
           year: "numeric",
@@ -68,7 +70,7 @@ class News extends Component {
             </h3>
             <p className="h6-heading">
               {newsItem.author && <span>by {newsItem.author} on </span>}
-              {formattedDate}
+              {formattedPublishDate}
             </p>
           </div>
           {hasHR && <hr />}

--- a/source/js/components/news/news.jsx
+++ b/source/js/components/news/news.jsx
@@ -1,6 +1,7 @@
 import { Component } from "react";
 import PropTypes from "prop-types";
 import moment from "moment";
+import { getCurrentLanguage } from "../petition/locales";
 
 /**
  * Pulls news items from API and


### PR DESCRIPTION
Part 1 of https://github.com/mozilla/foundation.mozilla.org/issues/7310

Daniel's code copied over, but without any of the dependency removals.

Do note that the news page is kind of a weird page in that it doesn't really exist anyomre. I.e. https://foundation-s-test-momen-tb79rb.herokuapp.com/news/ exists, but https://foundation.mozilla.org/news/ was unpublished 3 months ago.

So I _think_ that means what we actually want to do is just delete anything related to the news page in the repo, but let's get that confirmed.