### PR TITLE
updated default value for multipage nav from undefined to blank string

### DIFF
--- a/source/js/multipage-nav.js
+++ b/source/js/multipage-nav.js
@@ -9,7 +9,7 @@ export default () => {
   const multipageLinks = document.querySelectorAll(`#multipage-nav a`);
 
   if (targetNode && multipageLinks.length) {
-    let activeLinkLabel = "";
+    let activeLinkLabel = window.gettext("Navigate to...");
 
     let links = Array.from(multipageLinks).map((link) => {
       const [href, isActive] = [

--- a/source/js/multipage-nav.js
+++ b/source/js/multipage-nav.js
@@ -9,7 +9,7 @@ export default () => {
   const multipageLinks = document.querySelectorAll(`#multipage-nav a`);
 
   if (targetNode && multipageLinks.length) {
-    let activeLinkLabel;
+    let activeLinkLabel = "";
 
     let links = Array.from(multipageLinks).map((link) => {
       const [href, isActive] = [


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

In the JS code for the multipage nav, we define the variable `activeLinkLabel`, but do not assign it a value unless one of the options on the menu is the current page. This means for children banner pages, such as https://foundation.mozilla.org/en/data-futures-lab/grantmaking/2023-prototype-fund/, which do not appear on the list, the "active link label" will display as "undefined".

This is not desired, and this PR updates the default to the string to "Navigate to...".

Link to sample test page:
Related PRs/issues: #9478 


# Screenshots
Before:

<img width="677" alt="image" src="https://user-images.githubusercontent.com/18314510/194954541-e03d7c3d-2fec-4a52-9ee7-1f3aada076f0.png">

After:
<img width="534" alt="image" src="https://user-images.githubusercontent.com/18314510/194955562-c64fa3e2-9667-429f-8006-fc3a62151e07.png">