### PR TITLE
YouTube Regrets 2021 - Fix template path

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_2.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/fragments/accordion_section_2.html
@@ -18,6 +18,6 @@
   <div class="col-12 col-xl-5 mt-3 mt-xl-0 ml-xl-10">
     {% trans "views per video" as views_per_video %}
     {% trans "K" as localized_suffix %}
-    {% include "./standout-stat.html" with number=760 label=views_per_video classes="mb-5" id="views-per-video-count-up" prefix="~" suffix=localized_suffix %}
+    {% include "../../youtube-regrets-shared/standout-stat.html" with number=760 label=views_per_video classes="mb-5" id="views-per-video-count-up" prefix="~" suffix=localized_suffix %}
   </div>
 </div>


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
Fix missing template issue: https://sentry.prod.mozaws.net/operations/foundation-mozilla-org/issues/19532337/?query=is%3Aunresolved

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
