### PR TITLE
Add a slow option for the new-db command

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -122,7 +122,7 @@ def new_db(ctx, slow=False):
     """
     Delete your database and create a new one with fake data.
 
-    If you are experiencing "too many clients errors while running this command, try
+    If you are experiencing 'too many clients' errors while running this command, try
     to pass the `--slow` flag. This will make sure that the containers are stopped
     between the management commands and prevent that issue.
 

--- a/tasks.py
+++ b/tasks.py
@@ -225,13 +225,19 @@ def copy_production_database(ctx):
 
 # Django shorthands
 @task(aliases=["docker-manage"])
-def manage(ctx, command):
-    """Shorthand to manage.py. inv docker-manage \"[COMMAND] [ARG]\""""
+def manage(ctx, command, stop=False):
+    """
+    Shorthand to manage.py. inv docker-manage \"[COMMAND] [ARG]\"
+
+    To stop the containers after the command has been run, pass the `--stop` flag.
+    """
     with ctx.cd(ROOT):
         ctx.run(
             f"docker-compose run --rm backend ./dockerpythonvenv/bin/python network-api/manage.py {command}",
             **PLATFORM_ARG,
         )
+        if stop:
+            ctx.run("docker-compose stop")
 
 
 @task(aliases=["docker-migrate"])

--- a/tasks.py
+++ b/tasks.py
@@ -73,16 +73,27 @@ def create_env_file(env_file):
 
 
 # Project setup and update
-def l10n_block_inventory(ctx):
+def l10n_block_inventory(ctx, stop=False):
+    """
+    Update the block inventory.
+
+    To stop the containers after the command has run, pass `stop=True`.
+
+    """
     print("* Updating block information")
-    manage(ctx, "block_inventory")
+    manage(ctx, "block_inventory", stop=stop)
 
 
 @task(aliases=["create-super-user"])
-def createsuperuser(ctx):
+def createsuperuser(ctx, stop=False):
+    """
+    Create a superuser with username and password 'admin'.
+
+    To stop the containers after the command is run, pass the `--stop` flag.
+    """
     preamble = "from django.contrib.auth.models import User;"
     create = "User.objects.create_superuser('admin', 'admin@example.com', 'admin')"
-    manage(ctx, f'shell -c "{preamble} {create}"')
+    manage(ctx, f'shell -c "{preamble} {create}"', stop=stop)
     print("\nCreated superuser `admin` with password `admin`.")
 
 
@@ -93,27 +104,17 @@ def initialize_database(ctx, slow=False):
     To stop all containers after each management command, pass `slow=True`.
     """
     print("* Applying database migrations.")
-    migrate(ctx)
-    if slow:
-        ctx.run("docker-compose stop")
+    migrate(ctx, stop=slow)
 
     print("* Creating fake data")
-    manage(ctx, "load_fake_data")
-    if slow:
-        ctx.run("docker-compose stop")
+    manage(ctx, "load_fake_data", stop=slow)
 
     print("* Sync locales")
-    manage(ctx, "sync_locale_trees")
-    if slow:
-        ctx.run("docker-compose stop")
+    manage(ctx, "sync_locale_trees", stop=slow)
 
-    l10n_block_inventory(ctx)
-    if slow:
-        ctx.run("docker-compose stop")
+    l10n_block_inventory(ctx, stop=slow)
 
-    createsuperuser(ctx)
-    if slow:
-        ctx.run("docker-compose stop")
+    createsuperuser(ctx, stop=slow)
 
 
 @task(aliases=["docker-new-db"])
@@ -241,9 +242,13 @@ def manage(ctx, command, stop=False):
 
 
 @task(aliases=["docker-migrate"])
-def migrate(ctx):
-    """Updates database schema"""
-    manage(ctx, "migrate --no-input")
+def migrate(ctx, stop=False):
+    """
+    Update the database schema.
+
+    To stop the containers after the command has run, pass the `--stop` flag.
+    """
+    manage(ctx, "migrate --no-input", stop=stop)
 
 
 @task(aliases=["docker-makemigrations"])


### PR DESCRIPTION
I have been continuously experiencing "too many clients" errors
everytime I run `inv new-db`. I have made sure to stop containers before
everytime to no change.

What does apparently help is to make sure that the containers are
stopped between the managememnt commands.

This commit adds an optional flag that can be passed to enable the
stopping of the containers after each management command.

To create a new db in this fashion run `inv new-db --slow`.
