### PR TITLE
added the newsletter box to blog pages, without the social buttons

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_index_page.html
@@ -29,6 +29,6 @@
 
 {% block newsletter-callout-box %}
   {% if not filtered %}
-    {% include "./fragments/newsletter-signup-box.html" %}
+    {% include "./fragments/newsletter-signup-box.html" with show_socials=True %}
   {% endif %}
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blog_page.html
@@ -62,6 +62,9 @@
 {% endblock %}
 
 {% block prefooter %}
+  <div class="tw-container">
+    {% include "./fragments/newsletter-signup-box.html" %}
+  </div>
   {% include "./fragments/related_posts.html" %}
 {% endblock %}
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/newsletter-signup-box.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/newsletter-signup-box.html
@@ -10,8 +10,10 @@
       data-cta-description="<p class='tw-mb-5'>{% trans "Help shape the future of the web for the public good. Join our Mozilla News email list to get action alerts & internet tips right to your inbox." %}</p>"
     >
     </div>
-    <div class="tw-hidden medium:tw-block">
-        {% include "./mozilla-social-buttons.html" %}
-    </div>
+    {% if show_socials %}
+      <div class="tw-hidden medium:tw-block">
+          {% include "./mozilla-social-buttons.html" %}
+      </div>
+    {% endif %}
 
 </div>   


### PR DESCRIPTION
Closes #8787 

This PR adds the newsletter sign up box template to the blog page template, this time removing the social button with a parameter "show_socials".


Note: @nancyt1 The sign up box is a little longer than the figma design, this is because without the length, the size would "grow" when the user clicks on the form, similar to what we discussed with the first newsletter sign up box ticket. If you want me to find another way to work around this, by maybe reducing the space between the inputs and the button, please let me know 😄 



### Screenshots:

How it looks on the entire page:
---
![Screenshot 2022-06-22 at 17-46-59 Initial test blog post with fixed title](https://user-images.githubusercontent.com/18314510/175184141-bf986f6a-b1ef-4911-94ba-d6212a73853e.png)


Close up:
---
![Screenshot 2022-06-22 at 17-47-35 Initial test blog post with fixed title](https://user-images.githubusercontent.com/18314510/175184159-2b062789-1df0-4c0d-a6dc-186413c579d3.png)



Close up (focused):
---
![Screenshot 2022-06-22 at 17-48-02 Initial test blog post with fixed title](https://user-images.githubusercontent.com/18314510/175184162-5a03a26b-1d78-4c2a-905f-d870ce1ffc95.png)

