### PR TITLE
Run CI on all PRs regardless of branch

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -6,7 +6,6 @@ on:
     paths-ignore:
       - maintenance/**/*.*
   pull_request:
-    branches: ["main"]
     paths-ignore:
       - maintenance/**/*.*
 


### PR DESCRIPTION
When ever we are making PRs between branches, it is still a good idea to
make sure that the code passes CI. Otherwise this can lead to bad merges
that break other branches.

This is particularly important when we work on longer projects with
integration branches (e.g. PNI).