### PR TITLE
9097 Product page editorial content

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/article_listing_compact.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/article_listing_compact.html
@@ -9,7 +9,7 @@
     {% include "./wavy_line.html" %}
   {% endif %}
 
-  <h2 class="tw-font-zilla tw-font-normal tw-text-2xl tw-text-black tw-mt-2 tw-mb-[20px]">{{ heading }}</h2>
+  <h2 class="tw-h3-heading tw-mt-2">{{ heading }}</h2>
 
   {% if articles %}
     <ul class="tw-list-none {% if show_images %} tw-space-y-4 {% else %} tw-space-y-5 {% endif %} tw-p-0">

--- a/network-api/networkapi/templates/fragments/buyersguide/article_listing_wide.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/article_listing_wide.html
@@ -2,7 +2,7 @@
 
 <div class="tw-grid tw-grid-cols-2 {% if columns_above_large == 3 %} large:tw-grid-cols-3 {% endif %} tw-gap-6">
   <div class="tw-col-span-full tw-flex tw-flex-row tw-justify-between tw-items-baseline tw-gap-5">
-    <div class="tw-h4-heading tw-m-0 tw-whitespace-nowrap">
+    <div class="tw-h3-heading tw-m-0 tw-whitespace-nowrap">
       {{ heading }}
     </div>
 

--- a/network-api/networkapi/templates/fragments/buyersguide/dive_deeper.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/dive_deeper.html
@@ -2,7 +2,7 @@
 
 <div id="dive-deeper">
     {% include "./wavy_line.html" %}
-    <h2 class="tw-font-zilla tw-font-normal tw-text-2xl tw-text-black tw-mt-2 tw-mb-[20px]">{% trans "Dive Deeper" %}</h2>
+    <h2 class="tw-h3-heading tw-mt-2">{% trans "Dive Deeper" %}</h2>
 
     <ul class="tw-list-none tw-space-y-4 tw-p-0">
         {% for item in updates %}

--- a/network-api/networkapi/templates/fragments/buyersguide/related_product.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/related_product.html
@@ -2,7 +2,7 @@
 
 <div class="related-product">
   <a class="tw-block {% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url %}">
-    <div class="img-container">
+    <div class="img-container tw-p-5">
       {% image related_product.image width-600 as img %}
       <img
         class="product-thumbnail"

--- a/network-api/networkapi/templates/fragments/buyersguide/related_product.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/related_product.html
@@ -8,12 +8,12 @@
         class="product-thumbnail"
         width="600"
         loading="lazy"
-        src="{{img.url}}"
+        src="{{ img.url }}"
         alt=""
         >
     </div>
-    <p class="tw-body-small mt-3 mb-1">{{related_product.company}}</p>
-    <p>{{related_product.title}}</p>
+    <p class="tw-body-small mt-3 mb-1">{{ related_product.company }}</p>
+    <p>{{ related_product.title }}</p>
   </a>
 
   {% include "fragments/buyersguide/privacy_ding.html" with product=related_product %}

--- a/network-api/networkapi/templates/fragments/buyersguide/related_product.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/related_product.html
@@ -1,7 +1,7 @@
 {% load localization wagtailimages_tags%}
 
-<div class="related-product col-6 col-md-3 mb-3 mb-md-0">
-  <a class="d-block{% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url %}">
+<div class="related-product">
+  <a class="tw-block {% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url %}">
     <div class="img-container">
       {% image related_product.image width-600 as img %}
       <img

--- a/network-api/networkapi/templates/fragments/buyersguide/related_product.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/related_product.html
@@ -1,0 +1,21 @@
+{% load localization wagtailimages_tags%}
+
+<div class="related-product col-6 col-md-3 mb-3 mb-md-0">
+  <a class="d-block{% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url %}">
+    <div class="img-container">
+      {% image related_product.image width-600 as img %}
+      <img
+        class="product-thumbnail"
+        width="600"
+        loading="lazy"
+        src="{{img.url}}"
+        alt="{{related_product.title}}"
+        >
+    </div>
+    <p class="tw-body-small mt-3 mb-1">{{related_product.company}}</p>
+    <p>{{related_product.title}}</p>
+  </a>
+
+  {% include "fragments/buyersguide/privacy_ding.html" with product=related_product %}
+  {% include "fragments/buyersguide/adult_content_badge.html" with product=related_product %}
+</div>

