### PR TITLE
8772 blog search page template

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
@@ -237,3 +237,12 @@ class BlogIndexPage(IndexPage):
             return redirect(self.full_url)
 
         return IndexPage.serve(self, request, *args, **kwargs)
+
+    @route(r'^search/')
+    def search(self, request):
+        """Render search results view."""
+        return self.render(
+            request,
+            context_overrides={},
+            template="wagtailpages/blog_index_search.html"
+        )

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
@@ -243,6 +243,9 @@ class BlogIndexPage(IndexPage):
         """Render search results view."""
         return self.render(
             request,
-            context_overrides={},
+            context_overrides={
+                'index_title': 'Search',
+                'entries': [],
+            },
             template="wagtailpages/blog_index_search.html"
         )

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
@@ -245,10 +245,10 @@ class BlogIndexPage(IndexPage):
             request,
             context_overrides={
                 'index_title': 'Search',
-                'entries': self.get_search_entires(),
+                'entries': self.get_search_entries(),
             },
             template="wagtailpages/blog_index_search.html"
         )
 
-    def get_search_entires(self):
+    def get_search_entries(self):
         return self.get_entries()[:6]

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog_index.py
@@ -245,7 +245,10 @@ class BlogIndexPage(IndexPage):
             request,
             context_overrides={
                 'index_title': 'Search',
-                'entries': [],
+                'entries': self.get_search_entires(),
             },
             template="wagtailpages/blog_index_search.html"
         )
