### PR TITLE
9170 refactor orderable relations

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/article_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/article_page.html
@@ -11,14 +11,14 @@
 {% endblock hero %}
 
 {% block guts %}
-  {% with content_category_relations=page.content_category_relations.all  %}
-    {% if content_category_relations %}
+  {% with content_categories=page.content_category_relations.related_items  %}
+    {% if content_categories %}
       <div>
         <strong>Categories</strong>
 
         <ul>
-          {% for content_category_relation in content_category_relations  %}
-            <li>{{ content_category_relation.content_category.title|title }}</li>
+          {% for content_category in content_categories  %}
+            <li>{{ content_category.title|title }}</li>
           {% endfor %}
         </ul>
       </div>
@@ -27,14 +27,14 @@
 
   <h1>{{ page.title }}</h1>
 
-  {% with author_profile_relations=page.author_profile_relations.all  %}
-    {% if author_profile_relations %}
+  {% with author_profiles=page.author_profile_relations.related_items  %}
+    {% if author_profiles %}
       <div>
         <h2>Authors</h2>
 
         <ul>
-          {% for author_profile_relation in author_profile_relations %}
-            <li>{{ author_profile_relation.author_profile.name }}</li>
+          {% for author_profile in author_profiles %}
+            <li>{{ author_profile.name }}</li>
           {% endfor %}
         </ul>
       </div>

--- a/network-api/networkapi/templates/pages/buyersguide/home.html
+++ b/network-api/networkapi/templates/pages/buyersguide/home.html
@@ -15,11 +15,11 @@
 
         <div>
           By
-          {% with author_profile_relations=hero_featured_article.author_profile_relations.all  %}
-            {% if author_profile_relations %}
+          {% with author_profiles=hero_featured_article.author_profile_relations.related_items  %}
+            {% if author_profiles %}
               <ul>
-                {% for author_profile_relation in author_profile_relations %}
-                  <li>{{ author_profile_relation.author_profile.name }}</li>
+                {% for author_profile in author_profiles %}
+                  <li>{{ author_profile.name }}</li>
                 {% endfor %}
               </ul>
             {% endif %}
@@ -29,7 +29,7 @@
     {% endif %}
   {% endwith %}
 
