### PR TITLE
Hide empty filter groups on library page

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/library_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/library_page.py
@@ -131,16 +131,41 @@ class ResearchLibraryPage(research_base.ResearchHubBasePage):
         return context
 
     def _get_author_options(self):
-        author_options = profile_models.Profile.objects.filter_research_authors()
-        return utils.localize_queryset(author_options)
+        author_profiles = profile_models.Profile.objects.filter_research_authors()
+        author_profiles = utils.localize_queryset(author_profiles)
+        return [
+            {
+                'id': author_profile.id,
+                'value': author_profile.id,
+                'label': author_profile.name,
+            }
+            for author_profile in author_profiles
+        ]
+
 
     def _get_topic_options(self):
         topics = taxonomies.ResearchTopic.objects.all()
-        return utils.localize_queryset(topics)
+        topics = utils.localize_queryset(topics)
+        return [
+            {
+                'id': topic.id,
+                'value': topic.id,
+                'label': topic.name,
+            }
+            for topic in topics
+        ]
 
     def _get_region_options(self):
         regions = taxonomies.ResearchRegion.objects.all()
-        return utils.localize_queryset(regions)
+        regions = utils.localize_queryset(regions)
+        return [
+            {
+                'id': region.id,
+                'value': region.id,
+                'label': region.name,
+            }
+            for region in regions
+        ]
 
     def _get_year_options(self):
         return [

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/library_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/library_page.py
@@ -143,7 +143,6 @@ class ResearchLibraryPage(research_base.ResearchHubBasePage):
             for author_profile in author_profiles
         ]
 
-
     def _get_topic_options(self):
         topics = taxonomies.ResearchTopic.objects.all()
         topics = utils.localize_queryset(topics)

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/library_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/library_page.py
@@ -4,6 +4,7 @@ from typing import Optional
 from django.core import paginator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import pgettext_lazy
 from wagtail import images as wagtail_images
 from wagtail.admin import edit_handlers as panels
 from wagtail.images import edit_handlers as image_panels
@@ -168,15 +169,25 @@ class ResearchLibraryPage(research_base.ResearchHubBasePage):
         ]
 
     def _get_year_options(self):
