### PR TITLE
9542 - related articles on article page

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/article_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/article_page.html
@@ -49,10 +49,13 @@
 
   {% with related_articles=page.get_primary_related_articles  %}
     {% if related_articles %}
-      {% trans "PRIMARY RELATED ARTICLES" %}
-      <div class="tw-m-4">
-        {% include "fragments/buyersguide/related_reading.html" with articles=related_articles %}
+    <div class="tw-container tw-my-4">
+      <div class="tw-row">
+        <div class="tw-px-4 tw-w-8/12 tw-mx-auto" id="pni-related-content">
+          {% include "fragments/buyersguide/related_reading.html" with articles=related_articles %}
+        </div>
       </div>
+    </div>
     {% endif %}
   {% endwith %}
 
@@ -101,6 +104,5 @@
       </div>
     {% endif %}
   {% endwith %}
-
 </div>
 {% endblock guts %}

--- a/network-api/networkapi/templates/pages/buyersguide/article_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/article_page.html
@@ -55,7 +55,7 @@
     {% if related_articles %}
     <div class="tw-container tw-my-4">
       <div class="tw-row">
-        <div class="tw-px-4 tw-w-8/12 tw-mx-auto" id="pni-related-content">
+        <div class="tw-px-4 tw-w-8/12 tw-mx-auto" id="buyersguide-related-content">
           {% include "fragments/buyersguide/related_reading.html" with articles=related_articles %}
         </div>
       </div>

--- a/network-api/networkapi/templates/pages/buyersguide/article_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/article_page.html
@@ -47,6 +47,10 @@
     </div>
   </div>
 
+  {% for block in page.body %}
+      {% include_block block with parent_page=page page_type="blog" %}
+  {% endfor %}
+
   {% with related_articles=page.get_primary_related_articles  %}
     {% if related_articles %}
     <div class="tw-container tw-my-4">
@@ -58,10 +62,6 @@
     </div>
     {% endif %}
   {% endwith %}
-
-  {% for block in page.body %}
-      {% include_block block with parent_page=page page_type="blog" %}
-  {% endfor %}
 
   <div class="tw-container tw-mt-6">
     <div class="tw-row tw-justify-center">

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -113,6 +113,22 @@ let main = {
     if (document.querySelector(`body.pni.catalog`)) {
       HomepageSlider.init();
     }
+    if (document.querySelector("#view-article")) {
+      const firstParagraph = document.querySelector(
+        ".paragraph-block .rich-text"
+      );
+      const relatedContainer = document.querySelector("#pni-related-content");
+      if (!firstParagraph || !relatedContainer) return;
+      const relatedContent = relatedContainer.querySelector("div");
+      const relatedPlace = firstParagraph.querySelector("*:nth-child(3)");
+      if (!relatedPlace) return;
+      firstParagraph.insertBefore(relatedContent, relatedPlace);
+      relatedContent.classList.add(
+        "large:tw-float-right",
+        "large:tw-pl-4",
+        "large:tw-mr-[-20%]"
+      );
+    }
   },
 };
 

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -125,7 +125,8 @@ let main = {
       firstParagraph.insertBefore(relatedContent, relatedPlace);
       relatedContent.classList.add(
         "large:tw-float-right",
-        "large:tw-pl-4",
+        "tw-p-4",
+        "tw-pr-0",
         "large:tw-mr-[-20%]"
       );
     }

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -13,6 +13,7 @@ import injectMultipageNav from "../multipage-nav.js";
 import primaryNav from "../primary-nav.js";
 
 import HomepageSlider from "./homepage-c-slider.js";
+import RelatedArticles from "./related-articles.js";
 import AnalyticsEvents from "./analytics-events.js";
 import initializeSentry from "../common/sentry-config.js";
 import PNIMobileNav from "./pni-mobile-nav.js";
