### PR TITLE
9099 newsletter in product grid

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/item.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/item.html
@@ -7,7 +7,6 @@
     tw-flex-col
     tw-justify-between
     tw-m-0
-    tw-w-[var(--item-width)]
 
     {# We need to unset the order rule at the next breakpoint, because the nth-child pseudo-class changes. #}
     tw-order-none

--- a/network-api/networkapi/templates/fragments/buyersguide/item.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/item.html
@@ -6,10 +6,18 @@
     {% if matched == False %}d-none{% else %}d-flex{% endif %}
     tw-flex-col
     tw-justify-between
+    tw-m-0
+    tw-w-[var(--item-width)]
+
+    {# We need to unset the order rule at the next breakpoint, because the nth-child pseudo-class changes. #}
+    tw-order-0
+    [&:nth-child(n+10)]:tw-order-2 medium:[&:nth-child(n+10)]:tw-order-[unset]
+    medium:[&:nth-child(n+9)]:tw-order-2 large:[&:nth-child(n+9)]:tw-order-[unset]
+    large:[&:nth-child(n+12)]:tw-order-2
+
     {% if product.draft %}draft-product{% endif %}
     {% if product.adult_content %}adult-content{% endif %}
     {% if product.privacy_ding %}privacy-ding{% endif%}
-    tw-m-0
   "
   data-creepiness="{{ product.creepiness|unlocalize }}"
 >

--- a/network-api/networkapi/templates/fragments/buyersguide/item.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/item.html
@@ -1,8 +1,18 @@
 {% load static i18n wagtailimages_tags l10n localization %}
 
 <figure
-  class="product-box {% if matched == False %}d-none{% else %}d-flex{% endif %}  flex-column justify-content-between{% if product.draft %} draft-product{% endif %}{% if product.adult_content %} adult-content{% endif %}{% if product.privacy_ding %} privacy-ding{% endif%}"
-  data-creepiness="{{ product.creepiness|unlocalize }}">
+  class="
+    product-box
+    {% if matched == False %}d-none{% else %}d-flex{% endif %}
+    tw-flex-col
+    tw-justify-between
+    {% if product.draft %}draft-product{% endif %}
+    {% if product.adult_content %}adult-content{% endif %}
+    {% if product.privacy_ding %}privacy-ding{% endif%}
+    tw-m-0
+  "
+  data-creepiness="{{ product.creepiness|unlocalize }}"
+>
   <div class="top-left-badge-container">
       {% if product.privacy_ding %}
       <img

--- a/network-api/networkapi/templates/fragments/buyersguide/item.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/item.html
@@ -10,7 +10,7 @@
     tw-w-[var(--item-width)]
 
     {# We need to unset the order rule at the next breakpoint, because the nth-child pseudo-class changes. #}
-    tw-order-0
+    tw-order-none
     [&:nth-child(n+10)]:tw-order-2 medium:[&:nth-child(n+10)]:tw-order-[unset]
     medium:[&:nth-child(n+9)]:tw-order-2 large:[&:nth-child(n+9)]:tw-order-[unset]
     large:[&:nth-child(n+12)]:tw-order-2

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_newsletter_box.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_newsletter_box.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags i18n static %}
 
-<div class="tw-relative tw-mt-3 tw-mb-7 tw-py-5 tw-px-5 tw-rounded-lg medium:tw-px-7 medium:tw-py-6 tw-bg-gradient-to-r tw-from-purple-05 tw-to-blue-05">
+<div class="tw-relative tw-py-5 tw-px-5 tw-rounded-lg medium:tw-px-7 medium:tw-py-6 tw-bg-gradient-to-r tw-from-purple-05 tw-to-blue-05">
     <img
   class="tw-absolute tw-right-0 tw-top-0 tw-hidden large:tw-block"
   src="{% static "_images/buyers-guide/asterick.svg" %}"
@@ -15,4 +15,4 @@
       data-cta-description="<p class='tw-mb-5'>{% trans "Join our Mozilla News email list to get action alerts & internet tips right to your inbox." %}</p>"
     >
     </div>
-</div>   
+</div>

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -92,17 +92,7 @@
         tw-gap-[2px]
         tw-grid-flow-row-dense
       ">
-        <div class="
-          tw-col-span-2
-          tw-col-end-5
-          tw-order-1
-
-          tw-flex
-          tw-items-stretch
-          tw-bg-blue-05
-        ">
-          <div class="tw-h-[200px]"></div>
-        </div>
+        {% block extra_product_box_list_items %}{% endblock extra_product_box_list_items %}
 
         {% if request.user.is_anonymous %}
           {# User is not logged in. Return cached results. 24 hour caching applied. #}

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -94,7 +94,7 @@
         tw-justify-center
         tw-items-stretch
         tw-flex-wrap
-        [--gap-width:1px]
+        [--gap-width:2px]
         [--col-count:2] medium:[--col-count:3] large:[--col-count:4]
         [--item-width:calc((100%_+_var(--gap-width))/var(--col-count)_-_var(--gap-width))]
         tw-gap-[var(--gap-width)]
@@ -111,19 +111,7 @@
 
         {% for product in products %}
           {% product_in_category product category as matched %}
-          <div class="
-            tw-w-[var(--item-width)]
-            tw-flex
-            tw-items-stretch
-
-            {# We need to unset the order rule at the next breakpoint, because the nth-child pseudo-class changes. #}
-            tw-order-0
-            [&:nth-child(n+10)]:tw-order-2 medium:[&:nth-child(n+10)]:tw-order-[unset]
-            medium:[&:nth-child(n+9)]:tw-order-2 large:[&:nth-child(n+9)]:tw-order-[unset]
-            large:[&:nth-child(n+12)]:tw-order-2
-          ">
-            {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
-          </div>
+          {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
         {% endfor %}
 
         {% comment %}

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -83,10 +83,25 @@
     </div>
 
     <div class="product-box-list-wrapper">
-      <div class="product-box-list tw-overflow-hidden tw-flex tw-justify-center tw-items-stretch tw-flex-wrap">
-        <figure class="product-box tw-opacity-1">
+      <div class="product-box-list tw-overflow-hidden tw-flex tw-justify-center tw-items-stretch tw-flex-wrap tw-gap-px">
+        {% comment %}
+
+        <figure class="product-box tw-opacity-100">
           <figcaption>TEST</figcaption>
         </figure>
+        {% endcomment %}
+        {% for product in products %}
+          {% product_in_category product category as matched %}
+          <div class="
+            tw-w-[calc(100%/4-(1px*(4-1)))]
+            tw-flex
+            tw-items-stretch
+          ">
+            {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
+          </div>
+        {% endfor %}
+
+        {% comment %}
         {% if request.user.is_anonymous %}
           {# User is not logged in. Return cached results. 24 hour caching applied. #}
           {% cache 86400 pni_home_page template_cache_key_fragment %}
@@ -102,6 +117,7 @@
             {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
           {% endfor %}
         {% endif %}
+        {% endcomment %}
       </div>
 
       <div id="product-filter-no-results-notice" class="d-none text-center my-5 py-5">

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -82,28 +82,23 @@
       </div>
     </div>
 
-    {% comment %}
-      Full width = (column count * item width) + (column count - 1) * gap width
-      -> Item with = (Full width + gap width)/column count - gap width
-    {% endcomment %}
     <div class="product-box-list-wrapper">
       <div class="
         product-box-list
         tw-overflow-hidden
-        tw-flex
-        tw-justify-center
-        tw-items-stretch
-        tw-flex-wrap
-        [--gap-width:2px]
-        [--col-count:2] medium:[--col-count:3] large:[--col-count:4]
-        [--item-width:calc((100%_+_var(--gap-width))/var(--col-count)_-_var(--gap-width))]
-        tw-gap-[var(--gap-width)]
+
+        tw-grid
+        tw-grid-cols-4
+        tw-gap-[2px]
+        tw-grid-flow-row-dense
       ">
         <div class="
-          tw-w-[calc(var(--item-width)*2_+_var(--gap-width))]
+          tw-col-span-2
+          tw-col-end-5
+          tw-order-1
+
           tw-flex
           tw-items-stretch
-          tw-order-1
           tw-bg-blue-05
         ">
           <div class="tw-h-[200px]"></div>

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -13,7 +13,6 @@
     <div class="tw-row">
       <div class="tw-px-4 tw-w-full">
         <div id="sticky-bar" class="creepiness-slider bg-white text-center tw-flex tw-justify-center">
-
           <div class="creep-o-meter-information">
             <p class="speech-bubble-container">
               <span class="speech-bubble tw-bg-gradient-to-t tw-from-purple-05 tw-to-blue-05">
@@ -23,8 +22,6 @@
             </p>
             <span class="current-creepiness"></span>
           </div>
-
-
         </div>
       </div>
     </div>
@@ -51,12 +48,10 @@
                 {% trans "All" %}
               {% endif %}
             </a>
-
-
           </div>
-
         </div>
       </div>
+
       <div class="row px-0 tw-mb-6 medium:tw-mb-4">
         <div class="tw-w-[98vw] tw-relative tw-left-1/2 tw-ml-[-51vw] large:tw-left-auto large:tw-ml-0 large:tw-static large:tw-w-full">
           <div class="tw-px-4 large:tw-px-0 tw-flex tw-space-x-2 tw-overflow-auto tw-pb-2 tw-no-scrollbar tw-touch-pan-x subcategory-header">
@@ -113,6 +108,7 @@
       </div>
     </div>
   </div>
+
   <div class="recommend-product">
     <div class="container text-center my-5">
       <h2 class="tw-h3-heading">{% trans "Don’t see the product you’re looking for?" %}</h2>

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -103,6 +103,7 @@
           tw-w-[calc(var(--item-width)*2_+_var(--gap-width))]
           tw-flex
           tw-items-stretch
+          tw-order-1
           tw-bg-blue-05
         ">
           <div class="tw-h-[200px]"></div>
@@ -114,6 +115,12 @@
             tw-w-[var(--item-width)]
             tw-flex
             tw-items-stretch
+
+            {# We need to unset the order rule at the next breakpoint, because the nth-child pseudo-class changes. #}
+            tw-order-0
+            [&:nth-child(n+10)]:tw-order-2 medium:[&:nth-child(n+10)]:tw-order-[unset]
+            medium:[&:nth-child(n+9)]:tw-order-2 large:[&:nth-child(n+9)]:tw-order-[unset]
+            large:[&:nth-child(n+12)]:tw-order-2
           ">
             {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
           </div>

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -83,7 +83,10 @@
     </div>
 
     <div class="product-box-list-wrapper">
-      <div class="product-box-list tw-overflow-hidden d-flex justify-content-center align-items-stretch flex-wrap">
+      <div class="product-box-list tw-overflow-hidden tw-flex tw-justify-center tw-items-stretch tw-flex-wrap">
+        <figure class="product-box tw-opacity-1">
+          <figcaption>TEST</figcaption>
+        </figure>
         {% if request.user.is_anonymous %}
           {# User is not logged in. Return cached results. 24 hour caching applied. #}
           {% cache 86400 pni_home_page template_cache_key_fragment %}

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -85,15 +85,21 @@
     <div class="product-box-list-wrapper">
       <div class="product-box-list tw-overflow-hidden tw-flex tw-justify-center tw-items-stretch tw-flex-wrap tw-gap-px">
         {% comment %}
-
-        <figure class="product-box tw-opacity-100">
-          <figcaption>TEST</figcaption>
-        </figure>
+          Full width = (n * item width) + (n - 1) * gap width
+          -> Item with = (Full width + gap width)/n - gap width
         {% endcomment %}
+        <div class="
+          tw-w-[calc(((100%_+_1px)/4_-_1px)*2_+_1px)]
+          tw-flex
+          tw-items-stretch
+          tw-bg-blue-05
+        ">
+        </div>
+
         {% for product in products %}
           {% product_in_category product category as matched %}
           <div class="
-            tw-w-[calc(100%/4-(1px*(4-1)))]
+            tw-w-[calc((100%_+_1px)/4_-_1px)]
             tw-flex
             tw-items-stretch
           ">

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -82,24 +82,36 @@
       </div>
     </div>
 
+    {% comment %}
+      Full width = (column count * item width) + (column count - 1) * gap width
+      -> Item with = (Full width + gap width)/column count - gap width
+    {% endcomment %}
     <div class="product-box-list-wrapper">
-      <div class="product-box-list tw-overflow-hidden tw-flex tw-justify-center tw-items-stretch tw-flex-wrap tw-gap-px">
-        {% comment %}
-          Full width = (n * item width) + (n - 1) * gap width
-          -> Item with = (Full width + gap width)/n - gap width
-        {% endcomment %}
+      <div class="
+        product-box-list
+        tw-overflow-hidden
+        tw-flex
+        tw-justify-center
+        tw-items-stretch
+        tw-flex-wrap
+        [--gap-width:1px]
+        [--col-count:2] medium:[--col-count:3] large:[--col-count:4]
+        [--item-width:calc((100%_+_var(--gap-width))/var(--col-count)_-_var(--gap-width))]
+        tw-gap-[var(--gap-width)]
+      ">
         <div class="
-          tw-w-[calc(((100%_+_1px)/4_-_1px)*2_+_1px)]
+          tw-w-[calc(var(--item-width)*2_+_var(--gap-width))]
           tw-flex
           tw-items-stretch
           tw-bg-blue-05
         ">
+          <div class="tw-h-[200px]"></div>
         </div>
 
         {% for product in products %}
           {% product_in_category product category as matched %}
           <div class="
-            tw-w-[calc((100%_+_1px)/4_-_1px)]
+            tw-w-[var(--item-width)]
             tw-flex
             tw-items-stretch
           ">

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -104,12 +104,6 @@
           <div class="tw-h-[200px]"></div>
         </div>
 
-        {% for product in products %}
-          {% product_in_category product category as matched %}
-          {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
-        {% endfor %}
-
-        {% comment %}
         {% if request.user.is_anonymous %}
           {# User is not logged in. Return cached results. 24 hour caching applied. #}
           {% cache 86400 pni_home_page template_cache_key_fragment %}
@@ -125,7 +119,6 @@
             {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
           {% endfor %}
         {% endif %}
-        {% endcomment %}
       </div>
 
       <div id="product-filter-no-results-notice" class="d-none text-center my-5 py-5">

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -7,12 +7,12 @@
 {% block main_content_class %}{% endblock %}
 
 {% block hero %}
-<input type="hidden" class="category-title" value="{% if current_category %}{{current_category.localized.name}}{% else %}None{% endif %}">
-<input type="hidden" class="parent-title" value="{{current_category.parent.localized.name}}">
-<div class="tw-container">
-  <div class="tw-row">
-    <div class="tw-px-4 tw-w-full">
-      <div id="sticky-bar" class="creepiness-slider bg-white text-center tw-flex tw-justify-center">
+  <input type="hidden" class="category-title" value="{% if current_category %}{{current_category.localized.name}}{% else %}None{% endif %}">
+  <input type="hidden" class="parent-title" value="{{current_category.parent.localized.name}}">
+  <div class="tw-container">
+    <div class="tw-row">
+      <div class="tw-px-4 tw-w-full">
+        <div id="sticky-bar" class="creepiness-slider bg-white text-center tw-flex tw-justify-center">
 
           <div class="creep-o-meter-information">
             <p class="speech-bubble-container">
@@ -26,108 +26,108 @@
 
 
         </div>
+      </div>
     </div>
   </div>
-</div>
 {% endblock %}
 
 {% block guts %}
-{% get_bg_home_page as home_page %}
-<div class="project-list-section">
-  <div class="container">
-    <div class="row">
-      <div class="col-12 tw-mb-4 tw-px-0">
-        <div class="tw-flex tw-items-end">
-          <a
-          href="{% if current_category.parent %}{% localizedroutablepageurl home_page 'category-view' current_category.parent.slug  %}{% elif current_category %}{% localizedroutablepageurl home_page 'category-view' current_category.slug  %}{% else %}{% relocalized_url home_page.localized.url %}{% endif %}"
-          data-name="{% if current_category.parent %}{{ current_category.parent.name }}{% elif current_category %}{{current_category.name}}{% else %}None{% endif %}"
-          class="tw-text-5xl tw-font-zilla category-header tw-text-black hover:tw-text-pni-blue tw-no-underline tw-cursor-pointer tw-hidden medium:tw-block"
-          >
-            {% if current_category.parent %}
-              {{current_category.parent.localized.name}}
-            {% elif current_category %}
-              {{current_category.localized.name}}
-            {% else %}
-              {% trans "All" %}
-            {% endif %}
-          </a>
-
-          
-        </div>
-
-      </div>
-    </div>
-    <div class="row px-0 tw-mb-6 medium:tw-mb-4">
-      <div class="tw-w-[98vw] tw-relative tw-left-1/2 tw-ml-[-51vw] large:tw-left-auto large:tw-ml-0 large:tw-static large:tw-w-full">
-        <div class="tw-px-4 large:tw-px-0 tw-flex tw-space-x-2 tw-overflow-auto tw-pb-2 tw-no-scrollbar tw-touch-pan-x subcategory-header">
-          
-          <span id="product-filter-pni" class="tw-flex tw-cursor-pointer tw-text-gray-60 border tw-border-gray-20 tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3] hover:tw-border-blue-10 hover:tw-bg-blue-10">
-            <input type="checkbox" id="product-filter-pni-toggle" autocomplete="off">
-            <span class="pni-icon tw-mr-1">&nbsp;</span>
-            <label for="product-filter-pni-toggle" class="tw-flex tw-m-0 tw-w-max">{% trans "Has privacy ding" %} </label>
-          </span>
-          
-          {% for cat in categories %}
-            {% with original=cat.original selected_classes="active tw-bg-gray-80 tw-text-white tw-border-gray-80" default_classes="hover:tw-border-blue-10 hover:tw-bg-blue-10 tw-text-gray-60 tw-border-gray-20 tw-bg-white" tailwind_classes="tw-no-underline border tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3] tw-whitespace-nowrap" %}
-            {% if cat.parent != None %}
-              {% if original.published_product_page_count > 0 %}
-                {% localizedroutablepageurl home_page 'category-view' original.slug as cat_url %}
-                <a class="{% if current_category.name != cat.parent.name and current_category.parent.name != cat.parent.name %} tw-hidden {% endif %} subcategories {{ tailwind_classes }} {% if current_category.name == cat.name %}{{ selected_classes }}{% else %}{{ default_classes }}{% endif %}"
-                   href="{{ cat_url }}"
-                   data-parent="{{ cat.parent.localized.name }}"
-                   data-name="{{ cat.name }}">
-                  {{ cat.name }}
-                </a>
+  {% get_bg_home_page as home_page %}
+  <div class="project-list-section">
+    <div class="container">
+      <div class="row">
+        <div class="col-12 tw-mb-4 tw-px-0">
+          <div class="tw-flex tw-items-end">
+            <a
+              href="{% if current_category.parent %}{% localizedroutablepageurl home_page 'category-view' current_category.parent.slug  %}{% elif current_category %}{% localizedroutablepageurl home_page 'category-view' current_category.slug  %}{% else %}{% relocalized_url home_page.localized.url %}{% endif %}"
+              data-name="{% if current_category.parent %}{{ current_category.parent.name }}{% elif current_category %}{{current_category.name}}{% else %}None{% endif %}"
+              class="tw-text-5xl tw-font-zilla category-header tw-text-black hover:tw-text-pni-blue tw-no-underline tw-cursor-pointer tw-hidden medium:tw-block"
+              >
+              {% if current_category.parent %}
+                {{current_category.parent.localized.name}}
+              {% elif current_category %}
+                {{current_category.localized.name}}
+              {% else %}
+                {% trans "All" %}
               {% endif %}
-            {% endif %}
-            {% endwith %}
-          {% endfor %}
+            </a>
+
+
+          </div>
+
+        </div>
+      </div>
+      <div class="row px-0 tw-mb-6 medium:tw-mb-4">
+        <div class="tw-w-[98vw] tw-relative tw-left-1/2 tw-ml-[-51vw] large:tw-left-auto large:tw-ml-0 large:tw-static large:tw-w-full">
+          <div class="tw-px-4 large:tw-px-0 tw-flex tw-space-x-2 tw-overflow-auto tw-pb-2 tw-no-scrollbar tw-touch-pan-x subcategory-header">
+
+            <span id="product-filter-pni" class="tw-flex tw-cursor-pointer tw-text-gray-60 border tw-border-gray-20 tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3] hover:tw-border-blue-10 hover:tw-bg-blue-10">
+              <input type="checkbox" id="product-filter-pni-toggle" autocomplete="off">
+              <span class="pni-icon tw-mr-1">&nbsp;</span>
+              <label for="product-filter-pni-toggle" class="tw-flex tw-m-0 tw-w-max">{% trans "Has privacy ding" %} </label>
+            </span>
+
+            {% for cat in categories %}
+              {% with original=cat.original selected_classes="active tw-bg-gray-80 tw-text-white tw-border-gray-80" default_classes="hover:tw-border-blue-10 hover:tw-bg-blue-10 tw-text-gray-60 tw-border-gray-20 tw-bg-white" tailwind_classes="tw-no-underline border tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3] tw-whitespace-nowrap" %}
+                {% if cat.parent != None %}
+                  {% if original.published_product_page_count > 0 %}
+                    {% localizedroutablepageurl home_page 'category-view' original.slug as cat_url %}
+                    <a class="{% if current_category.name != cat.parent.name and current_category.parent.name != cat.parent.name %} tw-hidden {% endif %} subcategories {{ tailwind_classes }} {% if current_category.name == cat.name %}{{ selected_classes }}{% else %}{{ default_classes }}{% endif %}"
+                       href="{{ cat_url }}"
+                       data-parent="{{ cat.parent.localized.name }}"
+                       data-name="{{ cat.name }}">
+                      {{ cat.name }}
+                    </a>
+                  {% endif %}
+                {% endif %}
+              {% endwith %}
+            {% endfor %}
+          </div>
         </div>
       </div>
     </div>
+
+    <div class="product-box-list-wrapper">
+      <div class="product-box-list tw-overflow-hidden d-flex justify-content-center align-items-stretch flex-wrap">
+        {% if request.user.is_anonymous %}
+          {# User is not logged in. Return cached results. 24 hour caching applied. #}
+          {% cache 86400 pni_home_page template_cache_key_fragment %}
+            {% for product in products %}
+              {% product_in_category product category as matched %}
+              {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
+            {% endfor %}
+          {% endcache %}
+        {% else %}
+          {# User is logged in. Don't cache their results so they can see live and draft products here. #}
+          {% for product in products %}
+            {% product_in_category product category as matched %}
+            {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
+          {% endfor %}
+        {% endif %}
+      </div>
+
+      <div id="product-filter-no-results-notice" class="d-none text-center my-5 py-5">
+        {% block no_products_found %}
+          {% include "fragments/buyersguide/no_search_results.html" %}
+        {% endblock %}
+      </div>
+    </div>
+  </div>
+  <div class="recommend-product">
+    <div class="container text-center my-5">
+      <h2 class="tw-h3-heading">{% trans "Don’t see the product you’re looking for?" %}</h2>
+      <p class="tw-body">{% trans "Let us know what product you would like reviewed in the guide." %}</p>
+      {% include "fragments/buyersguide/submit_a_product.html" %}
+    </div>
   </div>
 
-  <div class="product-box-list-wrapper">
-    <div class="product-box-list tw-overflow-hidden d-flex justify-content-center align-items-stretch flex-wrap">
-    {% if request.user.is_anonymous %}
-      {# User is not logged in. Return cached results. 24 hour caching applied. #}
-      {% cache 86400 pni_home_page template_cache_key_fragment %}
-        {% for product in products %}
-          {% product_in_category product category as matched %}
-          {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
-        {% endfor %}
-      {% endcache %}
-    {% else %}
-      {# User is logged in. Don't cache their results so they can see live and draft products here. #}
-      {% for product in products %}
-        {% product_in_category product category as matched %}
-        {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
-      {% endfor %}
-    {% endif %}
-    </div>
-
-    <div id="product-filter-no-results-notice" class="d-none text-center my-5 py-5">
-      {% block no_products_found %}
-        {% include "fragments/buyersguide/no_search_results.html" %}
-      {% endblock %}
-    </div>
-  </div>
-</div>
-<div class="recommend-product">
- <div class="container text-center my-5">
-  <h2 class="tw-h3-heading">{% trans "Don’t see the product you’re looking for?" %}</h2>
-  <p class="tw-body">{% trans "Let us know what product you would like reviewed in the guide." %}</p>
-  {% include "fragments/buyersguide/submit_a_product.html" %}
- </div>
-</div>
-
-<noscript>
+  <noscript>
     <style type="text/css">
-        tw-body.catalog figure.product-box {
-            opacity: 1 !important;
-        }
+      tw-body.catalog figure.product-box {
+        opacity: 1 !important;
+      }
     </style>
-</noscript>
+  </noscript>
 
-<script src="{% static "_js/bg-search.compiled.js" %}" async type="module"></script>
+  <script src="{% static "_js/bg-search.compiled.js" %}" async type="module"></script>
 {% endblock %}

--- a/network-api/networkapi/templates/pages/buyersguide/home.html
+++ b/network-api/networkapi/templates/pages/buyersguide/home.html
@@ -22,7 +22,7 @@
     <div class="tw-container tw-my-6">
       <div class="tw-row">
         {% with row_item_classes="tw-px-4 tw-w-full large:tw-w-1/3 tw-py-5 large:tw-py-0" %}
-        
+
           {% with popular_articles=page.get_featured_articles %}
             {% if popular_articles %}
               <div class="{{row_item_classes}}">
@@ -54,3 +54,17 @@
   </div>
 
 {% endblock hero %}
+
+{% block extra_product_box_list_items %}
+  <div class="
+    tw-col-span-2
+    tw-col-end-5
+    tw-order-1
+
+    tw-flex
+    tw-items-stretch
+    tw-bg-blue-05
+  ">
+    <div class="tw-h-[200px]"></div>
+  </div>
+{% endblock extra_product_box_list_items %}

--- a/network-api/networkapi/templates/pages/buyersguide/home.html
+++ b/network-api/networkapi/templates/pages/buyersguide/home.html
@@ -63,8 +63,7 @@
 
     tw-flex
     tw-items-stretch
-    tw-bg-blue-05
   ">
-    <div class="tw-h-[200px]"></div>
+    {% include "fragments/buyersguide/pni_newsletter_box.html" %}
   </div>
 {% endblock extra_product_box_list_items %}

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -151,7 +151,7 @@
       </div>
     </div>
 
-    <div class="tw-container tw-grid tw-grid-cols-1 medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
+    <div class="tw-container tw-mt-7 tw-grid tw-grid-cols-1 medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
       {% with product_updates=product.updates.all  %}
         {% if product_updates %}
           <div class="tw-col-span-full medium:tw-col-span-1">

--- a/source/sass/buyers-guide/views/catalog.scss
+++ b/source/sass/buyers-guide/views/catalog.scss
@@ -90,11 +90,7 @@ body {
 
         display: inline-block;
         position: relative;
-        // margin-left: $box-margin;
-        // margin-right: $box-margin;
-        // margin-bottom: $box-margin * 2;
         padding: $padding-y $padding-x;
-        // width: calc((100% - #{$row-total-gutter-width}) / #{$items-per-row});
         background: $pni-product-list-background;
 
         .privacy-ding {

--- a/source/sass/buyers-guide/views/catalog.scss
+++ b/source/sass/buyers-guide/views/catalog.scss
@@ -90,11 +90,11 @@ body {
 
         display: inline-block;
         position: relative;
-        margin-left: $box-margin;
-        margin-right: $box-margin;
-        margin-bottom: $box-margin * 2;
+        // margin-left: $box-margin;
+        // margin-right: $box-margin;
+        // margin-bottom: $box-margin * 2;
         padding: $padding-y $padding-x;
-        width: calc((100% - #{$row-total-gutter-width}) / #{$items-per-row});
+        // width: calc((100% - #{$row-total-gutter-width}) / #{$items-per-row});
         background: $pni-product-list-background;
 
         .privacy-ding {


### PR DESCRIPTION
# Description

This PR adds the newsletter component into the product grid. I was not able to keep the centering of the last row of cards and combine it with a sensible positioning of the newsletter box when the category filters on the homepage are used. As a compromise, I switched from flex to grid. This allows the newsletter box to stick to the right hand side of the grid when the category filters are applied. 

Also, I was not able to get a ordering in place in which more cards are placed above the newsletter signup when the category filters are applied. It appears like the `nth-...` selectors do not update if classes are toggled with CSS. 

Since I also had to fix some indenting in the `catalog.html` template, it might be easier to follow the changes in the commits. 

Link to sample test page: http://localhost:8000/en/privacynotincluded/
Related PRs/issues: #9099

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~ No. 

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
