### PR TITLE
9459 Bump Django from 3.2.13 to 3.2.16

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -30,7 +30,7 @@ cryptography==36.0.1
     #   -c requirements.txt
     #   pyopenssl
     #   urllib3
-django==3.2.13
+django==3.2.16
     # via
     #   -c requirements.txt
     #   django-debug-toolbar

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ basket-client
 beautifulsoup4
 boto3
 cached_property==1.5.2
-Django==3.2.13
+Django==3.2.16
 dj-database-url
 djangorestframework
 django-admin-sortable==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ deprecated==1.2.13
     # via redis
 dj-database-url==0.5.0
     # via -r requirements.in
-django==3.2.13
+django==3.2.16
     # via
     #   -r requirements.in
     #   django-admin-sortable


### PR DESCRIPTION
# Description

This is to patch the security issues fixed with this release. See also:
https://docs.djangoproject.com/en/dev/releases/3.2.16/

No functionality changes necessary. 

Link to sample test page:
Related PRs/issues: #9459 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
