### PR TITLE
9167 refactor primary nav

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/no_search_results.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/no_search_results.html
@@ -1,4 +1,5 @@
-{% load i18n static localization %}
+{% load bg_nav_tags i18n static localization %}
+{% get_bg_home_page as home_page %}
 
 <div class="container">
   <img class="mb-3 oh-no-face" src="{% static '_images/buyers-guide/faces/oh-no.svg' %}" alt="{% trans "Sad face. No products were found." %}">

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_nav.html
@@ -1,4 +1,5 @@
 {% load bg_nav_tags localization i18n static wagtailroutablepage_tags %}
+{% get_bg_home_page as home_page %}
 
 <div class="d-md-none mt-0 mb-0" id="pni-nav-mobile">
     <div class="container">

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_nav_links.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_nav_links.html
@@ -1,9 +1,10 @@
 {% load bg_nav_tags i18n localization wagtailcore_tags %}
+{% get_bg_home_page as home_page %}
 
 {{ pre }}
 {% with home_page.get_editorial_content_index as editorial_content_index  %}
   {% if editorial_content_index %}
-    <a class="{{ class }}" href="{% pageurl editorial_content_index %}">{{ editorial_content_index }}</a>
+    <a class="{{ class }} {% bg_active_nav request.get_full_path editorial_content_index.url %} " href="{% pageurl editorial_content_index %}">{{ editorial_content_index }}</a>
   {% endif %}
 {% endwith %}
 {% localizedroutablepageurl home_page 'about-why-view' as about_why_url %}

--- a/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
@@ -1,7 +1,7 @@
 {% extends "partials/primary_nav.html" %}
 
 {% load bg_nav_tags i18n localization %}
-{% bg_home_page as home_page %}
+{% get_bg_home_page as home_page %}
 
 
 {% block nav_logo %}
@@ -14,8 +14,7 @@
 {% endblock %}
 
 {% block narrow_screen_nav_links %}
-{% url 'buyersguide-home' as home_url %}
-<div><a class="{% bg_active_nav request.get_full_path home_url %}" href="{% relocalized_url home_page.url %}">{% trans "Privacy Not Included" %}</a></div>
+<div><a class="{% bg_active_nav request.get_full_path home_page.url %}" href="{% relocalized_url home_page.url %}">{% trans "Privacy Not Included" %}</a></div>
 {% include "fragments/buyersguide/pni_nav_links.html" with pre="<div>" post="</div>" %}
 {% endblock %}
 

--- a/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
@@ -1,10 +1,10 @@
 {% extends "partials/primary_nav.html" %}
 
 {% load bg_nav_tags i18n localization %}
-{% get_bg_home_page as home_page %}
 
 
 {% block nav_logo %}
+{% get_bg_home_page as home_page %}
   <div class="d-flex align-items-center logo-section">
     <a href="/" class="moz-logo mb-0 mr-3"><span class="sr-only">Mozilla</span></a>
     <p class="mb-0 tw-h3-heading flex-wrap">
@@ -14,6 +14,7 @@
 {% endblock %}
 
 {% block narrow_screen_nav_links %}
+{% get_bg_home_page as home_page %}
 <div><a class="{% bg_active_nav request.get_full_path home_page.url %}" href="{% relocalized_url home_page.url %}">{% trans "Privacy Not Included" %}</a></div>
 {% include "fragments/buyersguide/pni_nav_links.html" with pre="<div>" post="</div>" %}
 {% endblock %}

--- a/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
@@ -1,6 +1,7 @@
 {% extends "partials/primary_nav.html" %}
 
 {% load bg_nav_tags i18n localization %}
+{% bg_home_page as home_page %}
 
 
 {% block nav_logo %}
@@ -14,7 +15,7 @@
 
 {% block narrow_screen_nav_links %}
 {% url 'buyersguide-home' as home_url %}
-<div><a class="{% bg_active_nav request.get_full_path home_url %}" href="{% relocalized_url home_url %}">{% trans "Privacy Not Included" %}</a></div>
+<div><a class="{% bg_active_nav request.get_full_path home_url %}" href="{% relocalized_url home_page.url %}">{% trans "Privacy Not Included" %}</a></div>
 {% include "fragments/buyersguide/pni_nav_links.html" with pre="<div>" post="</div>" %}
 {% endblock %}
 

