### PR TITLE
Custom GitHub Actions workflow to continuously deploy `main` to the Heroku staging app

### DIFF
--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -28,7 +28,9 @@ jobs:
       - name: Deploy to staging
         # run: git push heroku main
         # Test this workflow with a benign action at first
-        run: git fetch heroku main
+        run:
+          - cat ~/.netrc
+          - git fetch heroku main
 
 #   on-failure:
 #     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -28,9 +28,9 @@ jobs:
       - name: Deploy to staging
         # run: git push heroku main
         # Test this workflow with a benign action at first
-        run:
-          - cat ~/.netrc
-          - git fetch heroku main
+        run: |
+          cat ~/.netrc
+          git fetch heroku main
 
 #   on-failure:
 #     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -1,19 +1,19 @@
 name: Continuous Deployment
 # Based on https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
 
-on:
-  # Trigger this workflow (continuous deployment) when the "Continous Integration" workflow
-  # had completed on the main branch.
-  workflow_run:
-    workflows: [Continuous Integration]
-    types: [completed]
-    branches: ["main"]
+on: push
+  # # Trigger this workflow (continuous deployment) when the "Continous Integration" workflow
+  # # had completed on the main branch.
+  # workflow_run:
+  #   workflows: [Continuous Integration]
+  #   types: [completed]
+  #   branches: ["main"]
 
 jobs:
   on-success:
     runs-on: ubuntu-latest
-    # Check that the triggering workflow ended successfully.
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # # Check that the triggering workflow ended successfully.
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       # See Heroku authentication: https://devcenter.heroku.com/articles/authentication#retrieving-the-api-token
       HEROKU_DEPLOYMENT_USER_LOGIN: ${{ secrets.HEROKU_DEPLOYMENT_USER_LOGIN }}
@@ -30,8 +30,8 @@ jobs:
         # Test this workflow with a benign action at first
         run: git fetch heroku main
 
-  on-failure:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    steps:
-      - run: echo 'The continuous inegration failed. Not deploying.'
+#   on-failure:
+#     runs-on: ubuntu-latest
+#     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+#     steps:
+#       - run: echo 'The continuous inegration failed. Not deploying.'

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -24,7 +24,14 @@ jobs:
       - name: Set up git remote
         run: git remote add heroku https://git.heroku.com/foundation-mofostaging-net.git
       - name: Configure Heroku credentials in .netrc file
-        run: echo "machine api.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  password ${HEROKU_DEPLOYMENT_USER_API_TOKEN}\nmachine git.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  password ${HEROKU_DEPLOYMENT_USER_API_TOKEN}" > ~/.netrc
+        run: |
+          echo -e "machine api.heroku.com
+            login $HEROKU_DEPLOYMENT_USER_LOGIN
+            password $HEROKU_DEPLOYMENT_USER_API_TOKEN
+          machine git.heroku.com
+            login $HEROKU_DEPLOYMENT_USER_LOGIN
+            password $HEROKU_DEPLOYMENT_USER_API_TOKEN
+          " > ~/.netrc
       - name: Deploy to staging
         # run: git push heroku main
         # Test this workflow with a benign action at first

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -1,19 +1,19 @@
 name: Continuous Deployment
 # Based on https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
 
-on: push
-  # # Trigger this workflow (continuous deployment) when the "Continous Integration" workflow
-  # # had completed on the main branch.
-  # workflow_run:
-  #   workflows: [Continuous Integration]
-  #   types: [completed]
-  #   branches: ["main"]
+on:
+  # Trigger this workflow (continuous deployment) when the "Continous Integration" workflow
+  # had completed on the main branch.
+  workflow_run:
+    workflows: [Continuous Integration]
+    types: [completed]
+    branches: ["main"]
 
 jobs:
-  on-success:
+  ci-success:
     runs-on: ubuntu-latest
-    # # Check that the triggering workflow ended successfully.
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Check that the triggering workflow ended successfully.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       # See Heroku authentication: https://devcenter.heroku.com/articles/authentication#retrieving-the-api-token
       HEROKU_DEPLOYMENT_USER_LOGIN: ${{ secrets.HEROKU_DEPLOYMENT_USER_LOGIN }}
@@ -33,14 +33,10 @@ jobs:
             password $HEROKU_DEPLOYMENT_USER_API_TOKEN
           " > ~/.netrc
       - name: Deploy to staging
-        # run: git push heroku main
-        # Test this workflow with a benign action at first
-        run: |
-          cat ~/.netrc
-          git fetch heroku main
+        run: git push heroku main
 
