### PR TITLE
blog card now displaying description

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_card.html
@@ -24,6 +24,10 @@ each blog page's dominant tag)
   {% endif %}
 {% endblock %}
 
+{% block description %}
+  <p class="tw-body tw-line-clamp-3"> {{page.specific.get_meta_description}} </p>
+{% endblock %}
+
 {% block byline %}
 {% include "./blog_authors.html" with blog_page=page.specific %}
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -9,6 +9,7 @@
   {% block tags %}{% endblock %}
   <a class="tw-h4-heading d-inline-block my-2" href="{% relocalized_url page.localized.url %}">{{ page.localized.title }}</a>
   <p class="tw-body-small my-0">
+    {% block description %}{% endblock %}
     {% block byline %}{% endblock %}
   </p>
 </div>

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@glidejs/glide": "^3.4.1",
     "@sentry/browser": "^6.2.1",
     "@tailwindcss/forms": "^0.5.1",
+    "@tailwindcss/line-clamp": "^0.4.0",
     "autoprefixer": "^10.4.2",
     "axe-core": "^4.1.4",
     "bootstrap": "^4.6.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,7 @@ module.exports = {
     ...buttonPlugins,
     ...typePlugins,
     require("@tailwindcss/forms")({ strategy: "class" }),
+    require('@tailwindcss/line-clamp'),
   ],
   theme: {
     extend: {


### PR DESCRIPTION
Closes #8768 



<img width="1099" alt="Screen Shot 2022-06-02 at 8 26 54 PM" src="https://user-images.githubusercontent.com/18314510/171780663-37b8d64a-e271-4078-856d-35bf2846580f.png">


This pr is taking advantage of the blog pages "[get_meta_description](https://github.com/mozilla/foundation.mozilla.org/blob/62fada0345e002dd265472b0ec6d1988d56489db/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py#L303)" method to return either the pages "meta description" or, if no description is available, it will pull the first paragraph block from the page body.

We are then utilizing a new tailwind package called [line clamp](https://tailwindcss.com/blog/multi-line-truncation-with-tailwindcss-line-clamp), which allows us to truncate text to 3 lines, and add an ellipsis where the text is cut off! This seems useful to have in our tool kit for future tasks 🤞 


