### PR TITLE
8764 sticky apply filter button

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -76,7 +76,17 @@
       </div>
     </div>
 
-    <div id="filter" class="large:tw-block large:tw-w-[20rem] tw-shrink-0 large:tw-mr-0 large:-tw-ml-5 tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5 tw-pt-4 large:tw-pt-0 tw-bg-gray-05">
+    <div id="filter" class="
+    tw-bg-gray-05
+    large:tw-block
+    large:tw-mr-0
+    large:-tw-ml-5
+    large:tw-overflow-y-clip
+    tw-pt-4 large:tw-pt-0
+    tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5
+    tw-shrink-0
+    large:tw-w-[20rem]
+    ">
       {# FILTER SECTION #}
       <div class="tw-flex tw-justify-end">
         <button
@@ -116,7 +126,7 @@
         tw-bottom-0
         -tw-mx-4 small:-tw-mx-5 medium:-tw-mx-6 large:-tw-mx-5
         tw-opacity-50
-        tw-pb-7
+        tw-pb-6 large:tw-pb-5
         tw-pt-4
         tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5
         tw-sticky

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -121,7 +121,9 @@
         {% include "wagtailpages/fragments/research_filter_group.html" with heading=heading options=region_options|dictsort:'label' checked_option_values=filtered_region_ids field_name='region' %}
       {% endif %}
 
+      <div class="tw-h-5 tw-relative -tw-bottom-5">COVER</div>
       <div class="
+        tw-opacity-50
         tw-bg-gray-05
         tw-bottom-0
         -tw-mx-4 small:-tw-mx-5 medium:-tw-mx-6 large:-tw-mx-5
@@ -129,9 +131,8 @@
         tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5
         tw-sticky
       ">
-        <div class="tw-pt-5 large:tw-pt-4 tw-border-t tw-border-t-gray-20">
-          <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>
-        </div>
+        <div class="tw-h-5">MORE</div>
+        <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>
       </div>
     </div>
   </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -126,11 +126,12 @@
         tw-bottom-0
         -tw-mx-4 small:-tw-mx-5 medium:-tw-mx-6 large:-tw-mx-5
         tw-pb-6 large:tw-pb-5
-        tw-pt-4
         tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5
         tw-sticky
       ">
-        <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>
+        <div class="tw-pt-5 large:tw-pt-4 tw-border-t tw-border-t-gray-20">
+          <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>
+        </div>
       </div>
     </div>
   </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -121,9 +121,7 @@
         {% include "wagtailpages/fragments/research_filter_group.html" with heading=heading options=region_options|dictsort:'label' checked_option_values=filtered_region_ids field_name='region' %}
       {% endif %}
 
-      <div class="tw-h-5 tw-relative -tw-bottom-5">COVER</div>
       <div class="
-        tw-opacity-50
         tw-bg-gray-05
         tw-bottom-0
         -tw-mx-4 small:-tw-mx-5 medium:-tw-mx-6 large:-tw-mx-5
@@ -131,8 +129,9 @@
         tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5
         tw-sticky
       ">
-        <div class="tw-h-5">MORE</div>
-        <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>
+        <div class="tw-pt-5 large:tw-pt-4 tw-border-t tw-border-t-gray-20">
+          <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>
+        </div>
       </div>
     </div>
   </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -76,7 +76,7 @@
       </div>
     </div>
 
-    <div id="filter" class="large:tw-block large:tw-w-[20rem] tw-shrink-0 large:tw-mr-0 large:-tw-ml-5 tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5 tw-pt-4 large:tw-pt-0 tw-pb-7 tw-bg-gray-05">
+    <div id="filter" class="large:tw-block large:tw-w-[20rem] tw-shrink-0 large:tw-mr-0 large:-tw-ml-5 tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5 tw-pt-4 large:tw-pt-0 tw-bg-gray-05">
       {# FILTER SECTION #}
       <div class="tw-flex tw-justify-end">
         <button
@@ -111,7 +111,18 @@
         {% include "wagtailpages/fragments/research_filter_group.html" with heading=heading options=region_options|dictsort:'label' checked_option_values=filtered_region_ids field_name='region' %}
       {% endif %}
 
-      <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>
+      <div class="
+        tw-bg-blue-10
+        tw-bottom-0
+        -tw-mx-4 small:-tw-mx-5 medium:-tw-mx-6 large:-tw-mx-5
+        tw-opacity-50
+        tw-pb-7
+        tw-pt-4
+        tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5
+        tw-sticky
+      ">
+        <button type="submit" class="tw-w-full tw-btn-primary" form="search-form">{% translate 'Apply filters' context 'Button' %}</button>
+      </div>
     </div>
   </div>
 {% endblock research_hub_content %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_library_page.html
@@ -77,15 +77,15 @@
     </div>
 
     <div id="filter" class="
-    tw-bg-gray-05
-    large:tw-block
-    large:tw-mr-0
-    large:-tw-ml-5
-    large:tw-overflow-y-clip
-    tw-pt-4 large:tw-pt-0
-    tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5
-    tw-shrink-0
-    large:tw-w-[20rem]
+      tw-bg-gray-05
+      large:tw-block
+      large:tw-mr-0
+      large:-tw-ml-5
+      large:tw-overflow-y-clip
+      tw-pt-4 large:tw-pt-0
+      tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5
+      tw-shrink-0
+      large:tw-w-[20rem]
     ">
       {# FILTER SECTION #}
       <div class="tw-flex tw-justify-end">
@@ -122,10 +122,9 @@
       {% endif %}
 
       <div class="
-        tw-bg-blue-10
+        tw-bg-gray-05
         tw-bottom-0
         -tw-mx-4 small:-tw-mx-5 medium:-tw-mx-6 large:-tw-mx-5
-        tw-opacity-50
         tw-pb-6 large:tw-pb-5
         tw-pt-4
         tw-px-4 small:tw-px-5 medium:tw-px-6 large:tw-px-5


### PR DESCRIPTION
The changes are pretty simple. I only had to add a wrapper to the button and make that one sticky to the bottom. One thing to note is that it is necessary to set `overflow: clip` option when not using the modal. If the overflow is `auto` or `scroll`, then the button wrapper won't stick to the bottom of the screen. 

This article has been helpful: https://www.digitalocean.com/community/tutorials/css-position-sticky

Closes #8764
Related PRs/issues #

**Link to sample test page**: n/a


## Checklist

_Remove unnecessary checks_

**Tests**
- [x] Is the code I'm adding covered by tests? No

**Changes in Models:**
- [x] Did I update or add new fake data? No
- [x] Did I squash my migration? No migrations added.
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team? Backwards-compatible

**Documentation:**
- [x] Is my code documented?
- [x] Did I update the READMEs or wagtail documentation?
