### PR TITLE
Define frontend container to depend on the backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     volumes:
       - .:/app:delegated
       - node_modules:/app/node_modules/:delegated
+    depends_on:
+      - backend
 
   postgres:
     image: postgres:13.2


### PR DESCRIPTION
This is, because the default start up starts the CSS watch process. This
process is waiting for the backend starting.

I have been running into issues where the frontend container seems to
hammer the backend container to test if the app was up yet. This lead to
the backend container (which in turn hit the database container)
becoming unresonsive under the load.

I am not sure defining the dependency in the container start order will
solve this issue, but it can't hurt.

I think the container start order might be involved, because the issue
is not constant. There seems to be a race condition involved or some
part that makes it random. Maybe that is the container start order. This
change will make sure the containers are starting in a consistent order.

***

I am requesting review from all of you @Pomax @danielfmiranda @fessehaye to make sure that this is not impacting any of your local dev setups negatively.

To test, you only have to stop the containers if they are currently running and restart them with `docker compose up` (after you have checked out this branch).
