### PR TITLE
Blog card rendering date

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
@@ -12,23 +12,20 @@ crawls up the ancestor tree until it has found it.
 each blog page's dominant tag)
 
 {% block tags %}
-  {% if hide_classifiers != True %}
-    {% with topic=page.specific.topics.first %}
+  {% with topic=page.specific.topics.first %}
     {% if topic %}
       {% localized_version topic as localized_topic %}
       {% get_root_or_page as parent_page %}
         {# If we have a "root" context variable, we know this card is generated on an index page (or index page subroute) #}
         <a class="tw-h6-heading tw-mb-0" href="{% localizedroutablepageurl parent_page "entries_by_topic" topic.slug %}">{{ localized_topic }}</a>
-      {% endif %}
-    {% endwith %}
-  {% endif %}
+    {% endif %}
+  {% endwith %}
 {% endblock %}
 
 {% block published_date %}
   <span class="tw-h6-heading tw-mb-0 tw-ml-2 tw-text-gray-40"> {{ page.first_published_at|date:"DATE_FORMAT" }} </span>
 {% endblock %}
 
-
 {% block byline %}
-{% include "./blog_authors.html" with blog_page=page.specific %}
+  {% include "./blog_authors.html" with blog_page=page.specific %}
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
@@ -18,11 +18,16 @@ each blog page's dominant tag)
       {% localized_version topic as localized_topic %}
       {% get_root_or_page as parent_page %}
         {# If we have a "root" context variable, we know this card is generated on an index page (or index page subroute) #}
-        <a class="tw-h6-heading d-block mt-3 mb-0" href="{% localizedroutablepageurl parent_page "entries_by_topic" topic.slug %}">{{ localized_topic }}</a>
+        <a class="tw-h6-heading tw-mb-0" href="{% localizedroutablepageurl parent_page "entries_by_topic" topic.slug %}">{{ localized_topic }}</a>
       {% endif %}
     {% endwith %}
   {% endif %}
 {% endblock %}
+
+{% block published_date %}
+  <span class="tw-h6-heading tw-mb-0 tw-ml-2 tw-text-gray-40"> {{ page.first_published_at|date:"M d, Y" }} </span>
+{% endblock %}
+
 
 {% block byline %}
 {% include "./blog_authors.html" with blog_page=page.specific %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
@@ -25,7 +25,7 @@ each blog page's dominant tag)
 {% endblock %}
 
 {% block published_date %}
-  <span class="tw-h6-heading tw-mb-0 tw-ml-2 tw-text-gray-40"> {{ page.first_published_at|date:"M d, Y" }} </span>
+  <span class="tw-h6-heading tw-mb-0 tw-ml-2 tw-text-gray-40"> {{ page.first_published_at|date:"DATE_FORMAT" }} </span>
 {% endblock %}
 
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags localization %}
 
 <div class="entry-card {% block card_type %}{% endblock %} col-6 col-md-4 mb-5">
-  <div class="card-image tw-mb-1">
+  <div class="card-image tw-mb-2">
     <a href="{% relocalized_url page.localized.url %}">
       {% image page.localized.specific.get_meta_image fill-400x225 %}
     </a>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -6,7 +6,10 @@
       {% image page.localized.specific.get_meta_image fill-400x225 %}
     </a>
   </div>
-  {% block tags %}{% endblock %}
+  <div class="tw-mt-3">
+    {% block tags %}{% endblock %}
+    {% block published_date %}{% endblock %}
+  </div>
   <a class="tw-h4-heading d-inline-block my-2" href="{% relocalized_url page.localized.url %}">{{ page.localized.title }}</a>
   <p class="tw-body-small my-0">
     {% block byline %}{% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -1,16 +1,15 @@
 {% load wagtailcore_tags wagtailimages_tags localization %}
 
 <div class="entry-card {% block card_type %}{% endblock %} col-6 col-md-4 mb-5">
-  <div class="card-image">
+  <div class="card-image tw-mb-1">
     <a href="{% relocalized_url page.localized.url %}">
       {% image page.localized.specific.get_meta_image fill-400x225 %}
     </a>
   </div>
-  <div class="tw-mt-3">
-    {% block tags %}{% endblock %}
-    {% block published_date %}{% endblock %}
-  </div>
-  <a class="tw-h4-heading d-inline-block my-2" href="{% relocalized_url page.localized.url %}">{{ page.localized.title }}</a>
+  {% block tags %}{% endblock %}
+  {% block published_date %}{% endblock %}
+    
+  <a class="tw-h4-heading d-inline-block mt-1 mb-2" href="{% relocalized_url page.localized.url %}">{{ page.localized.title }}</a>
   <p class="tw-body-small my-0">
     {% block byline %}{% endblock %}
   </p>


### PR DESCRIPTION
Closes #8767 

This PR pulls the related blogs posts "published_date" and then renders it next to the tags.


Design in Figma:
---
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/18314510/171793588-cc9b26c9-6459-40a5-8180-6f7df952bc15.png">


What this PR introduces:
---
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/18314510/171770087-c8626aca-3500-4bec-8a08-77b8a9f042eb.png">
