### PR TITLE
updated category_page.html to show cta whether or not it has related articles

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/category_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/category_page.html
@@ -26,22 +26,23 @@
 
           </div>
         {% endif %}
-
-        <div
-        class="
-          {% if category != current_category %}
-            d-none
-          {% endif %}
-        "
-        >
-          {% with cta=featured_cta %}
-            {% if cta %}
-              {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
-            {% endif %}
-          {% endwith %}
-        </div>
-
       {% endwith %}
+
+      <div
+      class="
+        {% if category != current_category %}
+          d-none
+        {% endif %}
+      "
+      >
+        {% with cta=featured_cta %}
+          {% if current_category.show_cta %}
+            {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
+          {% endif %}
+        {% endwith %}
+      </div>
+
+
     {% endfor %}
 
     {{ block.super }}

--- a/network-api/networkapi/templates/pages/buyersguide/category_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/category_page.html
@@ -24,14 +24,23 @@
               {% include "fragments/buyersguide/related_reading.html" with articles=primary_related_articles index_page=editorial_content_index %}
             </div>
 
-            {% with cta=featured_cta %}
-              {% if cta %}
-                {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
-              {% endif %}
-            {% endwith %}
-            
           </div>
         {% endif %}
+
+        <div
+        class="
+          {% if category != current_category %}
+            d-none
+          {% endif %}
+        "
+        >
+          {% with cta=featured_cta %}
+            {% if cta %}
+              {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
+            {% endif %}
+          {% endwith %}
+        </div>
+
       {% endwith %}
     {% endfor %}
 

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -314,9 +314,6 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
                                f' | Mozilla Foundation'
         context['template_cache_key_fragment'] = f'{category.slug}_{request.LANGUAGE_CODE}'
 
-        if not category.show_cta:
-            context['featured_cta'] = None
-
         # Checking if category has custom metadata, if so, update the share image and description.
         if category.share_image:
             setattr(self, 'search_image_id', category.localized.share_image_id)


### PR DESCRIPTION
The featured_cta section on the category page was inside an if statement, that only rendered if a category had related articles.

This PR takes the cta section out of that if statement, so it can show based on whether or not the category has "show_cta" set to true, but does not depend on related articles.