### PR TITLE
added call to action to homepage

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/home.html
+++ b/network-api/networkapi/templates/pages/buyersguide/home.html
@@ -21,31 +21,36 @@
 
     <div class="tw-container tw-my-6">
       <div class="tw-row">
-        {% with popular_articles=page.get_featured_articles %}
-          {% if popular_articles %}
-            <div class="tw-px-4 tw-w-full large:tw-w-1/3 tw-mb-4">
-              {% include "fragments/buyersguide/popular_articles.html" with index_page=page.get_editorial_content_index %}
-            </div>
-          {% endif %}
-        {% endwith %}
+        {% with row_item_classes="tw-px-4 tw-w-full large:tw-w-1/3 tw-py-5 large:tw-py-0" %}
+        
+          {% with popular_articles=page.get_featured_articles %}
+            {% if popular_articles %}
+              <div class="{{row_item_classes}}">
+                {% include "fragments/buyersguide/popular_articles.html" with index_page=page.get_editorial_content_index %}
+              </div>
+            {% endif %}
+          {% endwith %}
 
-        {% with product_updates=page.get_featured_updates %}
-          {% if product_updates %}
-            <div class="tw-px-4 tw-w-full large:tw-w-1/3 tw-mb-4">
-              {% include "fragments/buyersguide/in_the_press.html" %}
-            </div>
-          {% endif %}
+          {% with product_updates=page.get_featured_updates %}
+            {% if product_updates %}
+              <div class="{{row_item_classes}}">
+                {% include "fragments/buyersguide/in_the_press.html" %}
+              </div>
+            {% endif %}
+          {% endwith %}
+
+          {% with cta=featured_cta %}
+            {% if cta %}
+              <div class="{{row_item_classes}} large:-tw-mt-[20px]">
+                {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
+              </div>
+            {% endif %}
+          {% endwith %}
+
         {% endwith %}
       </div>
     </div>
+
   </div>
-  <div class="tw-container tw-my-6">
-    <div class="tw-row">
-      {% with cta=featured_cta %}
-        {% if cta %}
-          {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
-        {% endif %}
-      {% endwith %}
-    </div>
-  </div>
+
 {% endblock hero %}

--- a/network-api/networkapi/templates/pages/buyersguide/home.html
+++ b/network-api/networkapi/templates/pages/buyersguide/home.html
@@ -41,7 +41,7 @@
 
           {% with cta=featured_cta %}
             {% if cta %}
-              <div class="{{row_item_classes}} large:-tw-mt-[20px]">
+              <div class="{{row_item_classes}}">
                 {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
               </div>
             {% endif %}


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
Related PRs/issues: #9357
Screenshot from Figma:
<img width="841" alt="image" src="https://user-images.githubusercontent.com/18314510/191355639-6ebfe098-ec05-4a64-bda2-343a76e3766a.png">


This PR adds the buyersguide call to the action to the home page, aligned with the other row items according to the figma file.


# Screenshots
Desktop:
![Screenshot 2022-09-20 at 13-09-11 Privacy Not Included A Buyer’s Guide for Connected Products](https://user-images.githubusercontent.com/18314510/191354804-19cb62d6-4cf2-4e56-a5e5-9049e2fc2b85.png)

Mobile:
<img width="300" alt="Screen Shot 2022-08-23 at 6 33 05 PM" src="https://user-images.githubusercontent.com/18314510/191354856-295459ab-53ed-418f-9c51-395f5b1df06e.png">

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
