### PR TITLE
#9397 [DFL] - Fix image feature block width

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_feature_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_feature_block.html
@@ -5,7 +5,7 @@
   <section class="tw-bg-white tw-mb-7">
     <div class="tw-container">
       <div class="tw-row">
-        <div class="tw-min-h-[400px] medium:tw-mb-7 tw-w-full">
+        <div class="xlarge:tw-min-h-[400px] medium:tw-mb-7 tw-w-full">
           <div class="tw-relative tw-h-full xlarge:tw-flex tw-justify-end">
 
           {# Image #}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_feature_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_feature_block.html
@@ -5,7 +5,7 @@
   <section class="tw-bg-white tw-mb-7">
     <div class="tw-container">
       <div class="tw-row">
-        <div class="tw-min-h-[400px] medium:tw-mb-7">
+        <div class="tw-min-h-[400px] medium:tw-mb-7 tw-w-full">
           <div class="tw-relative tw-h-full xlarge:tw-flex tw-justify-end">
 
           {# Image #}


### PR DESCRIPTION
# Description

This PR fixes an issue with the featured image block that caused the block to shrink when there is less content.

- Added width 100% to image feature card block
- Only apply min height of block on xlarge breakpoints to avoid large white spaces on mobile

<img width="1329" alt="Screen Shot 2022-10-27 at 9 20 54 AM" src="https://user-images.githubusercontent.com/25041665/198332281-3dfb501a-d65e-4a08-836f-76a994d8554b.png">

Related PRs/issues: #9397 

# Checklist

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [X] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
