### PR TITLE
Datalayer event for petition submission

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/petition.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/petition.html
@@ -21,6 +21,7 @@
 		class="sign-petition tw-w-full tw-mb-12"
         data-petition-id="{{ cta.id }}"
         data-cta-slug="{{ page.slug }}"
+        data-form-location="{{ page.url }}"
         data-cta-name="{{ cta.name }}"
         data-cta-header="{{ cta.header | escape }}"
         data-cta-description="{{ cta.description | escape }}"

--- a/source/js/components/petition/petition.jsx
+++ b/source/js/components/petition/petition.jsx
@@ -104,6 +104,15 @@ class Petition extends Component {
     }
 
     this.setState(update);
+
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      'event' : 'form_submission',
+      'form_name' : this.props.ctaName,
+      'form_location' : this.props.formLocation,
+      'form_type' : 'petition-form',
+      'form_id' : this.props.petitionId
+    });
   }
 
   // state update function


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->


Related PRs/issues: #9271
This PR introduces a datalayer event that occurs whenever a user submits a petition.


# Screenshots
**Event Fired when submitting a petition:**
<img width="889" alt="Screen Shot 2022-08-31 at 3 43 01 PM" src="https://user-images.githubusercontent.com/18314510/187806750-a245eb11-840a-4195-bcf3-d72542034b19.png">


# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