@@ -114,21 +115,7 @@ let main = {
       HomepageSlider.init();
     }
     if (document.querySelector("#view-article")) {
-      const firstParagraph = document.querySelector(
-        ".paragraph-block .rich-text"
-      );
-      const relatedContainer = document.querySelector("#pni-related-content");
-      if (!firstParagraph || !relatedContainer) return;
-      const relatedContent = relatedContainer.querySelector("div");
-      const relatedPlace = firstParagraph.querySelector("*:nth-child(3)");
-      if (!relatedPlace) return;
-      firstParagraph.insertBefore(relatedContent, relatedPlace);
-      relatedContent.classList.add(
-        "large:tw-float-right",
-        "tw-p-4",
-        "tw-pr-0",
-        "large:tw-mr-[-20%]"
-      );
+      RelatedArticles.init();
     }
   },
 };

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -115,7 +115,7 @@ let main = {
       HomepageSlider.init();
     }
     if (document.querySelector("#view-article")) {
-      RelatedArticles.init();
+      RelatedArticles.floatRelatedArticlesNextToThirdElement();
     }
   },
 };

--- a/source/js/buyers-guide/related-articles.js
+++ b/source/js/buyers-guide/related-articles.js
@@ -3,7 +3,9 @@ const RelatedArticles = {
     const firstParagraph = document.querySelector(
       ".paragraph-block .rich-text"
     );
-    const relatedContainer = document.querySelector("#pni-related-content");
+    const relatedContainer = document.querySelector(
+      "#buyersguide-related-content"
+    );
     if (!firstParagraph || !relatedContainer) return;
     const relatedContent = relatedContainer.querySelector("div");
     const relatedPlace = firstParagraph.querySelector("*:nth-child(3)");

--- a/source/js/buyers-guide/related-articles.js
+++ b/source/js/buyers-guide/related-articles.js
@@ -1,0 +1,21 @@
+const RelatedArticles = {
+  init: () => {
+    const firstParagraph = document.querySelector(
+      ".paragraph-block .rich-text"
+    );
+    const relatedContainer = document.querySelector("#pni-related-content");
+    if (!firstParagraph || !relatedContainer) return;
+    const relatedContent = relatedContainer.querySelector("div");
+    const relatedPlace = firstParagraph.querySelector("*:nth-child(3)");
+    if (!relatedPlace) return;
+    firstParagraph.insertBefore(relatedContent, relatedPlace);
+    relatedContent.classList.add(
+      "large:tw-float-right",
+      "tw-p-4",
+      "tw-pr-0",
+      "large:tw-mr-[-20%]"
+    );
+  },
+};
+
+export default RelatedArticles;

--- a/source/js/buyers-guide/related-articles.js
+++ b/source/js/buyers-guide/related-articles.js
@@ -8,6 +8,11 @@ const RelatedArticles = {
     );
     if (!firstParagraph || !relatedContainer) return;
     const relatedContent = relatedContainer.querySelector("div");
+    /*
+     * if there is at least 3 children inside the rich body container.
+     * Usually there is a header(h1-6) and a few paragraphs blocks to start most articles.
+     * If we do not have at least that many elements we leave the related articles at the bottom of the article page
+     */
     const relatedPlace = firstParagraph.querySelector("*:nth-child(3)");
     if (!relatedPlace) return;
     firstParagraph.insertBefore(relatedContent, relatedPlace);

--- a/source/js/buyers-guide/related-articles.js
+++ b/source/js/buyers-guide/related-articles.js
@@ -1,5 +1,5 @@
 const RelatedArticles = {
-  init: () => {
+  floatRelatedArticlesNextToThirdElement: () => {
     const firstParagraph = document.querySelector(
       ".paragraph-block .rich-text"
     );


### PR DESCRIPTION
# Description

Added Related Content positioning on article pages.

Will use similar floating position from FIgma when there is enough content from cms.body. If JS is disabled or not enough content, related articles will appear after CMS rich text is added.

Link to sample test page: any PNI article
Related PRs/issues: #9542 

