### PR TITLE
Exit release script when release commands fail

### DIFF
--- a/release-steps.sh
+++ b/release-steps.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 cd network-api
 


### PR DESCRIPTION
Prevents releases from succeeding when migrations fail. As discovered in #8034
