### PR TITLE
Fix the createsuperuser task

### DIFF
--- a/network-api/networkapi/management/commands/create_admin.py
+++ b/network-api/networkapi/management/commands/create_admin.py
@@ -1,0 +1,14 @@
+from django.contrib.auth import models as auth_models
+from django.core.management import base as management_base
+
+
+class Command(management_base.BaseCommand):
+    help = 'Create a superuser for use in local development'
+
+    def handle(self, *args, **options):
+        try:
+            auth_models.User.objects.get(username='admin')
+            print('Superuser `admin` already exists.')
+        except auth_models.User.DoesNotExist:
+            auth_models.User.objects.create_superuser('admin', 'admin@example.com', 'admin')
+            print("\nCreated superuser `admin` with password `admin`.")

--- a/tasks.py
+++ b/tasks.py
@@ -91,10 +91,7 @@ def createsuperuser(ctx, stop=False):
 
     To stop the containers after the command is run, pass the `--stop` flag.
     """
-    preamble = "from django.contrib.auth.models import User;"
-    create = "User.objects.create_superuser('admin', 'admin@example.com', 'admin')"
-    manage(ctx, f'shell -c "{preamble} {create}"', stop=stop)
-    print("\nCreated superuser `admin` with password `admin`.")
+    manage(ctx, f'create_admin', stop=stop)
 
 
 def initialize_database(ctx, slow=False):

--- a/tasks.py
+++ b/tasks.py
@@ -91,7 +91,7 @@ def createsuperuser(ctx, stop=False):
 
     To stop the containers after the command is run, pass the `--stop` flag.
     """
-    manage(ctx, f'create_admin', stop=stop)
+    manage(ctx, 'create_admin', stop=stop)
 
 
 def initialize_database(ctx, slow=False):


### PR DESCRIPTION
When setting up the `pyrun` task I introduced another layer through
which all the strings are passing. That broke the `createsuperuser` task
that was again trying to pass raw Python strings as a shell string...
which was already inside of the tasks.py and had to pass through the new
pyrun methods...

This was just one layer of string escaping too many.

I have now moved the actual creation of the admin to a management
comand and now we only need to run that command with a the task.