-        return [
-            date.year
-            for date
-            in detail_page.ResearchDetailPage.objects.dates(
-                'original_publication_date',
-                'year',
-                order='DESC',
-            )
+        dates = detail_page.ResearchDetailPage.objects.dates(
+            'original_publication_date',
+            'year',
+            order='DESC',
+        )
+        year_options = [
+            {
+                'id': date.year,
+                'value': date.year,
+                'label': date.year,
+            }
+            for date in dates
         ]
+        empty_option = {
+            'id': 'any',
+            'value': '',
+            'label': pgettext_lazy('Option in a list of years', 'Any'),
+        }
+        return [empty_option] + year_options
 
     def _get_research_detail_pages(
         self,

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/research_filter_group.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/research_filter_group.html
@@ -1,0 +1,14 @@
+
+<div class="tw-pt-4 tw-pb-7 tw-border-t">
+  <fieldset>
+    <legend><h3 class="tw-h4-heading">{{ heading }}</h3></legend>
+    <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
+      {% for option in options %}
+        <li class="tw-flex tw-flex-row tw-items-baseline">
+          <input type="checkbox" value="{{ option.value }}" name="{{ field_name }}" id="{{ field_name }}-option-{{ option.id }}" {% if option.value in checked_option_values %}checked{% endif %} form="search-form" class="rh-checkbox" />
+          <label for="{{ field_name }}-option-{{ option.id }}" >{{ option.label }}</label>
+        </li>
+      {% endfor %}
+    </ul>
+  </fieldset>
+</div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/research_filter_group.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/research_filter_group.html
@@ -1,11 +1,10 @@
-
 <div class="tw-pt-4 tw-pb-7 tw-border-t">
   <fieldset>
     <legend><h3 class="tw-h4-heading">{{ heading }}</h3></legend>
     <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
       {% for option in options %}
         <li class="tw-flex tw-flex-row tw-items-baseline">
-          <input type="checkbox" value="{{ option.value }}" name="{{ field_name }}" id="{{ field_name }}-option-{{ option.id }}" {% if option.value in checked_option_values %}checked{% endif %} form="search-form" class="rh-checkbox" />
+          <input type="{{ radio|yesno:'radio,checkbox' }}" value="{{ option.value }}" name="{{ field_name }}" id="{{ field_name }}-option-{{ option.id }}" {% if option.value in checked_option_values or option.value == checked_option_value %}checked{% endif %} form="search-form" class="{% if radio %} rh-radio {% else %} rh-checkbox {% endif %}" />
           <label for="{{ field_name }}-option-{{ option.id }}" >{{ option.label }}</label>
         </li>
       {% endfor %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -121,19 +121,23 @@
           </ul>
         </fieldset>
       </div>
-      <div class="tw-pt-4 tw-pb-7 tw-border-t">
-        <fieldset>
-          <legend><h3 class="tw-h4-heading">{% translate 'Authors' %}</h3></legend>
-          <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if author_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
-            {% for author in author_options|dictsort:"name" %}
-              <li class="tw-flex tw-flex-row tw-items-baseline">
-                <input type="checkbox" value="{{ author.id }}" name="author" id="author-option-{{ author.id }}" {% if author.id in filtered_author_ids %}checked{% endif %} form="search-form" class="rh-checkbox" />
-                <label for="author-option-{{ author.id }}">{{ author.name }}</label>
-              </li>
-            {% endfor %}
-        </fieldset>
-          </ul>
-      </div>
+
+      {% if author_options %}
+        <div class="tw-pt-4 tw-pb-7 tw-border-t">
+          <fieldset>
+            <legend><h3 class="tw-h4-heading">{% translate 'Authors' %}</h3></legend>
+            <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if author_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
+              {% for author in author_options|dictsort:"name" %}
+                <li class="tw-flex tw-flex-row tw-items-baseline">
+                  <input type="checkbox" value="{{ author.id }}" name="author" id="author-option-{{ author.id }}" {% if author.id in filtered_author_ids %}checked{% endif %} form="search-form" class="rh-checkbox" />
+                  <label for="author-option-{{ author.id }}">{{ author.name }}</label>
+                </li>
+              {% endfor %}
+            </ul>
+          </fieldset>
+        </div>
+      {% endif %}
+
       <div class="tw-pt-4 tw-pb-7 tw-border-t">
         <fieldset>
           <legend><h3 class="tw-h4-heading">{% translate 'Regions' %}</h3></legend>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -92,19 +92,8 @@
       <h2 class="large:tw-hidden tw-h1-heading">{% translate 'Filter' %}</h2>
 
       {% if topic_options %}
-        <div class="tw-pt-4 tw-pb-7 tw-border-t">
-          <fieldset>
-            <legend><h3 class="tw-h4-heading">{% translate 'Topics' %}</h3></legend>
-            <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if topic_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
-              {% for topic in topic_options|dictsort:"name" %}
-                <li class="tw-flex tw-flex-row tw-items-baseline">
-                  <input type="checkbox" value="{{ topic.id }}" name="topic" id="topic-option-{{ topic.id }}" {% if topic.id in filtered_topic_ids %}checked{% endif %} form="search-form" class="rh-checkbox" />
-                  <label for="topic-option-{{ topic.id }}" >{{ topic.name }}</label>
-                </li>
-              {% endfor %}
-            </ul>
-          </fieldset>
-        </div>
+        {% translate 'Topics' as heading %}
+        {% include "wagtailpages/fragments/research_filter_group.html" with heading=heading options=topic_options|dictsort:'label' checked_option_values=filtered_topic_ids field_name='topic' %}
       {% endif %}
 
       {% if year_options %}
@@ -128,35 +117,13 @@
       {% endif %}
 
       {% if author_options %}
-        <div class="tw-pt-4 tw-pb-7 tw-border-t">
-          <fieldset>
-            <legend><h3 class="tw-h4-heading">{% translate 'Authors' %}</h3></legend>
-            <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if author_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
-              {% for author in author_options|dictsort:"name" %}
-                <li class="tw-flex tw-flex-row tw-items-baseline">
-                  <input type="checkbox" value="{{ author.id }}" name="author" id="author-option-{{ author.id }}" {% if author.id in filtered_author_ids %}checked{% endif %} form="search-form" class="rh-checkbox" />
-                  <label for="author-option-{{ author.id }}">{{ author.name }}</label>
-                </li>
-              {% endfor %}
-            </ul>
-          </fieldset>
-        </div>
+        {% translate 'Authors' as heading %}
+        {% include "wagtailpages/fragments/research_filter_group.html" with heading=heading options=author_options|dictsort:'label' checked_option_values=filtered_author_ids field_name='author' %}
       {% endif %}
 
       {% if region_options %}
-        <div class="tw-pt-4 tw-pb-7 tw-border-t">
-          <fieldset>
-            <legend><h3 class="tw-h4-heading">{% translate 'Regions' %}</h3></legend>
-            <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if region_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
-              {% for region in region_options|dictsort:"name" %}
-                <li class="tw-flex tw-flex-row tw-items-baseline">
-                  <input type="checkbox" value="{{ region.id }}" name="region" id="region-option-{{ region.id }}" {% if region.id in filtered_region_ids %}checked{% endif %} form="search-form" class="rh-checkbox"/>
-                  <label for="region-option-{{ region.id }}">{{ region.name }}</label>
-                </li>
-              {% endfor %}
-            </ul>
-          </fieldset>
-        </div>
+        {% translate 'Regions' as heading %}
+        {% include "wagtailpages/fragments/research_filter_group.html" with heading=heading options=region_options|dictsort:'label' checked_option_values=filtered_region_ids field_name='region' %}
       {% endif %}
 
       <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -97,23 +97,8 @@
       {% endif %}
 
       {% if year_options %}
-        <div class="tw-pt-4 tw-pb-7 tw-border-t">
-          <fieldset>
-            <legend><h3 class="tw-h4-heading">{% translate 'Publication date' %}</h3></legend>
-            <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if year_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
-              <li class="tw-flex tw-flex-row tw-items-baseline">
-                <input type="radio" value="" name="year" id="year-option-all" {% if not filtered_year %}checked{% endif %} form="search-form" class="rh-radio" />
-                <label for="year-option-all">{% translate 'Any' context 'Option in a radio button list of years' %}</label>
-              </li>
-              {% for year in year_options %}
-                <li class="tw-flex tw-flex-row tw-items-baseline">
-                  <input type="radio" value="{{ year }}" name="year" id="year-option-{{ year }}" {% if year == filtered_year %}checked{% endif %} form="search-form" class="rh-radio" />
-                  <label for="year-option-{{ year }}">{{ year }}</label>
-                </li>
-              {% endfor %}
-            </ul>
-          </fieldset>
-        </div>
+        {% translate 'Publication date' as heading %}
+        {% include "wagtailpages/fragments/research_filter_group.html" with heading=heading radio=True options=year_options checked_option_value=filtered_year field_name='year' %}
       {% endif %}
 
       {% if author_options %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -91,19 +91,23 @@
       <div>
         <h2 class="large:tw-hidden tw-h1-heading">{% translate 'Filter' %}</h2>
       </div>
-      <div class="tw-pt-4 tw-pb-7 tw-border-t">
-        <fieldset>
-          <legend><h3 class="tw-h4-heading">{% translate 'Topics' %}</h3></legend>
-          <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if topic_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
-            {% for topic in topic_options|dictsort:"name" %}
-              <li class="tw-flex tw-flex-row tw-items-baseline">
-                <input type="checkbox" value="{{ topic.id }}" name="topic" id="topic-option-{{ topic.id }}" {% if topic.id in filtered_topic_ids %}checked{% endif %} form="search-form" class="rh-checkbox" />
-                <label for="topic-option-{{ topic.id }}" >{{ topic.name }}</label>
-              </li>
-            {% endfor %}
-          </ul>
-        </fieldset>
-      </div>
+
+      {% if topic_options %}
+        <div class="tw-pt-4 tw-pb-7 tw-border-t">
+          <fieldset>
+            <legend><h3 class="tw-h4-heading">{% translate 'Topics' %}</h3></legend>
+            <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if topic_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
+              {% for topic in topic_options|dictsort:"name" %}
+                <li class="tw-flex tw-flex-row tw-items-baseline">
+                  <input type="checkbox" value="{{ topic.id }}" name="topic" id="topic-option-{{ topic.id }}" {% if topic.id in filtered_topic_ids %}checked{% endif %} form="search-form" class="rh-checkbox" />
+                  <label for="topic-option-{{ topic.id }}" >{{ topic.name }}</label>
+                </li>
+              {% endfor %}
+            </ul>
+          </fieldset>
+        </div>
+      {% endif %}
+
       <div class="tw-pt-4 tw-pb-7 tw-border-t">
         <fieldset>
           <legend><h3 class="tw-h4-heading">{% translate 'Publication date' %}</h3></legend>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -107,23 +107,25 @@
         </div>
       {% endif %}
 
-      <div class="tw-pt-4 tw-pb-7 tw-border-t">
-        <fieldset>
-          <legend><h3 class="tw-h4-heading">{% translate 'Publication date' %}</h3></legend>
-          <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if year_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
-            <li class="tw-flex tw-flex-row tw-items-baseline">
-              <input type="radio" value="" name="year" id="year-option-all" {% if not filtered_year %}checked{% endif %} form="search-form" class="rh-radio" />
-              <label for="year-option-all">{% translate 'Any' context 'Option in a radio button list of years' %}</label>
-            </li>
-            {% for year in year_options %}
+      {% if year_options %}
+        <div class="tw-pt-4 tw-pb-7 tw-border-t">
+          <fieldset>
+            <legend><h3 class="tw-h4-heading">{% translate 'Publication date' %}</h3></legend>
+            <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if year_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
               <li class="tw-flex tw-flex-row tw-items-baseline">
-                <input type="radio" value="{{ year }}" name="year" id="year-option-{{ year }}" {% if year == filtered_year %}checked{% endif %} form="search-form" class="rh-radio" />
-                <label for="year-option-{{ year }}">{{ year }}</label>
+                <input type="radio" value="" name="year" id="year-option-all" {% if not filtered_year %}checked{% endif %} form="search-form" class="rh-radio" />
+                <label for="year-option-all">{% translate 'Any' context 'Option in a radio button list of years' %}</label>
               </li>
-            {% endfor %}
-          </ul>
-        </fieldset>
-      </div>
+              {% for year in year_options %}
+                <li class="tw-flex tw-flex-row tw-items-baseline">
+                  <input type="radio" value="{{ year }}" name="year" id="year-option-{{ year }}" {% if year == filtered_year %}checked{% endif %} form="search-form" class="rh-radio" />
+                  <label for="year-option-{{ year }}">{{ year }}</label>
+                </li>
+              {% endfor %}
+            </ul>
+          </fieldset>
+        </div>
+      {% endif %}
 
       {% if author_options %}
         <div class="tw-pt-4 tw-pb-7 tw-border-t">
@@ -141,19 +143,22 @@
         </div>
       {% endif %}
 
-      <div class="tw-pt-4 tw-pb-7 tw-border-t">
-        <fieldset>
-          <legend><h3 class="tw-h4-heading">{% translate 'Regions' %}</h3></legend>
-          <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if region_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
-            {% for region in region_options|dictsort:"name" %}
-              <li class="tw-flex tw-flex-row tw-items-baseline">
-                <input type="checkbox" value="{{ region.id }}" name="region" id="region-option-{{ region.id }}" {% if region.id in filtered_region_ids %}checked{% endif %} form="search-form" class="rh-checkbox"/>
-                <label for="region-option-{{ region.id }}">{{ region.name }}</label>
-              </li>
-            {% endfor %}
-          </ul>
-        </fieldset>
-      </div>
+      {% if region_options %}
+        <div class="tw-pt-4 tw-pb-7 tw-border-t">
+          <fieldset>
+            <legend><h3 class="tw-h4-heading">{% translate 'Regions' %}</h3></legend>
+            <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if region_options|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll {% endif %}">
+              {% for region in region_options|dictsort:"name" %}
+                <li class="tw-flex tw-flex-row tw-items-baseline">
+                  <input type="checkbox" value="{{ region.id }}" name="region" id="region-option-{{ region.id }}" {% if region.id in filtered_region_ids %}checked{% endif %} form="search-form" class="rh-checkbox"/>
+                  <label for="region-option-{{ region.id }}">{{ region.name }}</label>
+                </li>
+              {% endfor %}
+            </ul>
+          </fieldset>
+        </div>
+      {% endif %}
+
       <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>
     </div>
   </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -88,9 +88,8 @@
           <span aria-hidden="true" class="">&times;</span>
         </button>
       </div>
-      <div>
-        <h2 class="large:tw-hidden tw-h1-heading">{% translate 'Filter' %}</h2>
-      </div>
+
+      <h2 class="large:tw-hidden tw-h1-heading">{% translate 'Filter' %}</h2>
 
       {% if topic_options %}
         <div class="tw-pt-4 tw-pb-7 tw-border-t">

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
@@ -302,26 +302,28 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         )
         self.assertEqual(default_sort_detail_pages, newest_first_detail_pages)
 
-    def test_research_author_profile_in_context(self):
+    def test_research_author_profile_in_options(self):
         detail_page = research_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
 
         response = self.client.get(self.library_page.url)
 
+        author_option_values = [i['value'] for i in response.context['author_options']]
         self.assertIn(
-            detail_page.research_authors.first().author_profile,
-            response.context['author_options'],
+            detail_page.research_authors.first().author_profile.id,
+            author_option_values,
         )
 
-    def test_non_research_author_profile_not_in_context(self):
+    def test_non_research_author_profile_not_in_options(self):
         profile = profiles_factory.ProfileFactory()
 
         response = self.client.get(self.library_page.url)
 
+        author_option_values = [i['value'] for i in response.context['author_options']]
         self.assertNotIn(
-            profile,
-            response.context['author_options'],
+            profile.id,
+            author_option_values,
         )
 
     def test_research_author_in_context_aliased_detail_page_fr(self):
@@ -339,9 +341,10 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
         response = self.client.get(self.library_page.localized.url)
 
+        author_option_values = [i['value'] for i in response.context['author_options']]
         self.assertIn(
-            profile_en,
-            response.context['author_options'],
+            profile_en.id,
+            author_option_values,
         )
 
     def test_research_author_in_context_translated_detail_page_fr(self):
@@ -361,13 +364,14 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
         response = self.client.get(self.library_page.localized.url)
 
+        author_option_values = [i['value'] for i in response.context['author_options']]
         self.assertNotIn(
-            profile_en,
-            response.context['author_options'],
+            profile_en.id,
+            author_option_values,
         )
         self.assertIn(
-            profile_fr,
-            response.context['author_options'],
+            profile_fr.id,
+            author_option_values,
         )
 
     def test_filter_author_profile(self):
@@ -457,18 +461,18 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(detail_page_1, research_detail_pages)
         self.assertNotIn(detail_page_2, research_detail_pages)
 
-    def test_research_topics_in_context(self):
+    def test_research_topics_in_options(self):
         topic_1 = research_factory.ResearchTopicFactory()
         topic_2 = research_factory.ResearchTopicFactory()
 
         response = self.client.get(self.library_page.url)
 
-        topic_options = response.context['topic_options']
-        self.assertEqual(len(topic_options), 2)
-        self.assertIn(topic_1, topic_options)
-        self.assertIn(topic_2, topic_options)
+        topic_option_values = [i['value'] for i in response.context['topic_options']]
+        self.assertEqual(len(topic_option_values), 2)
+        self.assertIn(topic_1.id, topic_option_values)
+        self.assertIn(topic_2.id, topic_option_values)
 
-    def test_topic_in_context_matches_active_locale(self):
+    def test_topic_in_options_matches_active_locale(self):
         topic_en = research_factory.ResearchTopicFactory()
         topic_fr = topic_en.copy_for_translation(self.fr_locale)
         topic_fr.save()
@@ -477,14 +481,18 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         translation.activate(self.fr_locale.language_code)
         response_fr = self.client.get(self.library_page.localized.url)
 
-        topic_options_en = response_en.context['topic_options']
-        self.assertEqual(len(topic_options_en), 1)
-        self.assertIn(topic_en, topic_options_en)
-        self.assertNotIn(topic_fr, topic_options_en)
-        topic_options_fr = response_fr.context['topic_options']
-        self.assertEqual(len(topic_options_fr), 1)
-        self.assertNotIn(topic_en, topic_options_fr)
-        self.assertIn(topic_fr, topic_options_fr)
+        topic_option_values_en = [
+            i['value'] for i in response_en.context['topic_options']
+        ]
+        self.assertEqual(len(topic_option_values_en), 1)
+        self.assertIn(topic_en.id, topic_option_values_en)
+        self.assertNotIn(topic_fr.id, topic_option_values_en)
+        topic_option_values_fr = [
+            i['value'] for i in response_fr.context['topic_options']
+        ]
+        self.assertEqual(len(topic_option_values_fr), 1)
+        self.assertNotIn(topic_en.id, topic_option_values_fr)
+        self.assertIn(topic_fr.id, topic_option_values_fr)
 
     def test_localized_topic_options(self):
         '''
@@ -502,11 +510,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
         response = self.client.get(self.library_page.localized.url)
 
-        topic_options = response.context['topic_options']
-        self.assertEqual(len(topic_options), 2)
-        self.assertNotIn(topic_1_en, topic_options)
-        self.assertIn(topic_1_fr, topic_options)
-        self.assertIn(topic_2_en, topic_options)
+        topic_option_values = [i['value'] for i in response.context['topic_options']]
+        self.assertEqual(len(topic_option_values), 2)
+        self.assertNotIn(topic_1_en.id, topic_option_values)
+        self.assertIn(topic_1_fr.id, topic_option_values)
+        self.assertIn(topic_2_en.id, topic_option_values)
 
     def test_filter_topic(self):
         topic_A = research_factory.ResearchTopicFactory()
@@ -592,18 +600,18 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(detail_page_1, research_detail_pages)
         self.assertNotIn(detail_page_2, research_detail_pages)
 
-    def test_research_regions_in_context(self):
+    def test_research_regions_in_options(self):
         region_1 = research_factory.ResearchRegionFactory()
         region_2 = research_factory.ResearchRegionFactory()
 
         response = self.client.get(self.library_page.url)
 
-        region_options = response.context['region_options']
-        self.assertEqual(len(region_options), 2)
-        self.assertIn(region_1, region_options)
-        self.assertIn(region_2, region_options)
+        region_option_values = [i['value'] for i in response.context['region_options']]
+        self.assertEqual(len(region_option_values), 2)
+        self.assertIn(region_1.id, region_option_values)
+        self.assertIn(region_2.id, region_option_values)
 
-    def test_region_in_context_matches_active_locale(self):
+    def test_region_in_options_matches_active_locale(self):
         region_en = research_factory.ResearchRegionFactory()
         region_fr = region_en.copy_for_translation(self.fr_locale)
         region_fr.save()
@@ -612,14 +620,18 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         translation.activate(self.fr_locale.language_code)
         response_fr = self.client.get(self.library_page.localized.url)
 
-        region_options_en = response_en.context['region_options']
-        self.assertEqual(len(region_options_en), 1)
-        self.assertIn(region_en, region_options_en)
-        self.assertNotIn(region_fr, region_options_en)
-        region_options_fr = response_fr.context['region_options']
-        self.assertEqual(len(region_options_fr), 1)
-        self.assertNotIn(region_en, region_options_fr)
-        self.assertIn(region_fr, region_options_fr)
+        region_option_values_en = [
+            i['value'] for i in response_en.context['region_options']
+        ]
+        self.assertEqual(len(region_option_values_en), 1)
+        self.assertIn(region_en.id, region_option_values_en)
+        self.assertNotIn(region_fr.id, region_option_values_en)
+        region_option_values_fr = [
+            i['value'] for i in response_fr.context['region_options']
+        ]
+        self.assertEqual(len(region_option_values_fr), 1)
+        self.assertNotIn(region_en.id, region_option_values_fr)
+        self.assertIn(region_fr.id, region_option_values_fr)
 
     def test_localized_region_options(self):
         '''
@@ -637,11 +649,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
         response = self.client.get(self.library_page.localized.url)
 
-        region_options = response.context['region_options']
-        self.assertEqual(len(region_options), 2)
-        self.assertNotIn(region_1_en, region_options)
-        self.assertIn(region_1_fr, region_options)
-        self.assertIn(region_2_en, region_options)
+        region_option_values = [i['value'] for i in response.context['region_options']]
+        self.assertEqual(len(region_option_values), 2)
+        self.assertNotIn(region_1_en.id, region_option_values)
+        self.assertIn(region_1_fr.id, region_option_values)
+        self.assertIn(region_2_en.id, region_option_values)
 
     def test_filter_region(self):
         region_A = research_factory.ResearchRegionFactory()
@@ -727,7 +739,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(detail_page_1, research_detail_pages)
         self.assertNotIn(detail_page_2, research_detail_pages)
 
-    def test_years_in_context(self):
+    def test_years_in_options(self):
         detail_page_1 = research_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
@@ -739,10 +751,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
         response = self.client.get(self.library_page.url)
 
-        year_options = response.context['year_options']
-        self.assertEqual(len(year_options), 2)
-        self.assertIn(year_1, year_options)
-        self.assertIn(year_2, year_options)
+        year_option_values = [i['value'] for i in response.context['year_options']]
+        # It's 3 options because of the two years and the "any" option.
+        self.assertEqual(len(year_option_values), 3)
+        self.assertIn(year_1, year_option_values)
+        self.assertIn(year_2, year_option_values)
 
     def test_filter_for_year(self):
         detail_page_1 = research_factory.ResearchDetailPageFactory(


### PR DESCRIPTION
## Description

This PR wraps the rendering of each of the filter groups in the filter section on the research hub library page in a conditional that tests that there are options to be displayed. This is to make sure we are not rendering the headings when there are no values to display. 

Also, this PR extracts the repeated HTML for a filter group into a fragment. The methods on the library page are adjusted to return dictionaries instead of objects so that the list values better fit for the reusability of the filter groups. 

Closes #8766 
Related PRs/issues #

**Link to sample test page**: n/a


## Checklist

_Remove unnecessary checks_

**Tests**
- [x] Is the code I'm adding covered by tests? -> Yes

**Changes in Models:**
- [x] Did I update or add new fake data? -> No
- [x] Did I squash my migration? -> No migrations added. 
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team? -> Yes, backwards-compatible

**Documentation:**
- [x] Is my code documented? -> No
- [x] Did I update the READMEs or wagtail documentation? -> No
