### PR TITLE
updated spacing by using grid rows and readjusting margin

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/research_detail_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/research_detail_page.html
@@ -10,7 +10,7 @@
 
     <div id="title-and-meta" class="medium:tw-col-start-2 medium:tw-col-end-4 xlarge:tw-col-end-3 tw-min-w-0">
       <h1>{{ page.title }}</h1>
-      <div class="tw-flex tw-flex-row tw-text-xs large:tw-text-base tw-text-gray-80 tw-uppercase tw-divide-x tw-divide-gray-20 tw-mt-4">
+      <div class="tw-flex tw-flex-row tw-text-xs large:tw-text-base tw-text-gray-80 tw-uppercase tw-divide-x tw-divide-gray-20">
         {% if page.original_publication_date %}
           <div class="tw-px-2 first:tw-pl-0 tw-whitespace-nowrap ">{{ page.original_publication_date|date:"DATE_FORMAT" }}</div>
         {% endif %}


### PR DESCRIPTION
Closes #9013


This PR introduces the `grid-template-rows: auto auto 1fr;`  and also a slight bottom-margin on the date and topics section to make the spacing more consistent with the design in figma


Screenshots:
---
Old Spacing (Desktop):
![image](https://user-images.githubusercontent.com/18314510/177886112-cd46302b-4cae-479a-8cab-3d91f4dfef26.png)

New Spacing (Desktop):
![Screenshot 2022-07-07 at 16-10-49 Research to shift power](https://user-images.githubusercontent.com/18314510/177886535-ba6e5c75-42f3-4086-9a42-8a7d43631dd0.png)


There were no changes to mobile spacing:
Old             |  New
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/18314510/177886696-99566366-d3fc-4275-803c-6502bb1c6742.png)  |  ![](https://user-images.githubusercontent.com/18314510/177887109-842c0fe4-5af7-4625-8d40-ad918a1ecf3a.png)