--- a/network-api/networkapi/templates/fragments/buyersguide/product_tab.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/product_tab.html
@@ -1,4 +1,6 @@
-{% load wagtailcore_tags bg_selector_tags l10n i18n localization static %}
+{% load wagtailcore_tags bg_selector_tags l10n i18n localization static bg_nav_tags %}
+
+{% get_bg_home_page as home_page %}
 
     <div id="product-tab" class="tw-w-full tw-mb-4">
 

--- a/network-api/networkapi/templates/fragments/buyersguide/product_tab.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/product_tab.html
@@ -1,5 +1,4 @@
 {% load wagtailcore_tags bg_selector_tags l10n i18n localization static bg_nav_tags %}
-
 {% get_bg_home_page as home_page %}
 
     <div id="product-tab" class="tw-w-full tw-mb-4">

--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -1,6 +1,7 @@
-{% load wagtailmetadata_tags i18n localization settings_value wagtailuserbar static mofo_common %}
+{% load bg_nav_tags wagtailmetadata_tags i18n localization settings_value wagtailuserbar static mofo_common %}
 
 {% get_current_language as lang_code %}
+{% get_bg_home_page as home_page %}
 
 <!DOCTYPE html>
 <html lang="{{ lang_code }}">

--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -1,7 +1,6 @@
-{% load bg_nav_tags wagtailmetadata_tags i18n localization settings_value wagtailuserbar static mofo_common %}
+{% load wagtailmetadata_tags i18n localization settings_value wagtailuserbar static mofo_common %}
 
 {% get_current_language as lang_code %}
-{% get_bg_home_page as home_page %}
 
 <!DOCTYPE html>
 <html lang="{{ lang_code }}">

--- a/network-api/networkapi/templates/pages/buyersguide/base.html
+++ b/network-api/networkapi/templates/pages/buyersguide/base.html
@@ -3,7 +3,6 @@
 {% load bg_nav_tags localization i18n static wagtailroutablepage_tags wagtailmetadata_tags debug_tags mofo_common %}
 
 {% get_current_language as lang_code %}
-{% get_bg_home_page as home_page %}
 
 {% block page_title %}
 {% environment_prefix %}
@@ -82,6 +81,7 @@
   {% block hero %}{% endblock %}
 
   {% block category_nav %}
+  {% get_bg_home_page as home_page %}
   {% include "fragments/buyersguide/pni_mobile_nav.html" with pagetype=pagetype categories=categories current_category=current_category %}
   <nav id="multipage-nav" class="pni-category-nav text-center d-none d-md-block" title="{% trans "site navigation" context "Tooltip on menu items" %}">
     <div class="container">

--- a/network-api/networkapi/templates/pages/buyersguide/base.html
+++ b/network-api/networkapi/templates/pages/buyersguide/base.html
@@ -3,6 +3,7 @@
 {% load bg_nav_tags localization i18n static wagtailroutablepage_tags wagtailmetadata_tags debug_tags mofo_common %}
 
 {% get_current_language as lang_code %}
+{% get_bg_home_page as home_page %}
 
 {% block page_title %}
 {% environment_prefix %}

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -2,6 +2,8 @@
 
 {% load static env i18n static wagtailimages_tags cache bg_nav_tags localization %}
 
+{% get_bg_home_page as home_page %}
+
 {% block bodyclass %}pni catalog{% endblock %}
 
 {% block main_content_class %}{% endblock %}

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -2,8 +2,6 @@
 
 {% load static env i18n static wagtailimages_tags cache bg_nav_tags localization %}
 
-{% get_bg_home_page as home_page %}
-
 {% block bodyclass %}pni catalog{% endblock %}
 
 {% block main_content_class %}{% endblock %}
@@ -37,6 +35,7 @@
 {% endblock %}
 
 {% block guts %}
+{% get_bg_home_page as home_page %}
 <div class="project-list-section">
   <div class="container">
     <div class="row px-0 px-sm-0">

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -1,6 +1,9 @@
 {% extends "pages/buyersguide/base.html" %}
 
