### PR TITLE
updated language switcher to completely use inline script instead of "onchange=..."

### DIFF
--- a/network-api/networkapi/templates/fragments/language_switcher.html
+++ b/network-api/networkapi/templates/fragments/language_switcher.html
@@ -7,7 +7,7 @@
   <input name="next" type="hidden" value="{% get_unlocalized_url page current_language %}" />
   <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-center mb-md-0">
     <label class="tw-h5-heading mb-0 d-flex align-items-center tw-globe-glyph" for="language-switcher">{% trans "Language" %}</label>
-    <select name="language" id="language-switcher" class="mt-3 mt-md-0 ml-md-3 w-100 form-control" onchange="submitLanguageChange()">
+    <select name="language" id="language-switcher" class="mt-3 mt-md-0 ml-md-3 w-100 form-control">
       {% for language_code, language_name in languages %}
         <option value="{{ language_code }}"{% if language_code == current_language %} selected{% endif %}>
           {{ language_name | capfirst }}
@@ -21,7 +21,9 @@
 
 <script nonce="{{request.csp_nonce}}">
   const form = document.getElementById('language-switcher-form')
-  function submitLanguageChange(){
-    form.submit()
-  }
+  const languageSelector = document.getElementById('language-switcher')
+  languageSelector.addEventListener(`change`, (e) => {
+          e.preventDefault();
+          form.submit()
+        });
 </script>


### PR DESCRIPTION
# Description
Related PRs/issues: #9218
Users were still experiencing issues with the language picker, after some investigation it appears that our CSP settings still did not like that the language picker element was using the "onchange=..." event within the html element. 

This update just removes that, and then handles the event handling within the inline script of the same file! 


# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ]~~ Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~