### PR TITLE
8658 checkbox color

### DIFF
--- a/source/sass/research-hub.scss
+++ b/source/sass/research-hub.scss
@@ -1,9 +1,9 @@
 input[type="checkbox"].rh-checkbox {
-  @apply tw-form-checkbox tw-relative tw-top-[3px] tw-mr-3 tw-w-[20px] tw-h-[20px] tw-border tw-border-gray-60 checked:tw-bg-pni-purple-pink focus:checked:tw-bg-pni-purple-pink focus:tw-outline-pni-purple-pink;
+  @apply tw-form-checkbox tw-relative tw-top-[3px] tw-mr-3 tw-w-[20px] tw-h-[20px] tw-border tw-border-gray-60 checked:tw-bg-blue-40 focus:checked:tw-bg-blue-40 focus:tw-outline-blue-40;
 }
 
 input[type="radio"].rh-radio {
-  @apply tw-form-radio tw-relative tw-top-[4px] tw-mr-3 tw-w-[20px] tw-h-[20px] tw-border tw-border-gray-60 checked:tw-bg-pni-purple-pink focus:checked:tw-bg-pni-purple-pink focus:tw-outline-pni-purple-pink;
+  @apply tw-form-radio tw-relative tw-top-[4px] tw-mr-3 tw-w-[20px] tw-h-[20px] tw-border tw-border-gray-60 checked:tw-bg-blue-40 focus:checked:tw-bg-blue-40 focus:tw-outline-blue-40;
 }
 
 .rh-filter-modal {

--- a/source/sass/research-hub.scss
+++ b/source/sass/research-hub.scss
@@ -1,9 +1,9 @@
 input[type="checkbox"].rh-checkbox {
-  @apply tw-form-checkbox tw-relative tw-top-[3px] tw-mr-3 tw-w-[20px] tw-h-[20px] tw-border tw-border-gray-60 checked:tw-bg-blue-40 focus:checked:tw-bg-blue-40 focus:tw-outline-blue-40;
+  @apply tw-form-checkbox tw-relative tw-top-[3px] tw-ml-1 tw-mr-3 tw-scroll-m-1 tw-w-[20px] tw-h-[20px] tw-border tw-border-gray-60 checked:tw-bg-blue-40 focus:checked:tw-bg-blue-40 focus:tw-outline-blue-40;
 }
 
 input[type="radio"].rh-radio {
-  @apply tw-form-radio tw-relative tw-top-[4px] tw-mr-3 tw-w-[20px] tw-h-[20px] tw-border tw-border-gray-60 checked:tw-bg-blue-40 focus:checked:tw-bg-blue-40 focus:tw-outline-blue-40;
+  @apply tw-form-radio tw-relative tw-top-[4px] tw-ml-1 tw-mr-3 tw-scroll-m-1 tw-w-[20px] tw-h-[20px] tw-border tw-border-gray-60 checked:tw-bg-blue-40 focus:checked:tw-bg-blue-40 focus:tw-outline-blue-40;
 }
 
 .rh-filter-modal {


### PR DESCRIPTION
## Description

This PR changes the color of radio and checkboxes as per request to blue. 

It also adds some margin and scroll margin to make sure that the focus ring is not cut off when the filter list is scrollable. 

Closes #8658 
Related PRs/issues #

**Link to sample test page**: n/a

<img width="488" alt="Screen Shot 2022-05-30 at 16 49 30" src="https://user-images.githubusercontent.com/24797493/171068955-8f439c9c-4ef0-4ec4-ae0f-6fc3f159c45b.png">



## Checklist

_Remove unnecessary checks_

**Tests**
- [x] Is the code I'm adding covered by tests? no

**Changes in Models:**
- [x] Did I update or add new fake data? no
- [x] Did I squash my migration? no migrations added. 
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team? yes

**Documentation:**
- [x] Is my code documented? no
- [x] Did I update the READMEs or wagtail documentation? no
