### PR TITLE
#9403 - [DFL] - Card list block heading fix

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/group_listing_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/group_listing_block.html
@@ -4,7 +4,7 @@
 {% block block_content %}
   <div class="tw-row tw-my-4 large:tw-mb-7">
     <div class="tw-px-4 tw-w-full">
-      <h2 class="tw-pt-2 tw-pb-3 tw-border-t tw-inline-block">{{ self.title }}</h2>
+      <h2 class="tw-h3-heading tw-pt-2 tw-pb-3 tw-border-t tw-inline-block">{{ self.title }}</h2>
     </div>
 
     <ul class="tw-space-y-4 large:tw-space-y-5 tw-list-none tw-pl-0">


### PR DESCRIPTION
# Description
Addresses an issue in #9403 where the title of this block should be styled as an h3

- Use heading 3 for title area

Related PRs/issues: #9403 

## Screenshot
<img width="731" alt="Screen Shot 2022-10-31 at 1 16 16 PM" src="https://user-images.githubusercontent.com/25041665/199091399-123b209c-0cf3-4563-8504-c9aaca3622e9.png">


# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [X] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