-#   on-failure:
-#     runs-on: ubuntu-latest
-#     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-#     steps:
-#       - run: echo 'The continuous inegration failed. Not deploying.'
+  ci-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The continuous inegration failed. Not deploying.'

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -15,7 +15,8 @@ jobs:
     # Check that the triggering workflow ended successfully.
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
-      # See Heroku authentication: https://devcenter.heroku.com/articles/authentication#retrieving-the-api-token
+      # This workflow uses authentication through an API token according to: https://devcenter.heroku.com/articles/authentication
+      # Note: API token are differnt from API keys.
       HEROKU_DEPLOYMENT_USER_LOGIN: ${{ secrets.HEROKU_DEPLOYMENT_USER_LOGIN }}
       HEROKU_DEPLOYMENT_USER_API_TOKEN: ${{ secrets.HEROKU_DEPLOYMENT_USER_API_TOKEN }}
     steps:

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -2,6 +2,8 @@ name: Continuous Deployment
 # Based on https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
 
 on:
+  # Trigger this workflow (continuous deployment) when the "Continous Integration" workflow
+  # had completed on the main branch.
   workflow_run:
     workflows: [Continuous Integration]
     types: [completed]
@@ -10,6 +12,7 @@ on:
 jobs:
   on-success:
     runs-on: ubuntu-latest
+    # Check that the triggering workflow ended successfully.
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       # See Heroku authentication: https://devcenter.heroku.com/articles/authentication#retrieving-the-api-token
@@ -20,10 +23,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up git remote
         run: git remote add heroku https://git.heroku.com/foundation-mofostaging-net.git
-      - name: Configure Heroku credentials
+      - name: Configure Heroku credentials in .netrc file
         run: echo "machine api.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  passwork ${HEROKU_DEPLOYMENT_USER_API_TOKEN}\nmachine git.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  password ${HEROKU_DEPLOYMENT_USER_API_TOKEN}" > ~/.netrc
       - name: Deploy to staging
-        run: git push heroku main
+        # run: git push heroku main
+        # Test this workflow with a benign action at first
+        run: git fetch heroku main
 
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -1,0 +1,32 @@
+name: Continuous Deployment
+# Based on https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
+
+on:
+  workflow_run:
+    workflows: [Continuous Integration]
+    types: [completed]
+    branches: ["main"]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    env:
+      # See Heroku authentication: https://devcenter.heroku.com/articles/authentication#retrieving-the-api-token
+      HEROKU_DEPLOYMENT_USER_LOGIN: ${{ secrets.HEROKU_DEPLOYMENT_USER_LOGIN }}
+      HEROKU_DEPLOYMENT_USER_API_TOKEN: ${{ secrets.HEROKU_DEPLOYMENT_USER_API_TOKEN }}
+    steps:
+      - run: echo 'The continuous integration passed. Deploying to staging...'
+      - uses: actions/checkout@v2
+      - name: Set up git remote
+        run: git remote add heroku https://git.heroku.com/foundation-mofostaging-net.git
+      - name: Configure Heroku credentials
+        run: echo "machine api.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  passwork ${HEROKU_DEPLOYMENT_USER_API_TOKEN}\nmachine git.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  password ${HEROKU_DEPLOYMENT_USER_API_TOKEN}" > ~/.netrc
+      - name: Deploy to staging
+        run: git push heroku main
+
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The continuous inegration failed. Not deploying.'

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up git remote
         run: git remote add heroku https://git.heroku.com/foundation-mofostaging-net.git
       - name: Configure Heroku credentials in .netrc file
-        run: echo "machine api.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  passwork ${HEROKU_DEPLOYMENT_USER_API_TOKEN}\nmachine git.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  password ${HEROKU_DEPLOYMENT_USER_API_TOKEN}" > ~/.netrc
+        run: echo "machine api.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  password ${HEROKU_DEPLOYMENT_USER_API_TOKEN}\nmachine git.heroku.com\n  login ${HEROKU_DEPLOYMENT_USER_LOGIN}\n  password ${HEROKU_DEPLOYMENT_USER_API_TOKEN}" > ~/.netrc
       - name: Deploy to staging
         # run: git push heroku main
         # Test this workflow with a benign action at first

