### PR TITLE
[Youtube Regrets 2022] - Remove locomotive scroll from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.25.1",
-    "locomotive-scroll": "^4.1.4",
     "optipng-bin": "^7.0.0",
     "prettier": "^2.3.2",
     "stylelint": "^13.13.1",


### PR DESCRIPTION
Update package.json to an issue with locomotive scroll imports not being found for youtube regrets 2022.

