### PR TITLE
9094 product page aside

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/call_to_action_box.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/call_to_action_box.html
@@ -1,8 +1,6 @@
 {% load static wagtailcore_tags wagtailimages_tags %}
 
-<div
-  {% if icon and not large %} class="tw-pt-[20px] medium:tw-pt-[24px]" {% endif %} {# Margin to create space for the icon bleed. #}
->
+<div>
   <div class="
     tw-bg-gradient-to-b tw-from-yellow-10 tw-to-purple-05
     tw-rounded-2xl

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -98,7 +98,7 @@
           <div class="row intro mb-4 tw-relative">
             <div class="col-12 tw-body">{{product.blurb | richtext}}</div>
 
-            <aside class="tw-absolute tw-w-[350px] tw-left-full tw-h-[700px] tw-border tw-border-red-40">
+            <aside class="2xl:tw-absolute tw-mt-4 2xl:tw-mt-0 tw-px-4 tw-w-full 2xl:tw-w-[320px] 2xl:tw-left-full tw-grid tw-grid-cols-1 large:tw-grid-cols-2 2xl:tw-grid-cols-1 tw-gap-7 medium:tw-gap-5 tw-border tw-border-red-40">
               {% with cta=featured_cta %}
                 {% if cta %}
                   {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -98,7 +98,16 @@
           <div class="row intro mb-4 tw-relative">
             <div class="col-12 tw-body">{{product.blurb | richtext}}</div>
 
-            <aside class="2xl:tw-absolute tw-mt-6 2xl:tw-mt-0 tw-px-4 tw-w-full 2xl:tw-w-[320px] 2xl:tw-left-full tw-grid tw-grid-cols-1 large:tw-grid-cols-2 2xl:tw-grid-cols-1 tw-gap-7 medium:tw-gap-5 tw-border tw-border-red-40">
+            <aside class="
+              2xl:tw-absolute
+              tw-mt-6 2xl:tw-mt-0
+              tw-px-4
+              tw-w-full 2xl:tw-w-[320px]
+              2xl:tw-left-full
+              tw-grid
+              tw-grid-cols-1 large:tw-grid-cols-2 2xl:tw-grid-cols-1
+              tw-gap-7 medium:tw-gap-5
+            ">
               {% with cta=featured_cta %}
                 {% if cta %}
                   {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -80,7 +80,7 @@
         {% endif %}
 
         <div class="bg-white tw-pb-4 tw-pt-5 tw-px-4 medium:tw-px-6">
-          <div class="row intro mb-4">
+          <div class="row intro">
             <div class="tw-flex tw-gap-2 tw-flex-wrap tw-px-4 tw-mb-4">
               {% for cat in product.product_categories.all %}
                 {% with category=cat.category %}
@@ -91,7 +91,9 @@
                 {% endwith %}
               {% endfor %}
             </div>
+
             <h1 class="tw-h1-heading col-12">{{product.title}}</h1>
+
             <div class="col-12 d-flex flex-column flex-md-row justify-content-between">
               <a id="product-company-url" class="company-external-link pni-product-intro-large mb-2 mb-md-0" href="{{product.product_url}}" target="_blank">{{product.company}}</a>
               {% if product.uses_wifi or product.uses_bluetooth %}
@@ -105,8 +107,15 @@
                 </div>
               {% endif %}
             </div>
+
             {% include "fragments/buyersguide/research_details.html" with review_date=product.review_date time_researched=product.time_researched mozilla_says=product.mozilla_says %}
-            <div class="col-12 tw-body">{{product.blurb | richtext}}</div>
+          </div>
+
+          <div class="row intro mb-4 tw-relative">
+            <div class="col-12 tw-body">THIS IS THE BLURB {{product.blurb | richtext}}</div>
+            <aside class="tw-absolute tw-w-[350px] tw-left-full tw-h-[700px] tw-border tw-border-red-40">
+              aside content
+            </aside>
           </div>
 
           <div class="row mb-4">

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -98,7 +98,7 @@
           <div class="row intro mb-4 tw-relative">
             <div class="col-12 tw-body">{{product.blurb | richtext}}</div>
 
-            <aside class="2xl:tw-absolute tw-mt-4 2xl:tw-mt-0 tw-px-4 tw-w-full 2xl:tw-w-[320px] 2xl:tw-left-full tw-grid tw-grid-cols-1 large:tw-grid-cols-2 2xl:tw-grid-cols-1 tw-gap-7 medium:tw-gap-5 tw-border tw-border-red-40">
+            <aside class="2xl:tw-absolute tw-mt-6 2xl:tw-mt-0 tw-px-4 tw-w-full 2xl:tw-w-[320px] 2xl:tw-left-full tw-grid tw-grid-cols-1 large:tw-grid-cols-2 2xl:tw-grid-cols-1 tw-gap-7 medium:tw-gap-5 tw-border tw-border-red-40">
               {% with cta=featured_cta %}
                 {% if cta %}
                   {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -30,27 +30,11 @@
 
   {% get_bg_home_page as home_page %}
 
-  {% with primary_related_articles=product.get_primary_related_articles  %}
-    {% if primary_related_articles %}
-      <div class="tw-pl-5">
-        <h2>Related</h2>
-
-        <p> Primary related articles (first 3 of list of max 5)</p>
-
-        <div class="tw-m-4">
-          {% include "fragments/buyersguide/related_reading.html" with articles=primary_related_articles %}
-        </div>
-
-        <div class="tw-max-w-[410px] tw-mb-5">
-          {% include "fragments/buyersguide/dive_deeper.html" with updates=product.updates.all %}
-        </div>
+  {% with product_updates=product.updates.all  %}
+    {% if product_updates %}
+      <div class="tw-max-w-[410px] tw-mb-5">
+        {% include "fragments/buyersguide/dive_deeper.html" with updates=product_updates %}
       </div>
-    {% endif %}
-  {% endwith %}
-
-  {% with cta=featured_cta %}
-    {% if cta %}
-      {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
     {% endif %}
   {% endwith %}
 
@@ -112,9 +96,20 @@
           </div>
 
           <div class="row intro mb-4 tw-relative">
-            <div class="col-12 tw-body">THIS IS THE BLURB {{product.blurb | richtext}}</div>
+            <div class="col-12 tw-body">{{product.blurb | richtext}}</div>
+
             <aside class="tw-absolute tw-w-[350px] tw-left-full tw-h-[700px] tw-border tw-border-red-40">
-              aside content
+              {% with cta=featured_cta %}
+                {% if cta %}
+                  {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
+                {% endif %}
+              {% endwith %}
+
+              {% with primary_related_articles=product.get_primary_related_articles  %}
+                {% if primary_related_articles %}
+                  {% include "fragments/buyersguide/related_reading.html" with articles=primary_related_articles %}
+                {% endif %}
+              {% endwith %}
             </aside>
           </div>
 

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -28,208 +28,208 @@
 
 {% block guts %}
 
-{% get_bg_home_page as home_page %}
+  {% get_bg_home_page as home_page %}
 
-{% with primary_related_articles=product.get_primary_related_articles  %}
-  {% if primary_related_articles %}
-    <div class="tw-pl-5">
-      <h2>Related</h2>
+  {% with primary_related_articles=product.get_primary_related_articles  %}
+    {% if primary_related_articles %}
+      <div class="tw-pl-5">
+        <h2>Related</h2>
 
-      <p> Primary related articles (first 3 of list of max 5)</p>
+        <p> Primary related articles (first 3 of list of max 5)</p>
 
-      <div class="tw-m-4">
-        {% include "fragments/buyersguide/related_reading.html" with articles=primary_related_articles %}
+        <div class="tw-m-4">
+          {% include "fragments/buyersguide/related_reading.html" with articles=primary_related_articles %}
+        </div>
+
+        <div class="tw-max-w-[410px] tw-mb-5">
+          {% include "fragments/buyersguide/dive_deeper.html" with updates=product.updates.all %}
+        </div>
+
+
       </div>
+    {% endif %}
+  {% endwith %}
 
-      <div class="tw-max-w-[410px] tw-mb-5">
-        {% include "fragments/buyersguide/dive_deeper.html" with updates=product.updates.all %}
-      </div>
-
-
-    </div>
-  {% endif %}
-{% endwith %}
-
-{% with cta=featured_cta %}
-  {% if cta %}
-    {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
-  {% endif %}
-{% endwith %}
+  {% with cta=featured_cta %}
+    {% if cta %}
+      {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
+    {% endif %}
+  {% endwith %}
 
 
-<div class="text-center product-header bg-product-image{% if product.draft %} draft-product{% endif %}">
-  <div class="tw-container tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6">
-    <div class="tw-col-start-3 tw-col-end-11 tw--mx-4 medium:tw--mx-6">
-      <div class="tw-w-full  product-header-content {% if product.privacy_ding %}show-privacy-ding{% endif %}">
-        <img
-          class="thumb-border tw-mx-auto"
-          width="250"
-          {% image product.image width-250 as img %}
-          src="{{ img.url }}"
-          alt="{{product.title}}"
-        >
+  <div class="text-center product-header bg-product-image{% if product.draft %} draft-product{% endif %}">
+    <div class="tw-container tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6">
+      <div class="tw-col-start-3 tw-col-end-11 tw--mx-4 medium:tw--mx-6">
+        <div class="tw-w-full  product-header-content {% if product.privacy_ding %}show-privacy-ding{% endif %}">
+          <img
+            class="thumb-border tw-mx-auto"
+            width="250"
+            {% image product.image width-250 as img %}
+            src="{{ img.url }}"
+            alt="{{product.title}}"
+            >
+        </div>
       </div>
     </div>
   </div>
-</div>
-{% with section_class="tw-col-start-3 tw-col-end-11 tw--mx-4 medium:tw--mx-6" %}
-<div class="tw-container product-detail tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6">
-  <div class="{{section_class}} tw-relative">
+  {% with section_class="tw-col-start-3 tw-col-end-11 tw--mx-4 medium:tw--mx-6" %}
+    <div class="tw-container product-detail tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6">
+      <div class="{{section_class}} tw-relative">
 
-    {% if product.privacy_ding %}
-    <div class="privacy-ding-band tw-px-4 medium:tw-px-6 ">
-      <p class="pni-product-smaller-body mb-0 py-2">{% blocktrans %}<strong>Warning</strong>: *privacy not included with this product{% endblocktrans %}</p>
+        {% if product.privacy_ding %}
+          <div class="privacy-ding-band tw-px-4 medium:tw-px-6 ">
+            <p class="pni-product-smaller-body mb-0 py-2">{% blocktrans %}<strong>Warning</strong>: *privacy not included with this product{% endblocktrans %}</p>
+          </div>
+        {% endif %}
+
+        <div class="bg-white tw-pb-4 tw-pt-5 tw-px-4 medium:tw-px-6">
+          <div class="row intro mb-4">
+            <div class="tw-flex tw-gap-2 tw-flex-wrap tw-px-4 tw-mb-4">
+              {% for cat in product.product_categories.all %}
+                {% with category=cat.category %}
+                  {% localizedroutablepageurl home_page 'category-view' category.slug as cat_url %}
+                  <a href="{{cat_url}}" class="category-tag {% if category.parent == None %}category{% else %}subcategory{% endif %} tw-no-underline tw-text-gray-60 border tw-border-gray-20 tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3]">
+                    {{category.localized.name}}
+                  </a>
+                {% endwith %}
+              {% endfor %}
+            </div>
+            <h1 class="tw-h1-heading col-12">{{product.title}}</h1>
+            <div class="col-12 d-flex flex-column flex-md-row justify-content-between">
+              <a id="product-company-url" class="company-external-link pni-product-intro-large mb-2 mb-md-0" href="{{product.product_url}}" target="_blank">{{product.company}}</a>
+              {% if product.uses_wifi or product.uses_bluetooth %}
+                <div>
+                  {% if product.uses_wifi %}
+                    <span class="connectivity-requirement use-wifi pni-product-intro-large">{% trans "Wi-Fi" %}</span>
+                  {% endif %}
+                  {% if product.uses_bluetooth %}
+                    <span class="connectivity-requirement use-bluetooth pni-product-intro-large">{% trans "Bluetooth" %}</span>
+                  {% endif %}
+                </div>
+              {% endif %}
+            </div>
+            {% include "fragments/buyersguide/research_details.html" with review_date=product.review_date time_researched=product.time_researched mozilla_says=product.mozilla_says %}
+            <div class="col-12 tw-body">{{product.blurb | richtext}}</div>
+          </div>
+
+          <div class="row mb-4">
+            <div class="col-12 worst-case">
+              <h2 class="tw-h3-heading">{% trans "What could happen if something goes wrong?" %}</h2>
+              <div class="tw-body">{{product.worst_case | richtext}}</div>
+            </div>
+          </div>
+
+          {% if product.tips_to_protect_yourself %}
+            <div class="row tw-my-5 tips-to-protect-yourself">
+              <div class="col-12 tw-py-5 tips">
+                <h2 class="tw-h3-heading">{% trans "Tips to protect yourself" %}</h2>
+                {{ product.tips_to_protect_yourself | richtext }}
+              </div>
+            </div>
+          {% endif %}
+
+
+          <div id="product-research" data-is-wagtail-page="true">
+            <div id="creepiness-vote">
+              <div class="row">
+                <div class="col-12">
+                  <div class="creep-vote-target mb-5 mt-3 mt-md-4 p-5" data-product-name="{{product.title}}" data-product-type="{{product.product_type}}">
+                    <input type="hidden" name="productID" value="{{ product.id }}">
+                    <input type="hidden" name="votes" value='{{ product.get_voting_json | safe }}'>
+                  </div>
+                </div>
+              </div>
+
+              {% include "fragments/buyersguide/product_tab.html" with  product=product %}
+
+              {% if product.updates.count > 0 %}
+                <hr class="pni-section-divider"/>
+                <h3 id="news" class="tw-h2-heading mb-3">{% trans "News" %}</h3>
+                <div class="mb-5">
+                  {% for item in product.updates.all %}
+                    {% with update=item.update %}
+                      <div class="product-update mb-4">
+                        <a class="product-update-link tw-h5-heading title" href="{{update.source}}" target="_blank">{{update.title}}</a>
+                        <div class="author">{{update.author}}</div>
+                        <div class="snippet">{{update.snippet}}</div>
+                      </div>
+                    {% endwith %}
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </div>
+
+            <hr class="pni-section-divider"/>
+
+            <div class="tw-w-full">
+              <h3 class="tw-h2-heading mb-4">{% trans "Related products" %}</h3>
+              <div class="row">
+                {% for related_product_page in product.related_product_pages.all %}
+                  {% with related_product=related_product_page.related_product.localized %}
+                    <div class="related-product col-6 col-md-3 mb-3 mb-md-0">
+                      <a class="d-block{% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url %}">
+                        <div class="img-container">
+                          {% image related_product.image width-600 as img %}
+                          <img
+                            class="product-thumbnail"
+                            width="600"
+                            loading="lazy"
+                            src="{{img.url}}"
+                            alt="{{related_product.title}}"
+                            >
+                        </div>
+                        <p class="tw-body-small mt-3 mb-1">{{related_product.company}}</p>
+                        <p>{{related_product.title}}</p>
+                      </a>
+
+                      {% include "fragments/buyersguide/privacy_ding.html" with product=related_product %}
+                      {% include "fragments/buyersguide/adult_content_badge.html" with product=related_product %}
+                    </div>
+                  {% endwith %}
+                {% endfor %}
+              </div>
+            </div>
+
+
+
+
+          </div>
+        </div>
+      </div>
     </div>
+
+    {% with secondary_related_articles=product.get_secondary_related_articles  %}
+      {% if secondary_related_articles %}
+        <div class="tw-container tw-grid medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
+          <div class="tw-col-span-full medium:tw-col-span-1">
+            Dive deeper
+          </div>
+          <div class="tw-col-span-full medium:tw-col-start-2 medium:tw-col-span-1 large:tw-col-span-2">
+            {% include "fragments/buyersguide/article_listing_what_to_read_next.html" with articles=secondary_related_articles index_page=home_page.get_editorial_content_index use_wide_above="large" wide_columns_above_large=2  %}
+          </div>
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    {% if use_commento %}
+
+      <div class="container-fluid position-relative comment-section">
+        <div class="row dotted-section d-block d-sm-flex mx-0 mt-5">
+          <div class="tw-container tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6 tw-z-10 position-relative">
+            <div class="{{section_class}}">
+              <div class="mt-3 pt-3 bg-white tw-px-4 medium:tw-px-6">
+
+                <h3 class="tw-h2-heading">{% trans "Comments" %}</h3>
+                <p class="mb-4">{% trans "Got a comment? Let us hear it." %}</p>
+                <div id="commento"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     {% endif %}
 
-    <div class="bg-white tw-pb-4 tw-pt-5 tw-px-4 medium:tw-px-6">
-      <div class="row intro mb-4">
-        <div class="tw-flex tw-gap-2 tw-flex-wrap tw-px-4 tw-mb-4">
-          {% for cat in product.product_categories.all %}
-            {% with category=cat.category %}
-              {% localizedroutablepageurl home_page 'category-view' category.slug as cat_url %}
-              <a href="{{cat_url}}" class="category-tag {% if category.parent == None %}category{% else %}subcategory{% endif %} tw-no-underline tw-text-gray-60 border tw-border-gray-20 tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3]">
-                {{category.localized.name}}
-              </a>
-            {% endwith %}
-          {% endfor %}
-        </div>
-        <h1 class="tw-h1-heading col-12">{{product.title}}</h1>
-        <div class="col-12 d-flex flex-column flex-md-row justify-content-between">
-          <a id="product-company-url" class="company-external-link pni-product-intro-large mb-2 mb-md-0" href="{{product.product_url}}" target="_blank">{{product.company}}</a>
-          {% if product.uses_wifi or product.uses_bluetooth %}
-            <div>
-              {% if product.uses_wifi %}
-                <span class="connectivity-requirement use-wifi pni-product-intro-large">{% trans "Wi-Fi" %}</span>
-              {% endif %}
-              {% if product.uses_bluetooth %}
-                <span class="connectivity-requirement use-bluetooth pni-product-intro-large">{% trans "Bluetooth" %}</span>
-              {% endif %}
-            </div>
-          {% endif %}
-        </div>
-        {% include "fragments/buyersguide/research_details.html" with review_date=product.review_date time_researched=product.time_researched mozilla_says=product.mozilla_says %}
-        <div class="col-12 tw-body">{{product.blurb | richtext}}</div>
-      </div>
-
-      <div class="row mb-4">
-        <div class="col-12 worst-case">
-          <h2 class="tw-h3-heading">{% trans "What could happen if something goes wrong?" %}</h2>
-          <div class="tw-body">{{product.worst_case | richtext}}</div>
-        </div>
-      </div>
-
-      {% if product.tips_to_protect_yourself %}
-      <div class="row tw-my-5 tips-to-protect-yourself">
-        <div class="col-12 tw-py-5 tips">
-          <h2 class="tw-h3-heading">{% trans "Tips to protect yourself" %}</h2>
-          {{ product.tips_to_protect_yourself | richtext }}
-        </div>
-      </div>
-      {% endif %}
-
-
-      <div id="product-research" data-is-wagtail-page="true">
-      <div id="creepiness-vote">
-        <div class="row">
-          <div class="col-12">
-            <div class="creep-vote-target mb-5 mt-3 mt-md-4 p-5" data-product-name="{{product.title}}" data-product-type="{{product.product_type}}">
-              <input type="hidden" name="productID" value="{{ product.id }}">
-              <input type="hidden" name="votes" value='{{ product.get_voting_json | safe }}'>
-            </div>
-        </div>
-      </div>
-
-        {% include "fragments/buyersguide/product_tab.html" with  product=product %}
-
-        {% if product.updates.count > 0 %}
-        <hr class="pni-section-divider"/>
-        <h3 id="news" class="tw-h2-heading mb-3">{% trans "News" %}</h3>
-          <div class="mb-5">
-            {% for item in product.updates.all %}
-            {% with update=item.update %}
-              <div class="product-update mb-4">
-                <a class="product-update-link tw-h5-heading title" href="{{update.source}}" target="_blank">{{update.title}}</a>
-                <div class="author">{{update.author}}</div>
-                <div class="snippet">{{update.snippet}}</div>
-              </div>
-            {% endwith %}
-            {% endfor %}
-          </div>
-          {% endif %}
-        </div>
-
-        <hr class="pni-section-divider"/>
-
-        <div class="tw-w-full">
-          <h3 class="tw-h2-heading mb-4">{% trans "Related products" %}</h3>
-          <div class="row">
-            {% for related_product_page in product.related_product_pages.all %}
-            {% with related_product=related_product_page.related_product.localized %}
-            <div class="related-product col-6 col-md-3 mb-3 mb-md-0">
-              <a class="d-block{% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url %}">
-                <div class="img-container">
-                  {% image related_product.image width-600 as img %}
-                  <img
-                    class="product-thumbnail"
-                    width="600"
-                    loading="lazy"
-                    src="{{img.url}}"
-                    alt="{{related_product.title}}"
-                  >
-                </div>
-                <p class="tw-body-small mt-3 mb-1">{{related_product.company}}</p>
-                <p>{{related_product.title}}</p>
-              </a>
-
-              {% include "fragments/buyersguide/privacy_ding.html" with product=related_product %}
-              {% include "fragments/buyersguide/adult_content_badge.html" with product=related_product %}
-            </div>
-            {% endwith %}
-            {% endfor %}
-          </div>
-        </div>
-
-
-
-
-      </div>
-    </div>
-  </div>
-</div>
-
-{% with secondary_related_articles=product.get_secondary_related_articles  %}
-  {% if secondary_related_articles %}
-    <div class="tw-container tw-grid medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
-      <div class="tw-col-span-full medium:tw-col-span-1">
-        Dive deeper
-      </div>
-      <div class="tw-col-span-full medium:tw-col-start-2 medium:tw-col-span-1 large:tw-col-span-2">
-        {% include "fragments/buyersguide/article_listing_what_to_read_next.html" with articles=secondary_related_articles index_page=home_page.get_editorial_content_index use_wide_above="large" wide_columns_above_large=2  %}
-      </div>
-    </div>
-  {% endif %}
-{% endwith %}
-
-{% if use_commento %}
-
-<div class="container-fluid position-relative comment-section">
-  <div class="row dotted-section d-block d-sm-flex mx-0 mt-5">
-    <div class="tw-container tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6 tw-z-10 position-relative">
-      <div class="{{section_class}}">
-        <div class="mt-3 pt-3 bg-white tw-px-4 medium:tw-px-6">
-
-        <h3 class="tw-h2-heading">{% trans "Comments" %}</h3>
-        <p class="mb-4">{% trans "Got a comment? Let us hear it." %}</p>
-        <div id="commento"></div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-{% endif %}
-
-{% endwith %}
+  {% endwith %}
 {% endblock %}
 
 {% block extra_scripts %}

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -44,8 +44,6 @@
         <div class="tw-max-w-[410px] tw-mb-5">
           {% include "fragments/buyersguide/dive_deeper.html" with updates=product.updates.all %}
         </div>
-
-
       </div>
     {% endif %}
   {% endwith %}
@@ -55,7 +53,6 @@
       {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
     {% endif %}
   {% endwith %}
-
 
   <div class="text-center product-header bg-product-image{% if product.draft %} draft-product{% endif %}">
     <div class="tw-container tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6">
@@ -128,7 +125,6 @@
             </div>
           {% endif %}
 
-
           <div id="product-research" data-is-wagtail-page="true">
             <div id="creepiness-vote">
               <div class="row">
@@ -190,9 +186,6 @@
               </div>
             </div>
 
-
-
-
           </div>
         </div>
       </div>
@@ -212,13 +205,11 @@
     {% endwith %}
 
     {% if use_commento %}
-
       <div class="container-fluid position-relative comment-section">
         <div class="row dotted-section d-block d-sm-flex mx-0 mt-5">
           <div class="tw-container tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6 tw-z-10 position-relative">
             <div class="{{section_class}}">
               <div class="mt-3 pt-3 bg-white tw-px-4 medium:tw-px-6">
-
                 <h3 class="tw-h2-heading">{% trans "Comments" %}</h3>
                 <p class="mb-4">{% trans "Got a comment? Let us hear it." %}</p>
                 <div id="commento"></div>

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -101,6 +101,7 @@
             <aside class="
               2xl:tw-absolute
               tw-mt-6 2xl:tw-mt-0
+              tw-mb-2
               tw-px-4
               tw-w-full 2xl:tw-w-[320px]
               2xl:tw-left-full


### PR DESCRIPTION
# Description

This PR positions the call to action box and the related articles on the product page according to [the design](https://www.figma.com/file/GwdoUiY4fzVyeLfXsAJGPq/*Privacy-Not-Included-Website?node-id=2573%3A15226). 

The components where already included in the page but not in the correct layout location. 

Link to sample test page: http://localhost:8000/en/privacynotincluded/general-percy-product/
Related PRs/issues: #9094

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests? Kind of, though the visual regression tests.

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
