### PR TITLE
8567 - Add debounce on input field

### DIFF
--- a/source/js/buyers-guide/search/search-filter.js
+++ b/source/js/buyers-guide/search/search-filter.js
@@ -12,6 +12,11 @@ export class SearchFilter {
   constructor() {
     gsap.registerPlugin(ScrollTrigger);
     gsap.defaults({ ease: "power3" });
+    gsap.config({
+      nullTargetWarn: false,
+    });
+    this.allProducts = document.querySelectorAll(`figure.product-box`);
+    this.categoryTitle = document.querySelector(`.category-title`);
 
     const { searchBar, searchInput } = this.setupSearchBar();
     setupNavLinks(this);
@@ -22,9 +27,6 @@ export class SearchFilter {
     [`mousedown`, `touchstart`].forEach((type) =>
       subContainer.addEventListener(type, markScrollStart)
     );
-
-    this.allProducts = document.querySelectorAll(`figure.product-box`);
-    this.categoryTitle = document.querySelector(`.category-title`);
 
     // we want the animation to start when the first eight products images are loaded
     Promise.allSettled(
@@ -65,19 +67,30 @@ export class SearchFilter {
       );
     }
 
+    const debounce = (fn, ms = 0) => {
+      let timeoutId;
+      return function (...args) {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => fn.apply(this, args), ms);
+      };
+    };
+
     const searchInput = (this.searchInput = searchBar.querySelector(`input`));
 
-    searchInput.addEventListener(`input`, (evt) => {
-      const searchText = searchInput.value.trim();
+    searchInput.addEventListener(
+      `input`,
+      debounce(() => {
+        const searchText = searchInput.value.trim();
 
-      if (searchText) {
-        searchBar.classList.add(`has-content`);
-        this.filter(searchText);
-      } else {
-        this.clearText();
-        applyHistory(this);
-      }
-    });
+        if (searchText) {
+          searchBar.classList.add(`has-content`);
+          this.filter(searchText);
+        } else {
+          this.clearText();
+          applyHistory(this);
+        }
+      }, 500)
+    );
 
     const clear = searchBar.querySelector(`.clear-icon`);
     if (!clear) {

--- a/source/js/buyers-guide/search/utils.js
+++ b/source/js/buyers-guide/search/utils.js
@@ -213,7 +213,9 @@ export class Utils {
    * Animation used for category selections
    */
   static toggleCategoryAnimation(initialLoad = false) {
-    gsap.set("figure.product-box.d-flex", { opacity: 0, y: 100 });
+    if (document.querySelectorAll("figure.product-box.d-flex")) {
+      gsap.set("figure.product-box.d-flex", { opacity: 0, y: 100 });
+    }
 
     if (initialLoad) {
       gsap.set("figure.product-box.d-flex:nth-child(-n+8)", {


### PR DESCRIPTION
Closes #8567 

There was a bug when you refresh the screen with something inside the search bar it would cause an error so that is resolved now.

I do not think safari in general like a bunch of keys on inputs with event listeners compared to other browsers so we are adding an debounce on the input field that delays invoking the provided function until at least 500ms milliseconds have elapsed since its last invocation

Hopefully that resolves all of the iphone issues reported but it is still hard to test in general without a physical device