--- a/network-api/networkapi/templates/fragments/buyersguide/related_product.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/related_product.html
@@ -9,7 +9,7 @@
         width="600"
         loading="lazy"
         src="{{img.url}}"
-        alt="{{related_product.title}}"
+        alt=""
         >
     </div>
     <p class="tw-body-small mt-3 mb-1">{{related_product.company}}</p>

--- a/network-api/networkapi/templates/fragments/buyersguide/wavy_line.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/wavy_line.html
@@ -1,5 +1,5 @@
 {% load static %}
 
 <div class="tw-overflow-x-hidden tw-flex">
-  <img src="{% static "_images/buyers-guide/very-long-wavy-border.svg" %}" class="tw-max-w-fit" />
+  <img src="{% static "_images/buyers-guide/very-long-wavy-border.svg" %}" class="tw-max-w-fit" alt="" />
 </div>

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -197,25 +197,25 @@
       </div>
     </div>
 
-    {% with secondary_related_articles=product.get_secondary_related_articles  %}
-      {% if secondary_related_articles %}
-        <div class="tw-container tw-grid tw-grid-cols-1 medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
+    <div class="tw-container tw-grid tw-grid-cols-1 medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
+      {% with product_updates=product.updates.all  %}
+        {% if product_updates %}
           <div class="tw-col-span-full medium:tw-col-span-1">
-            {% with product_updates=product.updates.all  %}
-              {% if product_updates %}
-                <div class="tw-max-w-[410px] tw-mb-5">
-                  {% include "fragments/buyersguide/dive_deeper.html" with updates=product_updates %}
-                </div>
-              {% endif %}
-            {% endwith %}
+            <div class="tw-max-w-[410px] tw-mb-5">
+              {% include "fragments/buyersguide/dive_deeper.html" with updates=product_updates %}
+            </div>
           </div>
+        {% endif %}
+      {% endwith %}
 
-          <div class="tw-col-span-full medium:tw-col-start-2 medium:tw-col-span-1 large:tw-col-span-2">
+      {% with secondary_related_articles=product.get_secondary_related_articles  %}
+        {% if secondary_related_articles %}
+          <div class="tw-col-span-full medium:tw-col-span-1 large:tw-col-span-2">
             {% include "fragments/buyersguide/article_listing_what_to_read_next.html" with articles=secondary_related_articles index_page=home_page.get_editorial_content_index use_wide_above="large" wide_columns_above_large=2  %}
           </div>
-        </div>
-      {% endif %}
-    {% endwith %}
+        {% endif %}
+      {% endwith %}
+    </div>
 
     {% if use_commento %}
       <div class="container-fluid position-relative comment-section">

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -187,8 +187,10 @@
       {% with related_products=product.related_product_pages.all %}
         {% if related_products %}
           <div class="tw-col-span-full medium:tw-col-span-2 large:tw-col-start-2">
-            {% include "fragments/buyersguide/wavy_line.html" %}
-            <h2 class="tw-h3-heading tw-mt-2">{% trans "Related products" %}</h2>
+            <div class="tw-flex tw-flex-col medium:tw-flex-row-reverse medium:tw-gap-5">
+              {% include "fragments/buyersguide/wavy_line.html" %}
+              <h2 class="tw-h3-heading tw-mt-2 tw-shrink-0">{% trans "Related products" %}</h2>
+            </div>
             <div class="tw-grid tw-grid-cols-2 medium:tw-grid-cols-4 tw-gap-6">
               {% for related_product_page in related_products  %}
                 {% include "fragments/buyersguide/related_product.html" with related_product=related_product_page.related_product.localized %}

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -160,20 +160,6 @@
                 </div>
               {% endif %}
             </div>