--- a/docs/ops_heroku_settings.md
+++ b/docs/ops_heroku_settings.md
@@ -3,11 +3,11 @@
 ## Staging
 
 We are deploying the `main` branch automatically to the staging environment via a [custom GitHub Actions workflow](https://github.com/mozilla/foundation.mozilla.org/blob/50ae3b68b00fcedda17d5f67d1fdfb6bca1a0f05/.github/workflows/continuous-deployment.yaml).
-The "continuous deployment" workflow is triggered by the "continuous integration" workflow finishing and checks that the "continuous integration" workflow was successful.
-
 We are using a custom action instead of the Heroku-GitHub integration because of security concerns after the [Heroku-GitHub incident in April 2022](https://status.heroku.com/incidents/2413).
 
-The deployment workflow uses the standard Heroku git push deployment.
+The "continuous deployment" workflow is triggered by the "continuous integration" workflow finishing and checks that the "continuous integration" workflow was successful.
+The workflow checks out the `main` branch and deploys it to Heroku using the traditional [Git push deployment](https://devcenter.heroku.com/articles/git) but without the need for the Heroku CLI.
+
 To run this workflow, we need to configure two secret variables for GitHub Action in https://github.com/mozilla/foundation.mozilla.org/settings/secrets/actions:
 
  * `HEROKU_DEPLOYMENT_USER_LOGIN` - Email address of the Heroku user to use for the push,

--- a/docs/ops_heroku_settings.md
+++ b/docs/ops_heroku_settings.md
@@ -2,7 +2,7 @@
 
 ## Staging
 
-We are deploying the `main` branch automatically to the staging environment via a [custom GitHub Actions workflow](https://github.com/mozilla/foundation.mozilla.org/pull/9494/files#diff-d6e37d8db765e21cf58ba38c965d3b81e792b464d5bfe83e4314fbddd5c0a33d).
+We are deploying the `main` branch automatically to the staging environment via a [custom GitHub Actions workflow](https://github.com/mozilla/foundation.mozilla.org/blob/50ae3b68b00fcedda17d5f67d1fdfb6bca1a0f05/.github/workflows/continuous-deployment.yaml).
 The "continuous deployment" workflow is triggered by the "continuous integration" workflow finishing and checks that the "continuous integration" workflow was successful.
 
 We are using a custom action instead of the Heroku-GitHub integration because of security concerns after the [Heroku-GitHub incident in April 2022](https://status.heroku.com/incidents/2413).

--- a/docs/ops_heroku_settings.md
+++ b/docs/ops_heroku_settings.md
@@ -2,23 +2,19 @@
 
 ## Staging
 
-~~Builds to staging are triggered by commits to `main`.~~
+We are deploying the `main` branch automatically to the staging environment via a [custom GitHub Actions workflow](https://github.com/mozilla/foundation.mozilla.org/pull/9494/files#diff-d6e37d8db765e21cf58ba38c965d3b81e792b464d5bfe83e4314fbddd5c0a33d).
+The "continuous deployment" workflow is triggered by the "continuous integration" workflow finishing and checks that the "continuous integration" workflow was successful.
 
-Automatic deployments are currently broken.
-To get your work deployed after the PR has been merged to `main`, check that the [GitHub Actions CI running on `main`](https://github.com/mozilla/foundation.mozilla.org/actions?query=branch%3Amain) is passing.
+We are using a custom action instead of the Heroku-GitHub integration because of security concerns after the [Heroku-GitHub incident in April 2022](https://status.heroku.com/incidents/2413).
 
-Once CI has passed you can pull the branch to local and push it to Heroku.
+The deployment workflow uses the standard Heroku git push deployment.
+To run this workflow, we need to configure two secret variables for GitHub Action in https://github.com/mozilla/foundation.mozilla.org/settings/secrets/actions:
 
-```console
-git switch main
-git fetch origin
-git pull origin main
-git push heroku-staging main
-```
+ * `HEROKU_DEPLOYMENT_USER_LOGIN` - Email address of the Heroku user to use for the push,
+ * `HEROKU_DEPLOYMENT_USER_API_TOKEN` - API token of the same Heroku user. Note: API tokens are separate from API keys in Heroku. To create a new API token visit: https://dashboard.heroku.com/account/applications
 
-For the above to work you will need access to the app on Heroku as well as the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) installed.
-Set up the Heroku git remote as `heroku-staging`, following the docs (except for the remote name): https://devcenter.heroku.com/articles/git
-
+The above login credentials are used to build a `.netrc` file, which is used by Git (through cURL) when pushing to Heroku.
+See the [Heroku authentication docs](https://devcenter.heroku.com/articles/authentication) for more information.
 
 The staging URLs are:
 
@@ -27,7 +23,9 @@ The staging URLs are:
 
 ## Production
 
-Production deployments are done by promoting Staging in the Heroku pipeline.
+Production deployments are done by promoting the staging app to production in the Heroku pipeline.
+This is done on the Heroku dashboard.
+See also: https://devcenter.heroku.com/articles/pipelines#deployment-with-pipelines
 
 The production URLs are:
 


### PR DESCRIPTION
This PR enables a custom GitHub Actions workflow to deploy the `main` branch to the staging app on Heroku. 

The custom workflow checks that the CI pipline has finished successfully, checks out the `main` branch and pushes it to Heroku via the traditional Git push deployment.

The docs are updated to reflect this change and contain information on which credentials need to be set up and how to get them. 

I have tested that the Heroku access works with a simple `git fetch heroku main`. This is the workflow run of the test: https://github.com/mozilla/foundation.mozilla.org/actions/runs/3492453124/jobs/5846247852


Related PRs/issues: #9215 