### PR TITLE
Youtube Regrets 2022 - Data wrap embed and standout stats section

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_1.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_1.html
@@ -17,8 +17,8 @@
       {% trans "Reported Videos" as reported_videos %}
       {% trans "Other Videos" as other_videos %}
       {% trans "views per day" as view_per_day %}
-      {% include "./standout-stat.html" with heading=reported_videos number=5794 label=view_per_day classes="mb-5" id="reported-views-per-day-count-up" prefix="~" %}
-      {% include "./standout-stat.html" with heading=other_videos number=3312 label=view_per_day id="other-views-per-day-count-up" prefix="~" %}
+      {% include "../../youtube-regrets-shared/standout-stat.html" with heading=reported_videos number=5794 label=view_per_day classes="mb-5" id="reported-views-per-day-count-up" prefix="~" %}
+      {% include "../../youtube-regrets-shared/standout-stat.html" with heading=other_videos number=3312 label=view_per_day id="other-views-per-day-count-up" prefix="~" %}
     </div>
     <div class="col-12 col-lg-6 offset-lg-1 mt-3 mt-lg-3">
       <h2 class="heading-2 mb-4">{% trans "What we do know is that reported videos seemed to accumulate views faster than those that were not." %}</h2>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_2.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_2.html
@@ -13,10 +13,10 @@
 <div class="row flex-xl-row">
   <div class="col-12 col-xl-7">
     {% trans "views over ~5 months" as views_over_160_days %}
-    {% include "./standout-stat.html" with number=160000000 label=views_over_160_days classes="mb-5" id="views-160days-count-up" smaller=True %}
+    {% include "../../youtube-regrets-shared/standout-stat.html" with number=160000000 label=views_over_160_days classes="mb-5" id="views-160days-count-up" smaller=True %}
   </div>
   <div class="col-12 col-xl-5 mt-3 mt-xl-0 ml-xl-10">
     {% trans "views per video" as views_per_video %}
-    {% include "./standout-stat.html" with number=760 label=views_per_video classes="mb-5" id="views-per-video-count-up" prefix="~" suffix="K" %}
+    {% include "../../youtube-regrets-shared/standout-stat.html" with number=760 label=views_per_video classes="mb-5" id="views-per-video-count-up" prefix="~" suffix="K" %}
   </div>
 </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_3.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_3.html
@@ -29,12 +29,12 @@
 
 <div class="row flex-column-reverse flex-lg-row">
   <div class="col-12 col-lg-5">
-    {% trans "36%" as 36_percent %}
+    {% trans "36" as 36_percent %}
     {% trans "of non-english videos were pandemic-related" as of_non_english_videos %}
-    {% trans "14%" as 14_percent %}
+    {% trans "14" as 14_percent %}
     {% trans "of english videos were pandemic-related" as of_english_videos %}
-    {% include "./standout-stat.html" with number=36_percent label=of_non_english_videos classes="mb-5" %}
-    {% include "./standout-stat.html" with number=14_percent label=of_english_videos %}
+    {% include "../../youtube-regrets-shared/standout-stat.html" with number=36_percent label=of_non_english_videos id="non-english-videos-count-up" classes="mb-5" suffix='%' %}
+    {% include "../../youtube-regrets-shared/standout-stat.html" with number=14_percent label=of_english_videos id="english-videos-count-up" suffix='%' %}
   </div>
   <div class="col-12 col-lg-6 offset-lg-1 mt-3 mt-lg-3">
     <h2 class="heading-2 mb-4">{% trans "We also found that misleading or harmful pandemic-related videos are especially prevalent among non-English regrets." %}</h2>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/chart_section.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/chart_section.html