-
-            <hr class="pni-section-divider"/>
-
-            <div class="tw-w-full">
-              <h3 class="tw-h2-heading mb-4">{% trans "Related products" %}</h3>
-              <div class="row">
-                {% for related_product_page in product.related_product_pages.all %}
-                  {% with related_product=related_product_page.related_product.localized %}
-                    {% include "fragments/buyersguide/related_product.html" with related_product=related_product %}
-                  {% endwith %}
-                {% endfor %}
-              </div>
-            </div>
-
           </div>
         </div>
       </div>
@@ -197,6 +183,17 @@
           </div>
         {% endif %}
       {% endwith %}
+
+      <div>
+        <h3 class="tw-h2-heading mb-4">{% trans "Related products" %}</h3>
+        <div>
+          {% for related_product_page in product.related_product_pages.all %}
+            {% with related_product=related_product_page.related_product.localized %}
+              {% include "fragments/buyersguide/related_product.html" with related_product=related_product %}
+            {% endwith %}
+          {% endfor %}
+        </div>
+      </div>
     </div>
 
     {% if use_commento %}

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -144,21 +144,6 @@
 
               {% include "fragments/buyersguide/product_tab.html" with  product=product %}
 
-              {% if product.updates.count > 0 %}
-                <hr class="pni-section-divider"/>
-                <h3 id="news" class="tw-h2-heading mb-3">{% trans "News" %}</h3>
-                <div class="mb-5">
-                  {% for item in product.updates.all %}
-                    {% with update=item.update %}
-                      <div class="product-update mb-4">
-                        <a class="product-update-link tw-h5-heading title" href="{{update.source}}" target="_blank">{{update.title}}</a>
-                        <div class="author">{{update.author}}</div>
-                        <div class="snippet">{{update.snippet}}</div>
-                      </div>
-                    {% endwith %}
-                  {% endfor %}
-                </div>
-              {% endif %}
             </div>
           </div>
         </div>

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -168,25 +168,7 @@
               <div class="row">
                 {% for related_product_page in product.related_product_pages.all %}
                   {% with related_product=related_product_page.related_product.localized %}
-                    <div class="related-product col-6 col-md-3 mb-3 mb-md-0">
-                      <a class="d-block{% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url %}">
-                        <div class="img-container">
-                          {% image related_product.image width-600 as img %}
-                          <img
-                            class="product-thumbnail"
-                            width="600"
-                            loading="lazy"
-                            src="{{img.url}}"
-                            alt="{{related_product.title}}"
-                            >
-                        </div>
-                        <p class="tw-body-small mt-3 mb-1">{{related_product.company}}</p>
-                        <p>{{related_product.title}}</p>
-                      </a>
-
-                      {% include "fragments/buyersguide/privacy_ding.html" with product=related_product %}
-                      {% include "fragments/buyersguide/adult_content_badge.html" with product=related_product %}
-                    </div>
+                    {% include "fragments/buyersguide/related_product.html" with related_product=related_product %}
                   {% endwith %}
                 {% endfor %}
               </div>

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -143,9 +143,10 @@
               </div>
 
               {% include "fragments/buyersguide/product_tab.html" with  product=product %}
-
             </div>
           </div>
+
+          {% include "fragments/buyersguide/pni_newsletter_box.html" %}
         </div>
       </div>
     </div>

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -187,7 +187,8 @@
       {% with related_products=product.related_product_pages.all %}
         {% if related_products %}
           <div class="tw-col-span-full medium:tw-col-span-2 large:tw-col-start-2">
-            <h3 class="tw-h2-heading mb-4">{% trans "Related products" %}</h3>
+            {% include "fragments/buyersguide/wavy_line.html" %}
+            <h2 class="tw-h3-heading tw-mt-2">{% trans "Related products" %}</h2>
             <div class="tw-grid tw-grid-cols-2 medium:tw-grid-cols-4 tw-gap-6">
               {% for related_product_page in related_products  %}
                 {% include "fragments/buyersguide/related_product.html" with related_product=related_product_page.related_product.localized %}

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -30,14 +30,6 @@
 
   {% get_bg_home_page as home_page %}
 
