### PR TITLE
Export YouTube Regrets 2022 strings to their own .po file

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -477,6 +477,7 @@ LOCALE_PATHS = (
     os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/buyersguide/locale'),
     os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/wagtailpages/pages/locale'),
     os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale'),
+    os.path.join(BASE_DIR, 'networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/locale'),
 )
 
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_2.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_2.html
@@ -17,6 +17,7 @@
   </div>
   <div class="col-12 col-xl-5 mt-3 mt-xl-0 ml-xl-10">
     {% trans "views per video" as views_per_video %}
-    {% include "./standout-stat.html" with number=760 label=views_per_video classes="mb-5" id="views-per-video-count-up" prefix="~" suffix="K" %}
+    {% trans "K" as localized_suffix %}
+    {% include "./standout-stat.html" with number=760 label=views_per_video classes="mb-5" id="views-per-video-count-up" prefix="~" suffix=localized_suffix %}
   </div>
 </div>

--- a/translation-management.sh
+++ b/translation-management.sh
@@ -41,6 +41,7 @@ case $command in
     cp -r "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/about/locale/" "network-api/networkapi/wagtailpages/templates/about/locale/"
     cp -r "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/locale/" "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/locale/"
     cp -r "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale/" "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale/"
+    cp -r "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/locale/" "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/locale/"
     cp -r "${L10N_REPO}foundation/translations/networkapi/mozfest/locale/" "network-api/networkapi/mozfest/locale/"
 esac
 
@@ -52,5 +53,6 @@ case $command in
     cp -r "network-api/networkapi/wagtailpages/templates/about/locale/" "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/about/locale/"
     cp -r "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/locale/" "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/locale/"
     cp -r "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale/" "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/locale/"
+    cp -r "network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/locale/" "${L10N_REPO}foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/locale/"
     cp -r "network-api/networkapi/mozfest/locale/" "${L10N_REPO}foundation/translations/networkapi/mozfest/locale/"
 esac


### PR DESCRIPTION
Making sure the strings for this year’s landing page get exported in their own .po file, as well as re-localizing a string on the 2021 landing page that got hardcoded in a recent PR

Related PRs/issues: #9300