-{% load wagtailcore_tags bg_selector_tags env l10n i18n localization static wagtailimages_tags %}
+{% load wagtailcore_tags bg_selector_tags env l10n i18n localization static wagtailimages_tags bg_nav_tags %}
+
+{% get_bg_home_page as home_page %}
+
 
 {% block social_metadata %}
   <meta property="og:type" content="website">

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -2,9 +2,6 @@
 
 {% load wagtailcore_tags bg_selector_tags env l10n i18n localization static wagtailimages_tags bg_nav_tags %}
 
-{% get_bg_home_page as home_page %}
-
-
 {% block social_metadata %}
   <meta property="og:type" content="website">
   <meta property="og:locale" content="{{ lang_code|to_opengraph_locale }}">
@@ -30,6 +27,7 @@
 {% block body_id %}product-page{% endblock %}
 
 {% block guts %}
+{% get_bg_home_page as home_page %}
 <div class="text-center product-header bg-product-image{% if product.draft %} draft-product{% endif %}">
   <div class="tw-container tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6">
     <div class="tw-col-start-3 tw-col-end-11 tw--mx-4 medium:tw--mx-6">

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
@@ -1,5 +1,4 @@
 from django import http
-from django.apps import apps
 from django.db import models
 from modelcluster import fields as cluster_fields
 from wagtail import images
