### PR TITLE
updated makemigrations tasks to use --args flag

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -264,8 +264,7 @@ def migrate(ctx, stop=False):
 @task(aliases=["docker-makemigrations"])
 def makemigrations(ctx, args=""):
     """
-    Creates new migration(s) for apps
-    Arguments can be passed with: inv makemigrations --args=""
+    Creates new migration(s) for apps. Optional: --args=""
     """
     manage(ctx, f"makemigrations {args}")
 
@@ -273,8 +272,7 @@ def makemigrations(ctx, args=""):
 @task(aliases=["docker-makemigrations-dryrun"])
 def makemigrations_dryrun(ctx, args=""):
     """
-    Show new migration(s) for apps without creating them
-    Arguments can be passed with: inv makemigrations_dryrun --args=""
+    Show new migration(s) for apps without creating them. Optional: --args=""
     """
     manage(ctx, f"makemigrations {args} --dry-run")
 

--- a/tasks.py
+++ b/tasks.py
@@ -262,15 +262,21 @@ def migrate(ctx, stop=False):
 
 
 @task(aliases=["docker-makemigrations"])
-def makemigrations(ctx, arguments=""):
-    """Creates new migration(s) for apps"""
-    manage(ctx, f"makemigrations {arguments}")
+def makemigrations(ctx, args=""):
+    """
+    Creates new migration(s) for apps
+    Arguments can be passed with: inv makemigrations --args=""
+    """
+    manage(ctx, f"makemigrations {args}")
 
 
 @task(aliases=["docker-makemigrations-dryrun"])
-def makemigrations_dryrun(ctx):
-    """Show new migration(s) for apps without creating them"""
-    manage(ctx, "makemigrations --dry-run")
+def makemigrations_dryrun(ctx, args=""):
+    """
+    Show new migration(s) for apps without creating them
+    Arguments can be passed with: inv makemigrations_dryrun --args=""
+    """
+    manage(ctx, f"makemigrations {args} --dry-run")
 
 
 @task(help={"args": "Override the arguments passed to mypy."})


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Related PRs/issues: #8292

The `inv makemigrations` command had a `--arguments` flag available for use, but not a lot of info on how to use it. 

This PR does the following:
- Updates the `makemigrations` command's `--arguments` flag to `--args`, since this is what all other commands with arguments use.
- Adds the `--args` flag to the `inv makemigrations-dryrun` command, in case a dev would like to use that command with arguments.
- Updates both of these task's comments to be more descriptive, and to also let the user know the --args flag is available
 for use whenever they run `inv -l`:
<img width="916" alt="Screen Shot 2022-10-14 at 4 10 35 PM" src="https://user-images.githubusercontent.com/18314510/195956278-328951c9-46dd-4e55-8167-80a78f994e49.png">

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [x] Is my code documented?
- ~~[ ] Did I update the READMEs or wagtail documentation?~~



# Steps to test

1. Check this branch out.
2. Make a backend change that would require a migration.
3. Run the command `inv makemigrations --args="-n test_name"`.
4. Note that the makemigration command runs, this time naming the migrations "test_name".
5. If everything is working as expected, testing is complete! 

