### PR TITLE
 9411 - Localized URLs in slider component

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/common/link_blocks.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/common/link_blocks.py
@@ -9,7 +9,7 @@ from wagtail.documents.blocks import DocumentChooserBlock
 class InternalLinkBlockStructValue(blocks.StructValue):
     @property
     def link_url(self):
-        return self.get('link').url
+        return self.get('link').localized.url
 
 
 class ExternalLinkBlockStructValue(blocks.StructValue):
@@ -21,7 +21,7 @@ class ExternalLinkBlockStructValue(blocks.StructValue):
 class DocumentLinkBlockStructValue(blocks.StructValue):
     @property
     def link_url(self):
-        return self.get('document').url
+        return self.get('document').localized.url
 
 
 class InternalLinkBlock(blocks.StructBlock):


### PR DESCRIPTION
Fixes #9411

Easier way to test is with the prod DB, and checking on http://mozfest.localhost:8000/fr/ the localized links in the slider:

<img width="603" alt="Capture d’écran 2022-09-21 à 18 03 36" src="https://user-images.githubusercontent.com/1294206/191554484-22b0cb67-e6a2-4d3f-bab9-ed7dc2040447.png">

Alternatively with the test DB, localizing the MozFest homepage in French should do it