### PR TITLE
Youtube Regrets 2022 - Top hero intro section #9253

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/hero.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/hero.html
@@ -13,7 +13,7 @@
       <p class="mb-1 tw-text-3xl tw-font-bold mt-0">{% trans "Investigating YouTube's ineffective user controls" %}</p>
       <p class="tw-body-large large:tw-text-2xl mt-0">
         {% blocktrans trimmed %}
-          powered by 22,722 volunteers, Mozilla scrutinized YouTube to determine how much control people actually have over the platform’s recommendation algorithm.
+          Powered by 22,722 volunteers, Mozilla scrutinized YouTube to determine how much control people actually have over the platform’s recommendation algorithm.
           <span class="tw-italic">This is what we learned</span>.
         {% endblocktrans %}
       </p>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/hero.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/hero.html
@@ -9,14 +9,16 @@
     </div>
 
     <div class="tw-relative tw-space-y-5 medium:tw-space-y-6 tw-flex tw-flex-col tw-justify-center tw-items-start">
-      <h1 class="mb-0 tw-leading-none tw-font-bold tw-text-4xl medium:tw-text-[3.25rem]">{% trans "Does this button work?" %}</h1>
-      <p class="mb-1 tw-text-3xl tw-font-bold mt-0">{% trans "Investigating YouTube's ineffective user controls" %}</p>
-      <p class="tw-body-large large:tw-text-2xl mt-0">
-        {% blocktrans trimmed %}
-          Powered by 22,722 volunteers, Mozilla scrutinized YouTube to determine how much control people actually have over the platform’s recommendation algorithm.
-          <span class="tw-italic">This is what we learned</span>.
-        {% endblocktrans %}
-      </p>
+      <div>
+        <h1 class="tw-mb-0 tw-leading-none tw-font-bold tw-text-4xl medium:tw-text-[3.25rem]">{% trans "Does this button work?" %}</h1>
+        <p class="tw-mb-1 tw-text-3xl medium:tw-text-[2.375rem] tw-leading-9 tw-font-changa tw-mt-3 tw-font-semibold">{% trans "Investigating YouTube's ineffective user controls" %}</p>
+        <p class="tw-body-large large:tw-text-2xl tw-mt-5">
+          {% blocktrans trimmed %}
+            Powered by 22,722 volunteers, Mozilla scrutinized YouTube to determine how much control people actually have over the platform’s recommendation algorithm.
+            <span class="tw-italic">This is what we learned</span>.
+          {% endblocktrans %}
+        </p>
+      </div>
       <a href="https://foundation.mozilla.org/research/library/user-controls/report/" class="btn btn-with-icon btn-red">
         <svg aria-hidden="true" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2 3.395h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2v-15ZM22 3.395h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7v-15Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/></svg>
         {% trans "Read the Full Report" %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/hero.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/fragments/hero.html
@@ -9,10 +9,11 @@
     </div>
 
     <div class="tw-relative tw-space-y-5 medium:tw-space-y-6 tw-flex tw-flex-col tw-justify-center tw-items-start">
-      <h1 class="tw-mb-0 tw-leading-none tw-font-bold tw-text-4xl medium:tw-text-[3.25rem]">{% trans "Does this button work?" %}</h1>
-      <p class="tw-body-large large:tw-text-2xl">
+      <h1 class="mb-0 tw-leading-none tw-font-bold tw-text-4xl medium:tw-text-[3.25rem]">{% trans "Does this button work?" %}</h1>
+      <p class="mb-1 tw-text-3xl tw-font-bold mt-0">{% trans "Investigating YouTube's ineffective user controls" %}</p>
+      <p class="tw-body-large large:tw-text-2xl mt-0">
         {% blocktrans trimmed %}
-          <span class="tw-font-bold">Investigating YouTube's ineffective user controls</span> powered by 22,722 volunteers, Mozilla scrutinized YouTube to determine how much control people actually have over the platform’s recommendation algorithm.
+          powered by 22,722 volunteers, Mozilla scrutinized YouTube to determine how much control people actually have over the platform’s recommendation algorithm.
           <span class="tw-italic">This is what we learned</span>.
         {% endblocktrans %}
       </p>


### PR DESCRIPTION
Addresses comment [here](https://github.com/mozilla/foundation.mozilla.org/issues/9253#issuecomment-1238578701) on 9253.

The spacing isn't quite right between the three text elements (when comparing with the Figma file), but the only way to overcome that would be to override this class, which isn't easy to do in a nice way:

```
@media (min-width: 768px)
.medium\:tw-space-y-6 > :not([hidden]) ~ :not([hidden]) {
   ...
    margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse))) !important;
    margin-bottom: calc(2rem * var(--tw-space-y-reverse)) !important;
}
```

Should I create a special class to make those overrides, or is the above snipper in place to prevent people from using incorrect spacing?

Screenshots:
![Screenshot 2022-09-08 at 11 04 35](https://user-images.githubusercontent.com/2553896/189095977-cae4eba3-d9e7-4cdd-94e6-0920f510f505.png)
![Screenshot 2022-09-08 at 11 05 01](https://user-images.githubusercontent.com/2553896/189095986-f09ca41f-3657-4652-abda-7abc9f2f598f.png)
