### PR TITLE
8040 - Fix Privacy Policies generated per product

### DIFF
--- a/network-api/networkapi/wagtailpages/factory/buyersguide.py
+++ b/network-api/networkapi/wagtailpages/factory/buyersguide.py
@@ -238,8 +238,6 @@ def generate(seed):
     for i in range(52):
         # General products
         general_page = GeneralProductPageFactory.create(parent=pni_homepage,)
-        fake_privacy_policy = ProductPagePrivacyPolicyLinkFactory(page=general_page)
-        general_page.privacy_policy_links.add(fake_privacy_policy)
         general_page.save_revision().publish()
 
     print('Crosslinking related products')

--- a/tests/integration.spec.js
+++ b/tests/integration.spec.js
@@ -45,7 +45,7 @@ test(`PNI search`, async ({ page }, testInfo) => {
   await page.locator(`body.react-loaded`);
   await waitForImagesToLoad(page);
 
-  const searchTerm = 'ab'
+  const searchTerm = "ab";
 
   const counts = {
     // provided RANDOM_SEED=530910203 was used!
@@ -53,7 +53,7 @@ test(`PNI search`, async ({ page }, testInfo) => {
     health: 13,
     smart: 5,
     percy: 1,
-    searchTerm: 6,
+    searchTerm: 4,
     searchTermWithDing: 2,
   };
 


### PR DESCRIPTION
Closes #8040 

Most of this was already done in a previous migration PR (#8252) so I just added the last fix of generating only 3 privacy policies instead of 4.

1. Go to /cms
2. Open one of the buyers guide products
3.  Should only have 3 policies