### PR TITLE
9526 - Update "Submit a product" section

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/submit_a_product.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/submit_a_product.html
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-<a href="https://forms.gle/UefDgjEU85Xwcf8C8" target="_blank" class="tw-btn-secondary btn-recommend after:tw-hidden">{% trans "Submit a product" %}</a>
+<a href="https://forms.gle/UefDgjEU85Xwcf8C8" target="_blank" class="tw-font-sans tw-text-blue-80 tw-underline tw-decoration-blue-80">{% trans "Submit a product here." %}</a>

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -144,7 +144,11 @@
   <div class="recommend-product">
     <div class="container text-center my-5">
       <h2 class="tw-h3-heading">{% trans "Don’t see the product you’re looking for?" %}</h2>
-      <p class="tw-body">{% trans "Let us know what product you would like reviewed in the guide." %}</p>
+      <p class="tw-body tw-mb-0">
+        {% blocktrans trimmed %}
+            Try <a href="#top" class="tw-underline tw-text-blue-80">search</a> or let us know what product you would like reviewed in the guide.
+        {% endblocktrans %}
+      </p>
       {% include "fragments/buyersguide/submit_a_product.html" %}
     </div>
   </div>


### PR DESCRIPTION
# Description

<img width="661" alt="image" src="https://user-images.githubusercontent.com/2374073/198754694-758510b4-450c-4e5b-95a7-f41d721a4f03.png">

New `submit a product` styling, #9574 should be checked first!

Link to sample test page: en/privacynotincluded
Related PRs/issues: #9526 
