### PR TITLE
Change order of python and node setup

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -146,13 +146,13 @@ def setup(ctx):
         ctx.run("docker-compose down --volumes")
         print("* Building Docker images")
         ctx.run("docker-compose build")
-        print("* Install Node dependencies")
-        npm_install(ctx)
         print("* Creating a Python virtualenv")
         ctx.run(
             "docker-compose run --rm backend python -m venv dockerpythonvenv",
             **PLATFORM_ARG,
         )
+        print("* Install Node dependencies")
+        npm_install(ctx)
         print("Done!")
         print("* Updating pip")
         ctx.run(


### PR DESCRIPTION
I was getting the following error since the frontend container was
declared to depend onthe backend container when running `inv new-env`:

```
Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "dockerpythonvenv/bin/python": stat dockerpythonvenv/bin/python: no such file or directory: unknown
```

To fix this issue, the order or node and python setup in the task need
to match the order of the containers.

***
This is a follow up to #8467

