### PR TITLE
9236 - Blog Landing page's "featured posts" images are stretching

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_index_feature.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_index_feature.html
@@ -39,7 +39,7 @@
     {% else %}
       <div id="featured-image-container" class="tw-w-full tw-h-full">
         <a href="{% relocalized_url blog_page.localized.url %}">
-          {% image blog_page.localized.specific.get_meta_image fill-1200x628 class='tw-h-full tw-w-full' %}
+          {% image blog_page.localized.specific.get_meta_image fill-1200x628 class='tw-h-full tw-w-full tw-object-contain tw-object-top' %}
         </a>
       </div>
     {% endif %}

--- a/tasks.py
+++ b/tasks.py
@@ -231,7 +231,7 @@ def pyrun(ctx, command, stop=False):
     """
     with ctx.cd(ROOT):
         ctx.run(
-            f"docker-compose run --rm backend bash -c 'source ./dockerpythonvenv/bin/activate && {command}'",
+            f"docker-compose run --rm backend bash -c \"source ./dockerpythonvenv/bin/activate && {command}\"",
             **PLATFORM_ARG,
         )
         if stop:


### PR DESCRIPTION
Closes #9236 

`http://localhost:3000/en/blog/` and play around with L and XL breakpoint
Should probably use staging/prod data to check images on the blog page