@@ -79,16 +78,7 @@ class BuyersGuideArticlePage(
 
     def get_context(self, request: http.HttpRequest, *args, **kwargs) -> dict:
         context = super().get_context(request, *args, **kwargs)
-        context['home_page'] = self.get_buyersguide_homepage()
         return context
-
-    def get_buyersguide_homepage(self):
-        BuyersGuidePage = apps.get_model(
-            app_label='wagtailpages',
-            model_name='BuyersGuidePage',
-        )
-        ancestor_ids = self.get_ancestors().values_list('id', flat=True)
-        return BuyersGuidePage.objects.filter(id__in=ancestor_ids).first()
 
     def get_related_articles(self) -> models.QuerySet['BuyersGuideArticlePage']:
         return self.related_article_relations.related_items()

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -39,6 +39,7 @@ from networkapi.wagtailpages.utils import (
     get_default_locale,
     get_language_from_request,
     get_locale_from_request,
+    set_main_site_nav_information,
 )
 
 
@@ -354,6 +355,8 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         pni_home_page = BuyersGuidePage.objects.first()
         context['about_page'] = pni_home_page
         context['home_page'] = pni_home_page
+        context = set_main_site_nav_information(self, context, "BuyersGuidePage")
+
         context['template_cache_key_fragment'] = f'pni_home_{request.LANGUAGE_CODE}'
         return context
 

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -39,7 +39,6 @@ from networkapi.wagtailpages.utils import (
     get_default_locale,
     get_language_from_request,
     get_locale_from_request,
-    set_main_site_nav_information,
 )
 
 
@@ -352,11 +351,6 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         context['current_category'] = None
         context['products'] = products
         context['web_monetization_pointer'] = settings.WEB_MONETIZATION_POINTER
-        pni_home_page = BuyersGuidePage.objects.first()
-        context['about_page'] = pni_home_page
-        context['home_page'] = pni_home_page
-        context = set_main_site_nav_information(self, context, "BuyersGuidePage")
-
         context['template_cache_key_fragment'] = f'pni_home_{request.LANGUAGE_CODE}'
         return context
 

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -2,7 +2,6 @@ import re
 import json
 
 from bs4 import BeautifulSoup
-from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import int_list_validator
@@ -876,7 +875,6 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
         return "unknown"
 
     def get_context(self, request, *args, **kwargs):
-        BuyersGuidePage = apps.get_model(app_label='wagtailpages', model_name='BuyersGuidePage')
         context = super().get_context(request, *args, **kwargs)
         context['product'] = self
         language_code = get_language_from_request(request)
@@ -884,9 +882,6 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
         context['mediaUrl'] = settings.MEDIA_URL
         context['use_commento'] = settings.USE_COMMENTO
         context['pageTitle'] = f'{self.title} | ' + gettext("Privacy & security guide") + ' | Mozilla Foundation'
-        pni_home_page = BuyersGuidePage.objects.first()
-        context['about_page'] = pni_home_page
-        context['home_page'] = pni_home_page
         return context
 
     def serve(self, request, *args, **kwargs):

--- a/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
@@ -8,9 +8,12 @@ register = template.Library()
 # Finds the page's parent "Buyer's Guide Homepage" and returns it.
 @register.simple_tag(name='get_bg_home_page', takes_context=True)
 def get_bg_home_page(context):
-    page = context.get('page', None)
     BuyersGuidePage = apps.get_model(app_label='wagtailpages', model_name='BuyersGuidePage')
-    pni_home_page = BuyersGuidePage.objects.ancestor_of(page, inclusive=True).live().first()
+    page = context.get('page', None)
+    if page:
+        pni_home_page = BuyersGuidePage.objects.ancestor_of(page, inclusive=True).live().first()
+    else:
+        pni_home_page = BuyersGuidePage.objects.first()
     return pni_home_page
 
 

--- a/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
@@ -5,11 +5,12 @@ from urllib.parse import urlparse
 register = template.Library()
 
 
-# Returns the PNI home page
-@register.simple_tag(name='get_bg_home_page')
-def get_bg_home_page():
+# Finds the page's parent "Buyer's Guide Homepage" and returns it.
+@register.simple_tag(name='get_bg_home_page', takes_context=True)
+def get_bg_home_page(context):
+    page = context.get('page', None)
     BuyersGuidePage = apps.get_model(app_label='wagtailpages', model_name='BuyersGuidePage')
-    pni_home_page = BuyersGuidePage.objects.first()
+    pni_home_page = BuyersGuidePage.objects.ancestor_of(page, inclusive=True).live().first()
     return pni_home_page
 
 

--- a/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
@@ -1,8 +1,15 @@
 from django import template
+from django.apps import apps
 from urllib.parse import urlparse
 
 register = template.Library()
 
+
+@register.simple_tag(name='bg_home_page')
+def bg_home_page():
+    BuyersGuidePage = apps.get_model(app_label='wagtailpages', model_name='BuyersGuidePage')
+    pni_home_page = BuyersGuidePage.objects.first()
+    return pni_home_page
 
 # Determine if a category nav link should be marked active
 @register.simple_tag(name='check_active_category')

--- a/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 register = template.Library()
 
 
+# Returns the PNI home page
 @register.simple_tag(name='get_bg_home_page')
 def get_bg_home_page():
     BuyersGuidePage = apps.get_model(app_label='wagtailpages', model_name='BuyersGuidePage')

--- a/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/bg_nav_tags.py
@@ -5,11 +5,12 @@ from urllib.parse import urlparse
 register = template.Library()
 
 
-@register.simple_tag(name='bg_home_page')
-def bg_home_page():
+@register.simple_tag(name='get_bg_home_page')
+def get_bg_home_page():
     BuyersGuidePage = apps.get_model(app_label='wagtailpages', model_name='BuyersGuidePage')
     pni_home_page = BuyersGuidePage.objects.first()
     return pni_home_page
+
 
 # Determine if a category nav link should be marked active
 @register.simple_tag(name='check_active_category')

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_article_page.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_article_page.py
@@ -71,15 +71,6 @@ class BuyersGuideArticlePageTest(test_base.WagtailpagesTestCase):
             template_name='pages/base.html',
         )
 
-    def test_buyersguide_home_page_in_context(self):
-        article_page = buyersguide_factories.BuyersGuideArticlePageFactory(
-            parent=self.content_index,
-        )
-
-        response = self.client.get(article_page.url)
-
-        self.assertEqual(response.context['home_page'], self.buyersguide_homepage)
-
     def test_content_template(self):
         article_page = buyersguide_factories.BuyersGuideArticlePageFactory(
             parent=self.content_index,


### PR DESCRIPTION
# Description
Related PRs/issues: #9167

- This PR adds a new template tag called "`get_bg_home_page`" which returns the buyers guide home page. 
- I then updated any template that needed the home page in its context to instead use this tag.
- I also removed any old logic that was used to add the home page to the pages context, as thanks to the tag it was no longer needed

Steps to test:
- Pull this branch
- Visit the PNI site
- Make sure all the links back to the PNI home page still work
