### PR TITLE
9558 - Sign up button styling on product page

### DIFF
--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -537,7 +537,7 @@ class JoinUs extends Component {
       );
       buttonText = getText("Subscribe");
     } else if (this.props.formStyle == "pni") {
-      classnames = classNames("tw-btn-primary", "tw-w-max", "tw-h-7");
+      classnames = classNames("tw-btn", "tw-btn-primary", "tw-w-max", "tw-h-7");
       buttonText = getText("Sign up");
     } else {
       classnames = classNames("tw-btn-primary", {


### PR DESCRIPTION
# Description
Lower priority ticket! Look at the others first!

Some SASS css is override the hover stylings on the join component when on the product pages. adding tw-btn fixes this issue.

Link to sample test page: pni homepage -> click on product -> scroll down to join us field
Related PRs/issues: #9558 
