### PR TITLE
DFL - #9393 - Link heading hover styling fix

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/listing_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/listing_block.html
@@ -11,7 +11,7 @@
             <img src="{{ img.url }}" alt="{{ card.alt_text }}"/>
             <div class="tw-flex tw-flex-1">
               <div class="tw-bg-white tw-relative tw-py-4 tw-w-full tw-flex tw-flex-col">
-                <h3 class="tw-h3-heading tw-mb-2 grou">
+                <h3 class="tw-h3-heading tw-mb-2">
                   {% if card.link %}<a href="{% pageurl card.link %}">{% endif %}
                   {{ card.title }}
                   {% if card.link %}</a>{% endif %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/listing_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/listing_block.html
@@ -2,24 +2,31 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {% block block_content %}
-	<div class="tw-row tw-py-4">
-		{% for block in self.cards %}
-          {% with card=block %}
-            {% image card.image fill-350x197 as img %}
-            <div class="tw-px-4 medium:tw-w-1/2 tw-mb-5">
-              <div class="card-regular tw-h-full tw-flex tw-flex-col">
-                <img src="{{ img.url }}" alt="{{ card.alt_text }}" />
-                <div class="tw-flex tw-flex-1">
-                  <div class="tw-bg-white tw-relative tw-py-4 tw-w-full tw-flex tw-flex-col">
-                    {% if card.link %}<a href="{% pageurl card.link %}">{% endif %}
-                        <h3 class="tw-h3-heading tw-mb-2">{{ card.title }}</h3>
-                    {% if card.link %}</a>{% endif %}
-                    {{ card.body|richtext }}
-                  </div>
-                </div>
+  <div class="tw-row tw-py-4">
+    {% for block in self.cards %}
+      {% with card=block %}
+        {% image card.image fill-350x197 as img %}
+        <div class="tw-px-4 medium:tw-w-1/2 tw-mb-5 group">
+          <div class="card-regular tw-h-full tw-flex tw-flex-col">
+            <img src="{{ img.url }}" alt="{{ card.alt_text }}"/>
+            <div class="tw-flex tw-flex-1">
+              <div class="tw-bg-white tw-relative tw-py-4 tw-w-full tw-flex tw-flex-col">
+                <h3 class="tw-h3-heading tw-mb-2 grou">
+                  {% if card.link %}<a href="{% pageurl card.link %}">{% endif %}
+                  {{ card.title }}
+                  {% if card.link %}</a>{% endif %}
+                </h3>
+                {{ card.body|richtext }}
               </div>
             </div>
-          {% endwith %}
-		{% endfor %}
-	</div>
+          </div>
+        </div>
+      {% endwith %}
+    {% endfor %}
+  </div>
 {% endblock %}
+
+
+color: inherit;
+text-decoration: underline;
+font-weight: inherit;

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/listing_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/listing_block.html
@@ -25,8 +25,3 @@
     {% endfor %}
   </div>
 {% endblock %}
-
-
-color: inherit;
-text-decoration: underline;
-font-weight: inherit;


### PR DESCRIPTION
# Description

This PR address a styling issue mentioned in #9393.

- Rearranged markup so that hover underline styles get inherited as intended.

**Screenshot**

**Card hover on left side**
![Screen Shot 2022-10-24 at 3 01 14 PM](https://user-images.githubusercontent.com/25041665/197628544-42288d34-60d3-4d5b-b74c-74490fe75b71.png)

Link to sample test page:
Related PRs/issues: #9393 