@@ -38,7 +38,7 @@
 
 {# Extra script for the data wrapper iframe #}
 {% block extra_scripts %}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="{{ request.csp_nonce }}">
     !function () {
       "use strict";
       window.addEventListener("message", (function (e) {

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/chart_section.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/chart_section.html
@@ -18,7 +18,7 @@
         {% endblocktrans %}
       </div>
       <iframe aria-label="{% trans 'YouTube Percentage of Bad Recommendations Chart' %}"
-              class="tw-w-0 tw-min-w-full tw-border-none tw-h-[140px]"
+              class="tw-w-0 tw-min-w-full tw-border-none"
               src="https://datawrapper.dwcdn.net/kl3jI/7/">
       </iframe>
     </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/chart_section.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/chart_section.html
@@ -1,0 +1,53 @@
+{% load static i18n %}
+<section class="tw-flex tw-flex-col tw-justify-center tw-items-center tw-my-7 medium:tw-my-[80px]">
+  <img src="{% static "_images/youtube-regrets/regrets-reporter/our-research-desktop.png" %}" alt="">
+  <div class="container tw-mt-5 medium:tw-mt-7 tw-space-y-7 medium:tw-space-y-[80px]">
+    <div class="tw-text-center tw-max-w-3xl tw-mx-auto">
+      {% blocktrans trimmed %}
+        <h2 class="tw-text-4xl medium:tw-text-[3.25rem] tw-leading-none">The result? People can’t escape bad recommendations.</h2>
+        <p>In the quantitative portion of our study, we ran a randomized controlled experiment across our community of RegretsReporter participants that could directly test the effectiveness of YouTube’s user controls. We found that YouTube’s user controls somewhat influence what is recommended, but this effect is meager and most unwanted videos still slip through.</p>
+      {% endblocktrans %}
+    </div>
+
+    {# Chart #}
+    <div class="tw-max-w-4xl tw-mx-auto tw-text-center">
+      <div class="tw-mb-5">
+        <p class="tw-uppercase tw-text-2xl tw-font-bold tw-mb-0">{% trans 'Percentage of Bad Recommendations' %}</p>
+        <p class="tw-italic tw-text-xl">among all video pairs assessed by our research assistants</p>
+      </div>
+      <iframe aria-label="{% trans 'YouTube Percentage of Bad Recommendations Chart' %}"
+              class="tw-w-0 tw-min-w-full tw-border-none tw-h-[140px]"
+              src="https://datawrapper.dwcdn.net/kl3jI/7/">
+      </iframe>
+    </div>
+
+    <div class="tw-flex tw-flex-col small:tw-flex-row tw-justify-start tw-items-start tw-gap-6 tw-max-w-4xl tw-mx-auto">
+      <img src="https://placehold.co/256x168" alt="">
+      {% blocktrans trimmed %}
+        <div>
+          <p class="tw-font-bold tw-text-xl tw-mb-2">What is a bad recommendation?</p>
+          <p>In our experiment, a “bad recommendation” is when YouTube recommends videos to users that are similar to a video they had previously rejected (clicked “Stop Recommending”). We determined whether videos were similar by relying on assessments by our research assistants and our machine learning video similarity model.</p>
+        </div>
+      {% endblocktrans %}
+    </div>
+  </div>
+</section>
+
+
+{# Extra script for the data wrapper iframe #}
+{% block extra_scripts %}
+  <script type="text/javascript">
+    !function () {
+      "use strict";
+      window.addEventListener("message", (function (e) {
+        if (void 0 !== e.data["datawrapper-height"]) {
+          var t = document.querySelectorAll("iframe");
+          for (var a in e.data["datawrapper-height"]) for (var r = 0; r < t.length; r++) {
+            if (t[r].contentWindow === e.source) t[r].style.height = e.data["datawrapper-height"][a] + "px"
+          }
+        }
+      }))
+    }();
+  </script>
+{% endblock %}
+

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/chart_section.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/chart_section.html
@@ -12,8 +12,10 @@
     {# Chart #}
     <div class="tw-max-w-4xl tw-mx-auto tw-text-center">
       <div class="tw-mb-5">
-        <p class="tw-uppercase tw-text-2xl tw-font-bold tw-mb-0">{% trans 'Percentage of Bad Recommendations' %}</p>
-        <p class="tw-italic tw-text-xl">among all video pairs assessed by our research assistants</p>
+        {% blocktrans trimmed %}
+          <p class="tw-uppercase tw-text-2xl tw-font-bold tw-mb-0">Percentage of Bad Recommendations</p>
+          <p class="tw-italic tw-text-xl">among all video pairs assessed by our research assistants</p>
+        {% endblocktrans %}
       </div>
       <iframe aria-label="{% trans 'YouTube Percentage of Bad Recommendations Chart' %}"
               class="tw-w-0 tw-min-w-full tw-border-none tw-h-[140px]"
@@ -23,12 +25,12 @@
 
     <div class="tw-flex tw-flex-col small:tw-flex-row tw-justify-start tw-items-start tw-gap-6 tw-max-w-4xl tw-mx-auto">
       <img src="https://placehold.co/256x168" alt="">
-      {% blocktrans trimmed %}
-        <div>
+      <div>
+        {% blocktrans trimmed %}
           <p class="tw-font-bold tw-text-xl tw-mb-2">What is a bad recommendation?</p>
           <p>In our experiment, a “bad recommendation” is when YouTube recommends videos to users that are similar to a video they had previously rejected (clicked “Stop Recommending”). We determined whether videos were similar by relying on assessments by our research assistants and our machine learning video similarity model.</p>
-        </div>
-      {% endblocktrans %}
+        {% endblocktrans %}
+      </div>
     </div>
   </div>
 </section>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/standout_stats.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/standout_stats.html
@@ -1,8 +1,10 @@
 {% load i18n %}
 <section class="container-xl tw-mb-7 medium:tw-mb-[80px]">
   <div class="tw-mb-7 tw-text-center">
-    <h3 class="tw-font-bold tw-mb-2 tw-font-changa">Which method was most effective?</h3>
-    <span class="tw-text-2xl medium:tw-text-[1.625rem] tw-font-light">None of them really.</span>
+    {% blocktrans trimmed %}
+      <h3 class="tw-font-bold tw-mb-2 tw-font-changa">Which method was most effective?</h3>
+      <span class="tw-text-2xl medium:tw-text-[1.625rem] tw-font-light">None of them really.</span>
+    {% endblocktrans %}
   </div>
 
   {% trans "Don’t recommend channel" as dont_recommend %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/standout_stats.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/standout_stats.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+<section class="container-xl tw-mb-7 medium:tw-mb-[80px]">
+  <div class="tw-mb-7 tw-text-center">
+    <h3 class="tw-font-bold tw-mb-2 tw-font-changa">Which method was most effective?</h3>
+    <span class="tw-text-2xl medium:tw-text-[1.625rem] tw-font-light">None of them really.</span>
+  </div>
+
+  {% trans "Don’t recommend channel" as dont_recommend %}
+  {% trans "Not interested" as not_interested %}
+  {% trans "Dislike" as dislike_text %}
+  {% trans "Remove from watch history" as remove_from_watch_history %}
+
+  <div class="tw-grid tw-gap-6 large:tw-gap-7 tw-grid-cols-2 xlarge:tw-grid-cols-4">
+    {% include "../../youtube-regrets-shared/standout-stat.html" with number=43 label=dont_recommend id="dont-recommend-channel-count-up" prefix="~" suffix="%" %}
+    {% include "../../youtube-regrets-shared/standout-stat.html" with number=11 label=not_interested id="not-interested-count-up" prefix="~" suffix="%" %}
+    {% include "../../youtube-regrets-shared/standout-stat.html" with number=12 label=dislike_text id="dislike-count-up" prefix="~" suffix="%" %}
+    {% include "../../youtube-regrets-shared/standout-stat.html" with number=29 label=remove_from_watch_history id="remove-from-watch-history-count-up" prefix="~" suffix="%" %}
+  </div>
+</section>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/youtube_regrets_2022.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/youtube_regrets_2022.html
@@ -29,6 +29,8 @@
 
         {% include './fragments/petition_cta.html' %}
       </div>
+
+      {% include './fragments/chart_section.html' %}
     {% endblock %}
   </main>
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/youtube_regrets_2022.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/youtube_regrets_2022.html
@@ -31,6 +31,8 @@
       </div>
 
       {% include './fragments/chart_section.html' %}
+
+      {% include './fragments/standout_stats.html' %}
     {% endblock %}
   </main>
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-shared/standout-stat.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-shared/standout-stat.html
@@ -5,8 +5,8 @@
     <p class="standout-stat__heading mb-0">{{ heading }}</p>
   {% endif %}
 
-  <div class="standout-stat__wrap text-center p-4">
-    <p class="standout-stat__number mb-2 {% if smaller %}standout-stat__number--smaller{% endif %}"
+  <div class="standout-stat__wrap">
+    <p class="standout-stat__number {% if smaller %}standout-stat__number--smaller{% endif %}"
        {% if id %}id="{{ id }}"{% endif %}
        data-stat="{{ number }}"
        data-stat-suffix="{{ suffix }}"

--- a/source/sass/views/youtube-regrets-2021.scss
+++ b/source/sass/views/youtube-regrets-2021.scss
@@ -403,56 +403,6 @@
     }
   }
 
-  .standout-stat {
-    &__heading {
-      font-size: 20px;
-      line-height: calc(48 / 20);
-      font-family: $font-changa;
-    }
-
-    &__number {
-      font-size: 50px;
-      line-height: calc(48 / 50);
-
-      @media screen and (min-width: $bp-md) {
-        font-size: 60px;
-        line-height: calc(48 / 60);
-      }
-      font-family: $font-changa;
-      color: $white;
-
-      &--smaller {
-        font-size: 40px;
-        line-height: calc(48 / 40);
-
-        @media screen and (min-width: $bp-md) {
-          font-size: 60px;
-          line-height: calc(48 / 60);
-        }
-      }
-    }
-
-    &__label {
-      color: $white;
-    }
-
-    &__wrap {
-      background-color: $black;
-      position: relative;
-      margin-bottom: 10px;
-
-      &::after {
-        content: "";
-        width: 100%;
-        height: 100%;
-        border: 1px solid $black;
-        left: 10px;
-        top: 10px;
-        position: absolute;
-      }
-    }
-  }
-
   .downloads-section {
     background-color: $black;
     padding: 150px 0 100px;

--- a/source/sass/views/youtube-regrets-shared.scss
+++ b/source/sass/views/youtube-regrets-shared.scss
@@ -75,7 +75,6 @@
   .btn-with-icon {
     display: inline-flex;
     align-items: center;
-    padding: 12px 20px 12px 25px;
 
     > svg {
       margin-right: 10px;

--- a/source/sass/views/youtube-regrets-shared.scss
+++ b/source/sass/views/youtube-regrets-shared.scss
@@ -11,8 +11,8 @@
         $youtube-regrets-dark-blue 26.46%,
         $black 57.83%,
         $black 100%
-      ),
-      linear-gradient(0deg, $black, $black);
+    ),
+    linear-gradient(0deg, $black, $black);
     border-radius: 0 0 30px 30px;
     overflow: hidden;
   }
@@ -121,6 +121,68 @@
 
     &__label {
       text-transform: uppercase;
+    }
+  }
+
+  .standout-stat {
+    &__heading {
+      font-size: 20px;
+      line-height: 2.4;
+      font-family: $font-changa;
+    }
+
+    &__number {
+      font-size: 50px;
+      line-height: 1;
+      margin-bottom: 0;
+
+      @media screen and (min-width: $bp-md) {
+        font-size: 60px;
+      }
+
+      font-family: $font-changa;
+      color: $white;
+
+      &--smaller {
+        font-size: 40px;
+        line-height: 1.2;
+
+        @media screen and (min-width: $bp-md) {
+          font-size: 60px;
+          line-height: 0.8;
+        }
+      }
+    }
+
+    &__label {
+      color: $white;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      line-height: 1.2;
+    }
+
+    &__wrap {
+      background-color: $black;
+      position: relative;
+      margin-bottom: 10px;
+      padding: 15px;
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      height: 100%;
+
+      &::after {
+        content: "";
+        width: 100%;
+        height: 100%;
+        border: 1px solid $black;
+        left: 10px;
+        top: 10px;
+        position: absolute;
+      }
     }
   }
 }


### PR DESCRIPTION
Addresses #9262 & #9261. 

This PR adds a new data embed with content section to the youtube regrets 2022 page. 
This also adds standout stats below the data embed section. 

### Screenshots

<img width="1068" alt="Screen Shot 2022-09-01 at 6 23 56 PM" src="https://user-images.githubusercontent.com/25041665/188034307-e43abd2f-59fd-4596-a8e3-b7fb4a79b17e.png">

**Mobile**
<img src="https://user-images.githubusercontent.com/25041665/188034351-ed40633b-ea6d-49b3-ba82-ecb5bb8bbb94.png" width="300px"> 

<img src="https://user-images.githubusercontent.com/25041665/188034318-b947f494-091d-4bce-a7c2-424cb7b4dfbb.png" width="300px"> 