-  {% with hero_supporting_articles=page.get_hero_supporting_articles %}
+  {% with hero_supporting_articles=page.hero_supporting_article_relations.related_items %}
     {% if hero_supporting_articles %}
       <div>
         <h2>{{ page.hero_supporting_articles_heading }}</h2>

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
@@ -169,6 +169,8 @@ class BuyersGuideArticlePageRelatedArticleRelation(
     panels = [panels.PageChooserPanel('article')]
 
     objects = orderables.OrderableRelationQuerySet.as_manager()
+    related_item_field_name = "article"
 
     def __str__(self):
         return f'{self.page.title} -> {self.article.title}'
+

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
@@ -91,11 +91,7 @@ class BuyersGuideArticlePage(
         return BuyersGuidePage.objects.filter(id__in=ancestor_ids).first()
 
     def get_related_articles(self) -> models.QuerySet['BuyersGuideArticlePage']:
-        related_article_ids = self.related_article_relations.values_list(
-            'article_id',
-            flat=True,
-        )
-        return BuyersGuideArticlePage.objects.filter(id__in=related_article_ids)
+        return self.related_article_relations.related_items()
 
     def get_primary_related_articles(self) -> models.QuerySet['BuyersGuideArticlePage']:
         return self.get_related_articles()[:3]

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
@@ -119,6 +119,9 @@ class BuyersGuideArticlePageAuthorProfileRelation(
 
     panels = [snippet_panels.SnippetChooserPanel('author_profile')]
 
+    objects = orderables.OrderableRelationQuerySet.as_manager()
+    related_item_field_name = "author_profile"
+
     def __str__(self):
         return f'{self.page.title} -> {self.author_profile.name}'
 
@@ -141,6 +144,9 @@ class BuyersGuideArticlePageContentCategoryRelation(
     )
 
     panels = [snippet_panels.SnippetChooserPanel('content_category')]
+
+    objects = orderables.OrderableRelationQuerySet.as_manager()
+    related_item_field_name = "content_category"
 
     def __str__(self):
         return f'{self.page.title} -> {self.content_category.title}'

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
@@ -10,6 +10,7 @@ from wagtail.images import edit_handlers as image_panels
 from wagtail.snippets import edit_handlers as snippet_panels
 
 from networkapi.wagtailpages.pagemodels import customblocks
+from networkapi.wagtailpages.pagemodels import orderables
 from networkapi.wagtailpages.pagemodels.mixin import foundation_metadata
 
 
@@ -166,6 +167,8 @@ class BuyersGuideArticlePageRelatedArticleRelation(
     )
 
     panels = [panels.PageChooserPanel('article')]
+
+    objects = orderables.OrderableRelationQuerySet.as_manager()
 
     def __str__(self):
         return f'{self.page.title} -> {self.article.title}'

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
@@ -175,4 +175,3 @@ class BuyersGuideArticlePageRelatedArticleRelation(
 
     def __str__(self):
         return f'{self.page.title} -> {self.article.title}'
-

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -24,6 +24,11 @@ from wagtail.core.models import (
 )
 from wagtail_localize.fields import SynchronizedField, TranslatableField
 
+from networkapi.wagtailpages.pagemodels import orderables
+from networkapi.wagtailpages.pagemodels.buyersguide.utils import (
+    get_categories_for_locale,
+    sort_average,
+)
 from networkapi.wagtailpages.pagemodels.mixin.foundation_metadata import (
     FoundationMetadataPageMixin
 )
@@ -32,10 +37,6 @@ from networkapi.wagtailpages.utils import (
     get_default_locale,
     get_language_from_request,
     get_locale_from_request,
-)
-from networkapi.wagtailpages.pagemodels.buyersguide.utils import (
-    get_categories_for_locale,
-    sort_average,
 )
 
 
@@ -342,15 +343,6 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         indexes = BuyersGuideEditorialContentIndexPage.objects.descendant_of(self)
         return indexes.first()
 
-    def get_hero_supporting_articles(self):
-        '''Return the article page objects that are supporting the hero featured article.'''
-        article_ids = self.hero_supporting_article_relations.values_list('article_id', flat=True)
-        BuyersGuideArticlePage = apps.get_model(
-            app_label='wagtailpages',
-            model_name='BuyersGuideArticlePage',
-        )
-        return BuyersGuideArticlePage.objects.filter(id__in=article_ids)
-
     class Meta:
         verbose_name = "Buyers Guide Page"
 
@@ -369,6 +361,9 @@ class BuyersGuidePageHeroSupportingArticleRelation(TranslatableMixin, Orderable)
     )
 
     panels = [PageChooserPanel('article', page_type='wagtailpages.BuyersGuideArticlePage')]
+
+    objects = orderables.OrderableRelationQuerySet.as_manager()
+    related_item_field_name = "article"
 
     def __str__(self):
         return f'{self.page.title} -> {self.article.title}'

--- a/network-api/networkapi/wagtailpages/pagemodels/orderables.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/orderables.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+
+class OrderableRelationQuerySet(models.QuerySet):
+    def related_items(self):
+        article_ids = self.values_list(('article_id'), flat=True)
+        return self.model.article.get_queryset().filter(id__in=article_ids)
+

--- a/network-api/networkapi/wagtailpages/pagemodels/orderables.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/orderables.py
@@ -3,6 +3,8 @@ from django.db import models
 
 class OrderableRelationQuerySet(models.QuerySet):
     def related_items(self):
-        article_ids = self.values_list(('article_id'), flat=True)
-        return self.model.article.get_queryset().filter(id__in=article_ids)
+        field_name = self.model.related_item_field_name
+        item_ids = self.values_list((f"{field_name}_id"), flat=True)
 
+        field = getattr(self.model, field_name)
+        return field.get_queryset().filter(id__in=item_ids)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_article_page.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_article_page.py
@@ -92,31 +92,6 @@ class BuyersGuideArticlePageTest(test_base.WagtailpagesTestCase):
             template_name='wagtailpages/blocks/rich_text_block.html',
         )
 
-    def test_get_related_articles(self):
-        """
-        Returns all related articles.
-
-        We don't want the through model, we really want the articles.
-        """
-        article_page = buyersguide_factories.BuyersGuideArticlePageFactory(
-            parent=self.content_index,
-        )
-        related_articles = []
-        for _ in range(4):
-            related_article = buyersguide_factories.BuyersGuideArticlePageFactory(
-                parent=self.content_index,
-            )
-            buyersguide_factories.BuyersGuideArticlePageRelatedArticleRelationFactory(
-                page=article_page,
-                article=related_article,
-            )
-            related_articles.append(related_article)
-
-        result = article_page.get_related_articles()
-
-        for related_article in related_articles:
-            self.assertIn(related_article, result)
-
     def test_related_article_relations_related_items(self):
         """
         Returns all related articles.
@@ -138,6 +113,31 @@ class BuyersGuideArticlePageTest(test_base.WagtailpagesTestCase):
             related_articles.append(related_article)
 
         result = article_page.related_article_relations.related_items()
+
+        for related_article in related_articles:
+            self.assertIn(related_article, result)
+
+    def test_get_related_articles(self):
+        """
+        Returns all related articles.
+
+        We don't want the through model, we really want the articles.
+        """
+        article_page = buyersguide_factories.BuyersGuideArticlePageFactory(
+            parent=self.content_index,
+        )
+        related_articles = []
+        for _ in range(4):
+            related_article = buyersguide_factories.BuyersGuideArticlePageFactory(
+                parent=self.content_index,
+            )
+            buyersguide_factories.BuyersGuideArticlePageRelatedArticleRelationFactory(
+                page=article_page,
+                article=related_article,
+            )
+            related_articles.append(related_article)
+
+        result = article_page.get_related_articles()
 
         for related_article in related_articles:
             self.assertIn(related_article, result)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_article_page.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_article_page.py
@@ -117,6 +117,31 @@ class BuyersGuideArticlePageTest(test_base.WagtailpagesTestCase):
         for related_article in related_articles:
             self.assertIn(related_article, result)
 
+    def test_related_article_relations_related_items(self):
+        """
+        Returns all related articles.
+
+        We don't want the through model, we really want the articles.
+        """
+        article_page = buyersguide_factories.BuyersGuideArticlePageFactory(
+            parent=self.content_index,
+        )
+        related_articles = []
+        for _ in range(4):
+            related_article = buyersguide_factories.BuyersGuideArticlePageFactory(
+                parent=self.content_index,
+            )
+            buyersguide_factories.BuyersGuideArticlePageRelatedArticleRelationFactory(
+                page=article_page,
+                article=related_article,
+            )
+            related_articles.append(related_article)
+
+        result = article_page.related_article_relations.related_items()
+
+        for related_article in related_articles:
+            self.assertIn(related_article, result)
+
     def test_get_related_articles_no_related_articles(self):
         article_page = buyersguide_factories.BuyersGuideArticlePageFactory(
             parent=self.content_index,

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -245,20 +245,3 @@ class TestBuyersGuidePage(BuyersGuideTestMixin):
         result = self.bg.get_editorial_content_index()
 
         self.assertEqual(result, None)
-
-    def test_get_hero_supporting_articles(self):
-        editorial_content_index = buyersguide_factories.BuyersGuideEditorialContentIndexPageFactory(
-            parent=self.bg,
-        )
-        articles = []
-        for _ in range(3):
-            article = buyersguide_factories.BuyersGuideArticlePageFactory(parent=editorial_content_index)
-            articles.append(article)
-            buyersguide_factories.BuyersGuidePageHeroSupportingArticleRelationFactory(
-                page=self.bg,
-                article=article,
-            )
-
-        result = self.bg.get_hero_supporting_articles()
-
-        self.assertQuerysetEqual(result, articles, ordered=False)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,7 +32,7 @@ module.exports = {
         },
         ".popout": {
           "box-shadow": "10px 10px rgba(0,0,0)",
-          "border": "1px solid #000000",
+          border: "1px solid #000000",
         },
       };
       addUtilities(newUtilities);


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

This PR does not add any functionality, it only reorganizes the implementation of a common pattern I have observed. This is  in preparation of #9170 which is going to add additional relations. 

Often we want to create related objects on pages, and we want them to be orderable. This means we create through model between the parent page and the related object. In the past we had to make sure that the templates handle this case and pull the actual model of interest out of the through model. 

To simplify this, I have been using methods on the page that return the related models directly. But this also has been  proven repetitive. I have now created a `OrderableRelationQuerySet` that can be used as the manager for the through models and adds the retrieval method `related_items` which returns the items that the page is related to. 


Link to sample test page: https://foundation-pni-2022.herokuapp.com/en/privacynotincluded/
Related PRs/issues: #9170

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
