### PR TITLE
8586 - Remove newlines from sticky nav titles

### DIFF
--- a/source/js/foundation/template-js-handler/publication-summary-bar.js
+++ b/source/js/foundation/template-js-handler/publication-summary-bar.js
@@ -26,7 +26,7 @@ export default () => {
     // update the title based on the header in the article in past by
     const titleObserver = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
-        const title = entry.target.innerText;
+        const title = entry.target.innerText.trim();
         if (entry.intersectionRatio > 0) {
           document.querySelector(
             ".dropdown-toggle.article-summary-toggle span"


### PR DESCRIPTION
Closes #8586 

This is caused by the titles getting <br/> from within the h2 tags. Easiest solution is just trimming additional whitespace. 

I would just check some articles and see if the sticky navigation looks normal!