-  {% with product_updates=product.updates.all  %}
-    {% if product_updates %}
-      <div class="tw-max-w-[410px] tw-mb-5">
-        {% include "fragments/buyersguide/dive_deeper.html" with updates=product_updates %}
-      </div>
-    {% endif %}
-  {% endwith %}
-
   <div class="text-center product-header bg-product-image{% if product.draft %} draft-product{% endif %}">
     <div class="tw-container tw-block medium:tw-grid tw-grid-cols-12 tw-gap-x-6">
       <div class="tw-col-start-3 tw-col-end-11 tw--mx-4 medium:tw--mx-6">
@@ -209,8 +201,15 @@
       {% if secondary_related_articles %}
         <div class="tw-container tw-grid tw-grid-cols-1 medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
           <div class="tw-col-span-full medium:tw-col-span-1">
-            Dive deeper
+            {% with product_updates=product.updates.all  %}
+              {% if product_updates %}
+                <div class="tw-max-w-[410px] tw-mb-5">
+                  {% include "fragments/buyersguide/dive_deeper.html" with updates=product_updates %}
+                </div>
+              {% endif %}
+            {% endwith %}
           </div>
+
           <div class="tw-col-span-full medium:tw-col-start-2 medium:tw-col-span-1 large:tw-col-span-2">
             {% include "fragments/buyersguide/article_listing_what_to_read_next.html" with articles=secondary_related_articles index_page=home_page.get_editorial_content_index use_wide_above="large" wide_columns_above_large=2  %}
           </div>

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -184,16 +184,18 @@
         {% endif %}
       {% endwith %}
 
-      <div>
-        <h3 class="tw-h2-heading mb-4">{% trans "Related products" %}</h3>
-        <div>
-          {% for related_product_page in product.related_product_pages.all %}
-            {% with related_product=related_product_page.related_product.localized %}
-              {% include "fragments/buyersguide/related_product.html" with related_product=related_product %}
-            {% endwith %}
-          {% endfor %}
-        </div>
-      </div>
+      {% with related_products=product.related_product_pages.all %}
+        {% if related_products %}
+          <div class="tw-col-span-full medium:tw-col-span-2 large:tw-col-start-2">
+            <h3 class="tw-h2-heading mb-4">{% trans "Related products" %}</h3>
+            <div class="tw-grid tw-grid-cols-2 medium:tw-grid-cols-4 tw-gap-6">
+              {% for related_product_page in related_products  %}
+                {% include "fragments/buyersguide/related_product.html" with related_product=related_product_page.related_product.localized %}
+              {% endfor %}
+            </div>
+          </div>
+        {% endif %}
+      {% endwith %}
     </div>
 
     {% if use_commento %}

--- a/source/sass/buyers-guide/views/product.scss
+++ b/source/sass/buyers-guide/views/product.scss
@@ -97,16 +97,18 @@
 }
 
 .related-product {
+  position: relative;
+
   .img-container {
     background: $gray-05;
   }
 
   .privacy-ding {
-    @include privacy-ding(5px, 20px, 25px, 25px);
+    @include privacy-ding(12px, 20px, 25px, 25px);
   }
 
   .adult-content-badge {
-    @include adult-content-badge(5px, 20px, 33px, 28px);
+    @include adult-content-badge(12px, 12px, 33px, 28px);
   }
 }
 


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

This PR adds the relation and links sections to the bottom of the product page. This was mostly achieved by fitting previously created components into a new layout. 

I did have to adjust the styling of the related products section though, because no component for this was created before hand. 

Link to sample test page: http://localhost:8000/en/privacynotincluded/general-percy-product/
Related PRs/issues: #9097 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~ 

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
