### PR TITLE
8774 blog search card

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
@@ -16,9 +16,9 @@
 
 {% block subcontent %}
   {% if entries  %}
-    <ul class="tw-p-0 tw-list-none">
+    <ul class="tw-divide-y tw-divide-gray-20 tw-flex tw-flex-col tw-gap-5 tw-list-none tw-px-[15px]">
       {% for entry in entries %}
-        <li>
+        <li class="tw-m-0 tw-p-0 tw-pt-5">
           {% include "wagtailpages/fragments/blog_card.html" with page=entry horizontal=True %}
         </li>
       {% endfor %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
@@ -19,7 +19,7 @@
     <ul class="tw-p-0 tw-list-none">
       {% for entry in entries %}
         <li>
-          {% include "wagtailpages/fragments/blog_card.html" with page=entry %}
+          {% include "wagtailpages/fragments/blog_card.html" with page=entry horizontal=True %}
         </li>
       {% endfor %}
     </ul>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_search.html
@@ -16,7 +16,13 @@
 
 {% block subcontent %}
   {% if entries  %}
-    {{ block.super }}
+    <ul class="tw-p-0 tw-list-none">
+      {% for entry in entries %}
+        <li>
+          {% include "wagtailpages/fragments/blog_card.html" with page=entry %}
+        </li>
+      {% endfor %}
+    </ul>
   {% else %}
     <div class="col-12 tw-my-[6rem] large:tw-my-[8rem]">
       {% include "wagtailpages/fragments/blog_search_no_results.html" %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_cards.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_cards.html
@@ -1,5 +1,0 @@
-{% load wagtailcore_tags %}
-
-{% for page in entries %}
-{% include "./blog_card.html" %}
-{% endfor %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/entry_cards.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/entry_cards.html
@@ -1,9 +1,13 @@
-{% for entry in entries %}
-    {% with type=entry.specific_class.get_verbose_name|lower %}
-    {% if type == "blog page" %}
-        {% include "./blog_card.html" with page=entry %}
-    {% else %}
-        {% include "./generic_card.html" with page=entry %}
-    {% endif %}
-    {% endwith %}
-{% endfor %}
+<ul class="tw-grid medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-x-5 tw-gap-y-6 tw-list-none tw-px-[15px]">
+  {% for entry in entries %}
+    <li class="tw-m-0 tw-p-0">
+      {% with type=entry.specific_class.get_verbose_name|lower %}
+        {% if type == "blog page" %}
+          {% include "./blog_card.html" with page=entry %}
+        {% else %}
+          {% include "./generic_card.html" with page=entry %}
+        {% endif %}
+      {% endwith %}
+    </li>
+  {% endfor %}
+</ul>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/entry_cards.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/entry_cards.html
@@ -1,4 +1,4 @@
-<ul class="tw-grid medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-x-5 tw-gap-y-6 tw-list-none tw-px-[15px]">
+<ul class="tw-grid medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-x-5 tw-gap-y-7 tw-list-none tw-px-[15px]">
   {% for entry in entries %}
     <li class="tw-m-0 tw-p-0">
       {% with type=entry.specific_class.get_verbose_name|lower %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -5,19 +5,18 @@
     tw-flex
     tw-flex-col
     tw-gap-3
-    tw-mb-5
-    tw-px-[15px]
     tw-w-full
     {% if horizontal %}
       medium:tw-flex-row
       medium:tw-gap-6
-    {% else %}
-      medium:tw-w-1/2
-      large:tw-w-1/3
     {% endif %}
   "
 >
-  <div class="medium:tw-max-w-xs large:tw-max-w-sm tw-shrink-0">
+  <div
+    {% if horizontal %}
+      class="medium:tw-max-w-xs large:tw-max-w-sm medium:tw-shrink-0"
+    {% endif %}
+  >
     <a href="{% relocalized_url page.localized.url %}">
       {% image page.localized.specific.get_meta_image fill-1200x628 %}
     </a>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags localization %}
 
-<div class="entry-card {% block card_type %}{% endblock %} col-12 col-md-6 col-lg-4 mb-5">
-  <div class="card-image tw-mb-3">
+<div class="col-12 col-md-6 col-lg-4 mb-5">
+  <div class="tw-mb-3">
     <a href="{% relocalized_url page.localized.url %}">
       {% image page.localized.specific.get_meta_image fill-1200x628 %}
     </a>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags localization %}
 
-<div class="col-12 col-md-6 col-lg-4 mb-5">
+<div class="tw-w-full medium:tw-w-1/2 large:tw-w-1/3 tw-px-[15px] mb-5">
   <div class="tw-mb-3">
     <a href="{% relocalized_url page.localized.url %}">
       {% image page.localized.specific.get_meta_image fill-1200x628 %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -1,22 +1,38 @@
 {% load wagtailcore_tags wagtailimages_tags localization %}
 
-<div class="tw-w-full medium:tw-w-1/2 large:tw-w-1/3 tw-px-[15px] mb-5">
+<div
+  class="
+    tw-flex
+    tw-w-full
+    {% if not horizontal %}
+      tw-flex-col
+      medium:tw-w-1/2
+      large:tw-w-1/3
+    {% else %}
+      tw-flex-row
+    {% endif %}
+    tw-px-[15px]
+    mb-5
+  "
+>
   <div class="tw-mb-3">
     <a href="{% relocalized_url page.localized.url %}">
       {% image page.localized.specific.get_meta_image fill-1200x628 %}
     </a>
   </div>
 
-  <div class="tw-flex tw-flex-wrap">
-    {% block tags %}{% endblock %}
-    {% block published_date %}{% endblock %}
-  </div>
+  <div>
+    <div class="tw-flex tw-flex-wrap">
+      {% block tags %}{% endblock %}
+      {% block published_date %}{% endblock %}
+    </div>
 
-  <a href="{% relocalized_url page.localized.url %}" class="tw-group tw-block hover:tw-no-underline">
-    <p class="tw-h4-heading d-inline-block mt-1 mb-2 group-hover:tw-underline">{{ page.localized.title }}</p>
-    <p class="tw-body-small my-0">
-      {% block description %}{% endblock %}
-      {% block byline %}{% endblock %}
-    </p>
-  </a>
+    <a href="{% relocalized_url page.localized.url %}" class="tw-group tw-block hover:tw-no-underline">
+      <p class="tw-h4-heading d-inline-block mt-1 mb-2 group-hover:tw-underline">{{ page.localized.title }}</p>
+      <p class="tw-body-small my-0">
+        {% block description %}{% endblock %}
+        {% block byline %}{% endblock %}
+      </p>
+    </a>
+  </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -3,19 +3,21 @@
 <div
   class="
     tw-flex
+    tw-flex-col
+    tw-gap-3
+    tw-mb-5
+    tw-px-[15px]
     tw-w-full
-    {% if not horizontal %}
-      tw-flex-col
+    {% if horizontal %}
+      medium:tw-flex-row
+      medium:tw-gap-6
+    {% else %}
       medium:tw-w-1/2
       large:tw-w-1/3
-    {% else %}
-      tw-flex-row
     {% endif %}
-    tw-px-[15px]
-    mb-5
   "
 >
-  <div class="tw-mb-3">
+  <div class="medium:tw-max-w-xs large:tw-max-w-sm tw-shrink-0">
     <a href="{% relocalized_url page.localized.url %}">
       {% image page.localized.specific.get_meta_image fill-1200x628 %}
     </a>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/related_posts.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/related_posts.html
@@ -9,11 +9,9 @@
 
       <div class="related-posts mb-4">
         <div class="row">
-          {% include "./blog_cards.html" with entries=related_posts %}
-          </div>
+          {% include "./entry_cards.html" with entries=related_posts %}
         </div>
       </div>
-
     </div>
   {% endif %}
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/tests/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/test_blog.py
@@ -13,6 +13,29 @@ from networkapi.wagtailpages.factory import profiles as profile_factories
 from networkapi.wagtailpages.tests import base as test_base
 
 
+class TestBlogIndex(test_base.WagtailpagesTestCase):
+    def test_templates(self):
+        blog_index = blog_factories.BlogIndexPageFactory(parent=self.homepage)
+        blog_factories.BlogPageFactory(parent=blog_index)
+        url = blog_index.get_url()
+
+        response = self.client.get(path=url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertTemplateUsed(
+            response,
+            template_name='wagtailpages/blog_index_page.html'
+        )
+        self.assertTemplateUsed(
+            response,
+            template_name='wagtailpages/fragments/entry_cards.html'
+        )
+        self.assertTemplateUsed(
+            response,
+            template_name='wagtailpages/fragments/blog_card.html'
+        )
+
+
 class TestBlogIndexSearch(test_base.WagtailpagesTestCase):
     @staticmethod
     def update_index():
@@ -58,7 +81,7 @@ class TestBlogIndexSearch(test_base.WagtailpagesTestCase):
         )
         self.assertTemplateUsed(
             response,
-            template_name='wagtailpages/fragments/entry_cards.html'
+            template_name='wagtailpages/fragments/blog_card.html'
         )
 
     def test_no_results_template(self):


### PR DESCRIPTION
This PR adds a `horizontal` option to the `generic_card.html` (which is extended by the `blog_card.html`). This options displays the image and text containers in a row (on medium+ screens). 

To aid the reuse of the `gerneric_card.html`/`blog_card.html` (previously only used in `entry_cards.html`) I chose to move the gutter spacing from the card fragments to the `entry_card.html`. This allows me to use different spacing/layout of the cards in `blog_index_search.htm`.


Closes #8774
Related PRs/issues #8774

**Link to sample test page**: http://localhost:8000/en/blog/search/


# Screenshots

## Mobile
<img src="https://user-images.githubusercontent.com/24797493/174682341-f58ab12a-0fc7-42b2-8866-b85d2bb4a11c.png" width="300px" />

## Tablet
<img src="https://user-images.githubusercontent.com/24797493/174682350-b7a78a94-d6c6-42ce-b60d-3ba40a8d3c5c.png" width="300px" />


## Desktop
<img src="https://user-images.githubusercontent.com/24797493/174682360-a93fa2bb-6f7a-4315-b3c7-20522e780bc9.png" width="300px" />


# Checklist

_Remove unnecessary checks_

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
