### PR TITLE
9524 privacy ding

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -78,7 +78,7 @@
             <span id="product-filter-pni" class="tw-flex tw-cursor-pointer tw-text-gray-60 border tw-border-gray-20 tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3] hover:tw-border-blue-10 hover:tw-bg-blue-10">
               <input type="checkbox" id="product-filter-pni-toggle" autocomplete="off">
               <span class="pni-icon tw-mr-1">&nbsp;</span>
-              <label for="product-filter-pni-toggle" class="tw-flex tw-m-0 tw-w-max">{% trans "privacy not included" %} </label>
+              <label for="product-filter-pni-toggle" class="tw-flex tw-m-0 tw-w-max" title="{% trans '*privacy not included with this product' %}">{% trans "privacy not included" %} </label>
             </span>
 
             {% for cat in categories %}

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -78,7 +78,7 @@
             <span id="product-filter-pni" class="tw-flex tw-cursor-pointer tw-text-gray-60 border tw-border-gray-20 tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3] hover:tw-border-blue-10 hover:tw-bg-blue-10">
               <input type="checkbox" id="product-filter-pni-toggle" autocomplete="off">
               <span class="pni-icon tw-mr-1">&nbsp;</span>
-              <label for="product-filter-pni-toggle" class="tw-flex tw-m-0 tw-w-max">{% trans "Has privacy ding" %} </label>
+              <label for="product-filter-pni-toggle" class="tw-flex tw-m-0 tw-w-max">{% trans "privacy not included" %} </label>
             </span>
 
             {% for cat in categories %}


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
This PR updates the button text and adds a tooltip for the filter button (checkbox) that filters for product with sever privacy concerns (ding / privacy not included).

Link to sample test page: http://localhost:8000/en/privacynotincluded
Related PRs/issues: #9524 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
