### PR TITLE
9486 Article first published at

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
@@ -82,6 +82,12 @@ class BuyersGuideArticlePage(
         panels.StreamFieldPanel('body'),
     ]
 
+    settings_panels = [
+        panels.PublishingPanel(),
+        panels.FieldPanel('first_published_at'),
+        panels.PrivacyModalPanel(),
+    ]
+
     def get_context(self, request: http.HttpRequest, *args, **kwargs) -> dict:
         context = super().get_context(request, *args, **kwargs)
         return context


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

This PR makes the `first_published_at` field editable in the settings tab. This implementation is copied from the [blog page](https://github.com/mozilla/foundation.mozilla.org/blob/pni-2022/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py#L208-L212). 

Link to sample test page: http://localhost:8000/cms/pages/77/edit/#tab-settings
Related PRs/issues: #9486

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
