### PR TITLE
Maintain: Run CI on push to PNI branch

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "pni-2022"]
     paths-ignore:
       - maintenance/**/*.*
   pull_request:


### PR DESCRIPTION
# Description

I thought we had this configured already, but apparently not. This PR activated the CI workflow when ever we push/merge into the `pni-2022` branch. We can remove this after the integration branch is merged into `main`. Until then, we want this so we can check that CI is passing before we deploy the PNI branch to the preview app. 

Link to sample test page:
Related PRs/issues: Dev only. No ticket.

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
