### PR TITLE
#9404 [DFL] - Group Listing - Fix tablet padding issue

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/group_listing_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/group_listing_block.html
@@ -17,7 +17,7 @@
             {% endif %}
             <div class="tw-px-4 tw-grid tw-grid-cols-1 large:tw-grid-cols-3 tw-gap-4 large:tw-gap-6">
               <div class="tw-col-span-1">
-                <img class="tw-w-full large:tw-w-auto large:tw-max-w-[345px]" src="{{ img.url }}" alt="{{ card.alt_text }}" width="{{ img.width }}" height="{{ img.height }}"/>
+                <img class="tw-w-full xlarge:tw-max-w-[345px]" src="{{ img.url }}" alt="{{ card.alt_text }}" width="{{ img.width }}" height="{{ img.height }}"/>
               </div>
               <div class="tw-col-span-1 large:tw-col-span-2 large:tw-items-center large:tw-flex">
                 <div class="tw-bg-white tw-relative tw-w-full tw-flex tw-flex-col">


### PR DESCRIPTION
# Description

This PR fixes an issue where the image was being overlapped by the content on tablet sized devices.

- changed the breakpoint of when the max image width was set
- removed unused width class 

https://user-images.githubusercontent.com/25041665/198681873-b4dfdf77-dc7d-4589-b0b8-8b2e7c41800a.mp4


Related PRs/issues: #9404 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible]~~(https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