+
+    def get_search_entires(self):
+        return self.get_entries()[:6]

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
@@ -1,0 +1,24 @@
+{% extends "./index_page.html" %}
+
+{% load wagtailcore_tags wagtailimages_tags i18n %}
+
+
+{% block rss_metadata %}
+  <link rel="alternate" type="application/rss+xml" href="{% url 'rss-feed' %}" />
+{% endblock %}
+
+
+{% block featured %}
+  <h1>SEARCH</h1>
+  {% if not filtered %}
+    <div class="row">
+      {%  for feature in page.specific.featured_pages.all %}
+      <div class="col-12 col-md-6 mb-5">
+        <div class="card-regular h-100 d-flex flex-column">
+          {% include "./fragments/blog_index_feature.html" with blog=feature.blog %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
@@ -1,24 +1,3 @@
-{% extends "./index_page.html" %}
+{% extends "./blog_index_page.html" %}
 
-{% load wagtailcore_tags wagtailimages_tags i18n %}
-
-
-{% block rss_metadata %}
-  <link rel="alternate" type="application/rss+xml" href="{% url 'rss-feed' %}" />
-{% endblock %}
-
-
-{% block featured %}
-  <h1>SEARCH</h1>
-  {% if not filtered %}
-    <div class="row">
-      {%  for feature in page.specific.featured_pages.all %}
-      <div class="col-12 col-md-6 mb-5">
-        <div class="card-regular h-100 d-flex flex-column">
-          {% include "./fragments/blog_index_feature.html" with blog=feature.blog %}
-        </div>
-      </div>
-      {% endfor %}
-    </div>
-  {% endif %}
-{% endblock %}
+{% block featured %}{% endblock %}

--- a/network-api/networkapi/wagtailpages/tests/base.py
+++ b/network-api/networkapi/wagtailpages/tests/base.py
@@ -4,6 +4,7 @@ from wagtail_localize import synctree
 
 from networkapi.wagtailpages.factory import homepage as home_factory
 
+
 class WagtailpagesTestCase(test.TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/network-api/networkapi/wagtailpages/tests/base.py
+++ b/network-api/networkapi/wagtailpages/tests/base.py
@@ -1,0 +1,41 @@
+from django import test
+from wagtail.core import models as wagtail_models
+from wagtail_localize import synctree
+
+from networkapi.wagtailpages.factory import homepage as home_factory
+
+class WagtailpagesTestCase(test.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls._setup_homepage()
+        cls._setup_locales()
+
+    @classmethod
+    def _setup_homepage(cls):
+        root = wagtail_models.Page.get_first_root_node()
+        if not root:
+            raise ValueError('A root page should exist. Something is off.')
+        cls.homepage = home_factory.WagtailHomepageFactory(parent=root)
+
+        sites = wagtail_models.Site.objects.all()
+        if sites.count() != 1:
+            raise ValueError('There should be exactly one site. Something is off.')
+        cls.site = sites.first()
+
+        cls.site.root_page = cls.homepage
+        cls.site.clean()
+        cls.site.save()
+
+    @classmethod
+    def _setup_locales(cls):
+        cls.default_locale = wagtail_models.Locale.get_default()
+        cls.fr_locale, _ = wagtail_models.Locale.objects.get_or_create(
+            language_code='fr'
+        )
+        assert cls.fr_locale != cls.default_locale
+
+    def synchronize_tree(self):
+        synctree.synchronize_tree(
+            source_locale=self.default_locale,
+            target_locale=self.fr_locale
+        )

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -1,8 +1,3 @@
-from django import test
-from wagtail.core import models as wagtail_models
-from wagtail_localize import synctree
-
-from networkapi.wagtailpages.factory import homepage as home_factory
 from networkapi.wagtailpages.factory import research_hub as research_factory
 from networkapi.wagtailpages.tests import base as test_base
 

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -4,30 +4,14 @@ from wagtail_localize import synctree
 
 from networkapi.wagtailpages.factory import homepage as home_factory
 from networkapi.wagtailpages.factory import research_hub as research_factory
+from networkapi.wagtailpages.tests import base as test_base
 
 
-class ResearchHubTestCase(test.TestCase):
+class ResearchHubTestCase(test_base.WagtailpagesTestCase):
     @classmethod
     def setUpTestData(cls):
-        cls._setup_homepage()
+        super().setUpTestData()
         cls._setup_research_hub_structure(homepage=cls.homepage)
-        cls._setup_locales()
-
-    @classmethod
-    def _setup_homepage(cls):
-        root = wagtail_models.Page.get_first_root_node()
-        if not root:
-            raise ValueError('A root page should exist. Something is off.')
-        cls.homepage = home_factory.WagtailHomepageFactory(parent=root)
-
-        sites = wagtail_models.Site.objects.all()
-        if sites.count() != 1:
-            raise ValueError('There should be exactly one site. Something is off.')
-        cls.site = sites.first()
-
-        cls.site.root_page = cls.homepage
-        cls.site.clean()
-        cls.site.save()
 
     @classmethod
     def _setup_research_hub_structure(cls, homepage):
@@ -42,19 +26,5 @@ class ResearchHubTestCase(test.TestCase):
             title='Authors',
         )
 
-    @classmethod
-    def _setup_locales(cls):
-        cls.default_locale = wagtail_models.Locale.get_default()
-        cls.fr_locale, _ = wagtail_models.Locale.objects.get_or_create(
-            language_code='fr'
-        )
-        assert cls.fr_locale != cls.default_locale
-
     def setUp(self):
         self.synchronize_tree()
-
-    def synchronize_tree(self):
-        synctree.synchronize_tree(
-            source_locale=self.default_locale,
-            target_locale=self.fr_locale
-        )

--- a/network-api/networkapi/wagtailpages/tests/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/test_blog.py
@@ -58,4 +58,3 @@ class TestBlogIndexSearch(test_base.WagtailpagesTestCase):
         self.assertIn(blog_page_3, entries)
         self.assertIn(blog_page_2, entries)
         self.assertNotIn(blog_page_1, entries)
-

--- a/network-api/networkapi/wagtailpages/tests/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/test_blog.py
@@ -1,0 +1,14 @@
+from http import HTTPStatus
+
+from networkapi.wagtailpages.factory import blog as blog_factories
+from networkapi.wagtailpages.tests import base as test_base
+
+
+class TestBlogIndexSearch(test_base.WagtailpagesTestCase):
+    def test_search_page(self):
+        blog_index = blog_factories.BlogIndexPageFactory(parent=self.homepage)
+        url = blog_index.get_url() + blog_index.reverse_subpage("search")
+
+        response = self.client.get(path=url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/network-api/networkapi/wagtailpages/tests/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/test_blog.py
@@ -1,3 +1,4 @@
+import datetime
 from http import HTTPStatus
 
 from networkapi.wagtailpages.factory import blog as blog_factories
@@ -5,10 +6,56 @@ from networkapi.wagtailpages.tests import base as test_base
 
 
 class TestBlogIndexSearch(test_base.WagtailpagesTestCase):
-    def test_search_page(self):
+    def test_route_success(self):
         blog_index = blog_factories.BlogIndexPageFactory(parent=self.homepage)
         url = blog_index.get_url() + blog_index.reverse_subpage("search")
 
         response = self.client.get(path=url)
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    def test_no_query(self):
+        blog_index = blog_factories.BlogIndexPageFactory(parent=self.homepage)
+        tz = datetime.timezone.utc
+        blog_page_1 = blog_factories.BlogPageFactory(
+            parent=blog_index,
+            first_published_at=datetime.datetime(2020, 1, 1, tzinfo=tz),
+        )
+        blog_page_2 = blog_factories.BlogPageFactory(
+            parent=blog_index,
+            first_published_at=datetime.datetime(2020, 1, 2, tzinfo=tz),
+        )
+        blog_page_3 = blog_factories.BlogPageFactory(
+            parent=blog_index,
+            first_published_at=datetime.datetime(2020, 1, 3, tzinfo=tz),
+        )
+        blog_page_4 = blog_factories.BlogPageFactory(
+            parent=blog_index,
+            first_published_at=datetime.datetime(2020, 1, 4, tzinfo=tz),
+        )
+        blog_page_5 = blog_factories.BlogPageFactory(
+            parent=blog_index,
+            first_published_at=datetime.datetime(2020, 1, 5, tzinfo=tz),
+        )
+        blog_page_6 = blog_factories.BlogPageFactory(
+            parent=blog_index,
+            first_published_at=datetime.datetime(2020, 1, 6, tzinfo=tz),
+        )
+        blog_page_7 = blog_factories.BlogPageFactory(
+            parent=blog_index,
+            first_published_at=datetime.datetime(2020, 1, 7, tzinfo=tz),
+        )
+        url = blog_index.get_url() + blog_index.reverse_subpage("search")
+
+        response = self.client.get(path=url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        entries = response.context['entries'].specific()
+        self.assertIn(blog_page_7, entries)
+        self.assertIn(blog_page_6, entries)
+        self.assertIn(blog_page_5, entries)
+        self.assertIn(blog_page_4, entries)
+        self.assertIn(blog_page_3, entries)
+        self.assertIn(blog_page_2, entries)
+        self.assertNotIn(blog_page_1, entries)
+


### PR DESCRIPTION
This PR adds a new route to the `BlogIndexPage` and uses that to render a new template. The route meant to be extended with the search functionality in the next couple of PRs. As of now, only the latest 6 blog posts are rendered. 

Closes #8772
Related PRs/issues #

**Link to sample test page**: n/a


## Checklist

_Remove unnecessary checks_

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~[ ] Did I update or add new fake data?~
- ~[ ] Did I squash my migration?~
- ~[ ] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~

**Documentation:**
- ~[ ] Is my code documented?~
- ~[ ] Did I update the READMEs or wagtail documentation?~
