### PR TITLE
Bump Django from 3.2.12 to 3.2.13

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ basket-client
 beautifulsoup4
 boto3
 cached_property==1.5.2
-Django==3.2.12
+Django==3.2.13
 dj-database-url
 djangorestframework
 django-admin-sortable==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ deprecated==1.2.13
     # via redis
 dj-database-url==0.5.0
     # via -r requirements.in
-django==3.2.12
+django==3.2.13
     # via
     #   -r requirements.in
     #   django-admin-sortable


### PR DESCRIPTION
This is to use the latest security release (severity: high).

See also:
https://docs.djangoproject.com/en/4.0/releases/3.2.13/

