### PR TITLE
9007 - Image Component isn't showing images side by side

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/article_double_image_block.html
@@ -3,7 +3,7 @@
 
 {% block block_content %}
   <div class="double-image-block">
-    <div class="">
+    <div class="tw-row">
       <div class="tw-w-full small:tw-w-1/2 tw-px-4 tw-relative">
 
         {% image self.image_1 fill-445x324 as img1 %}


### PR DESCRIPTION
Closes #9007 

forgot to add `tw-row` class to double image blocks!