### PR TITLE
updated spacing for blog callout box

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/blog_index_callout_box.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/blog_index_callout_box.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags static i18n %}
 
-<div class="tw-h-full tw-flex tw-flex-col tw-justify-between tw-p-6 tw-popout">
+<div class="tw-h-full tw-flex tw-flex-col tw-justify-between tw-p-5 small:tw-p-6 tw-popout">
   <div id="callout-box-body" class="tw-mb-7 tw-pb-4">
     {% if value.related_topics or value.show_icon %}
       <div class="tw-flex tw-mb-3">
@@ -17,7 +17,7 @@
     {% endif %}
   </div>
     {% if value.link_button_text and value.link_button_url %}
-      <div id="callout-box-button" class='tw-text-right tw-mt-7'>
+      <div id="callout-box-button" class='tw-text-right tw-mt-6'>
           <a class="tw-btn-secondary tw-border after:tw-content-[]" href="{{ value.link_button_url }}">{{ value.link_button_text }}</a>
       </div>
     {% endif %}


### PR DESCRIPTION
# Description
Related PRs/issues: #9192
This PR updates the spacing of the callout box from `tw-p-6` **(2rem)** to `tw-p-5` (**1.5rem)** on mobile breakpoints, as well as reducing the space in between the content and the external link button from `tw-mt-7` **(3rem)** to `tw-mt-5` **(2rem)**.

# Screenshots

Before:
<img width="300" alt="Screen Shot 2022-07-28 at 5 12 56 PM" src="https://user-images.githubusercontent.com/18314510/183312882-a611b7d4-0346-4013-b406-6853cf3cd6b9.png">



After:
<img width="300" alt="Screen Shot 2022-07-28 at 5 12 56 PM" src="https://user-images.githubusercontent.com/18314510/183312883-ac177389-3a17-4231-9b33-85b1615fb493.png">




# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
