### PR TITLE
8551 - Child Publications displaying Parent Publications Menu

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/fragments/article_subnav.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/article_subnav.html
@@ -23,6 +23,13 @@
         {% endif %}
       </div>
     </div>
-    {% include "sticky_dropdown.html" %}
+    {% if page.get_parent.get_parent.specific.is_publication_page %}
+      {% comment %}
+        Needed for child publications within publications
+      {% endcomment %}
+      {% include "sticky_dropdown.html" with page=page.get_parent %}
+    {% else %}
+      {% include "sticky_dropdown.html" with page=page %}
+    {% endif %}
   </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/sticky_dropdown.html
+++ b/network-api/networkapi/wagtailpages/templates/sticky_dropdown.html
@@ -1,5 +1,4 @@
 {% load i18n wagtailimages_tags wagtailcore_tags static %}
-
 <div class="
     tw-absolute 
     tw-overflow-auto
@@ -13,7 +12,7 @@
     tw-border 
   tw-border-gray-20 
     article-summary-menu" aria-labelledby="summaryMenu">
-    {% if page.get_parent and page.is_publication_article %}
+    {% if page.get_parent and page.get_parent.specific.is_publication_page %}
     <div class="article-container">
         <div class="tw-px-4 medium:tw-px-[3.5rem] large:tw-px-7 tw-py-[1.4rem] tw-sticky tw-top-0 tw-left-0 tw-bg-white">
         <div class="tw-text-2xl tw-leading-6 tw-font-zilla">{% trans "Table of Contents" %}</div>
@@ -88,19 +87,19 @@
     </div>
     
     {% else %}
-    <div class="article-container">
-    <div class="tw-px-4 medium:tw-px-[3.5rem] large:tw-px-7 tw-pt-6 tw-text-2xl tw-leading-6 tw-font-zilla">
-        {% trans "Summary" %}
-    </div>
-    <div class="tw-divide-y tw-divide-gray-20 tw-flex tw-flex-col tw-pb-6">
-        {% for slug, header in get_titles %}
-        <a class="tw-whitespace-normal tw-py-5 tw-px-4 medium:tw-px-[3.5rem] large:tw-px-7 tw-text-black hover:tw-no-underline hover:tw-text-blue" href="#{{ slug }}">{{ header }}</a>
-        {% endfor %}
-    </div>
-    </div>
+        <div class="article-container">
+            <div class="tw-px-4 medium:tw-px-[3.5rem] large:tw-px-7 tw-pt-6 tw-text-2xl tw-leading-6 tw-font-zilla">
+                {% trans "Summary" %}
+            </div>
+            <div class="tw-divide-y tw-divide-gray-20 tw-flex tw-flex-col tw-pb-6">
+                {% for slug, header in get_titles %}
+                <a class="tw-whitespace-normal tw-py-5 tw-px-4 medium:tw-px-[3.5rem] large:tw-px-7 tw-text-black hover:tw-no-underline hover:tw-text-blue" href="#{{ slug }}">{{ header }}</a>
+                {% endfor %}
+            </div>
+        </div>
     {% endif %}
 
-    {% if page.get_parent and page.is_publication_article %}
+    {% if page.get_parent and page.get_parent.specific.is_publication_page %}
         {% include "publication_child_menu.html" %}
     {% endif %}
 </div>


### PR DESCRIPTION
Closes #8551 

If you using the staging/live data:
Go to 'localhost:8000/en/insights/trustworthy-ai-whitepaper/path-forward/introduction-theory-change/'
Click on 'SHOW ALL' in the sticky menu
See that only the table of contents for 'The Path Forward' is shown vs the table of contents for 'Creating Trustworthy AI'

Else you can do a similar test with 
`/publication-page-with-chapter-pages`
`/publication-page-with-child-article-pages`