### PR TITLE
9169 Fix overflow on product page

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -207,7 +207,7 @@
 
     {% with secondary_related_articles=product.get_secondary_related_articles  %}
       {% if secondary_related_articles %}
-        <div class="tw-container tw-grid medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
+        <div class="tw-container tw-grid tw-grid-cols-1 medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
           <div class="tw-col-span-full medium:tw-col-span-1">
             Dive deeper
           </div>


### PR DESCRIPTION
# Description

Another QA follow up. I caught this one myself on the preview app: https://github.com/mozilla/foundation.mozilla.org/issues/9169#issuecomment-1255468424

Before, the template columns for mobile where not defined. This led to the compact article listing bleeding out of the parent.

That should now be fixed.

Link to sample test page: http://localhost:8000/en/privacynotincluded/general-percy-product/
Related PRs/issues: #9196

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
