### PR TITLE
7227 - Clean up the `debug_flag` context variable

### DIFF
--- a/network-api/networkapi/context_processor.py
+++ b/network-api/networkapi/context_processor.py
@@ -16,8 +16,3 @@ def canonical_path(request):
 
 def canonical_site_url(request):
     return {'CANONICAL_SITE_URL': request.scheme + '://' + request.get_host()}
-
-
-def env_debug(request):
-    debug_flag = settings.DEBUG
-    return{"debug_flag": debug_flag}

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -331,7 +331,6 @@ TEMPLATES = [
                 'networkapi.context_processor.review_app',
                 'networkapi.context_processor.canonical_path',
                 'networkapi.context_processor.canonical_site_url',
-                'networkapi.context_processor.env_debug',
                 'wagtail.contrib.settings.context_processors.settings',
             ])),
             'libraries': {
@@ -759,3 +758,10 @@ REVIEW_APP_DOMAIN = env("REVIEW_APP_DOMAIN", default=None)
 
 TITO_SECURITY_TOKEN = env("TITO_SECURITY_TOKEN", default=None)
 TITO_NEWSLETTER_QUESTION_ID = env("TITO_NEWSLETTER_QUESTION_ID", default=None)
+
+# Make sure the docker internal IP is a known internal IP, so that "debug" in templates works
+if DEBUG:
+    import os  # only if you haven't already imported this
+    import socket  # only if you haven't already imported this
+    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+    INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]

--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -41,7 +41,7 @@
 
     {% block stylesheets %}
       <link rel="stylesheet" href="{% static "_css/main.compiled.css" %}">
-      {% if debug_flag %}<link rel="stylesheet" href="{% static "_css/tailwind.compiled.css" %}">{% endif %}
+      {% if debug %}<link rel="stylesheet" href="{% static "_css/tailwind.compiled.css" %}">{% endif %}
 
       <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Nunito+Sans:400,300,700,300i,800,900,400i">
       <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,400,600,700,300i,400i,600i">

--- a/network-api/networkapi/wagtailpages/templates/buyersguide/bg_base.html
+++ b/network-api/networkapi/wagtailpages/templates/buyersguide/bg_base.html
@@ -29,7 +29,7 @@
 
 
 {% block stylesheets %}
-  {% if debug_flag %}<link rel="stylesheet" href="{% static "_css/tailwind.compiled.css" %}">{% endif %}
+  {% if debug %}<link rel="stylesheet" href="{% static "_css/tailwind.compiled.css" %}">{% endif %}
   <link rel="stylesheet" href="{% static "_css/buyers-guide.compiled.css" %}">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Nunito+Sans:400,300,700,300i,400i">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,400,600,700,300i,400i,600i">


### PR DESCRIPTION
Closes #7227 

removing debug_flag template and replacing with default django debug variable

For testing:
* Opening the review app and making sure the `tailwind.compiled.css` isn't included in dev tools should be enough!