### PR TITLE
9554 - Fix chrome related wavy lines

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/article_listing_wide.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/article_listing_wide.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailcore_tags %}
 
 <div class="tw-grid tw-grid-cols-2 {% if columns_above_large == 3 %} large:tw-grid-cols-3 {% endif %} tw-gap-6">
-  <div class="tw-col-span-full tw-flex tw-flex-row tw-justify-between tw-items-baseline tw-gap-5">
+  <div class="tw-col-span-full tw-flex tw-flex-row tw-justify-between large:tw-items-baseline tw-gap-5">
     <div class="tw-h3-heading tw-m-0 tw-whitespace-nowrap">
       {{ heading }}
     </div>

--- a/network-api/networkapi/templates/fragments/buyersguide/wavy_line.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/wavy_line.html
@@ -1,5 +1,5 @@
 {% load static %}
 
-<div class="tw-overflow-x-hidden tw-flex">
+<div class="tw-overflow-x-hidden">
   <img src="{% static "_images/buyers-guide/very-long-wavy-border.svg" %}" class="tw-max-w-fit" alt="" />
 </div>

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -173,7 +173,7 @@
       {% with related_products=product.related_product_pages.all %}
         {% if related_products %}
           <div class="tw-col-span-full medium:tw-col-span-2 large:tw-col-start-2">
-            <div class="tw-flex tw-flex-col tw-items-baseline medium:tw-flex-row-reverse medium:tw-gap-5">
+            <div class="tw-flex tw-flex-col medium:tw-items-center large:tw-items-baseline medium:tw-flex-row-reverse medium:tw-gap-5">
               {% include "fragments/buyersguide/wavy_line.html" %}
               <h2 class="tw-h3-heading tw-mt-2 tw-shrink-0">{% trans "Related products" %}</h2>
             </div>

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -173,7 +173,7 @@
       {% with related_products=product.related_product_pages.all %}
         {% if related_products %}
           <div class="tw-col-span-full medium:tw-col-span-2 large:tw-col-start-2">
-            <div class="tw-flex tw-flex-col medium:tw-flex-row-reverse medium:tw-gap-5">
+            <div class="tw-flex tw-flex-col tw-items-baseline medium:tw-flex-row-reverse medium:tw-gap-5">
               {% include "fragments/buyersguide/wavy_line.html" %}
               <h2 class="tw-h3-heading tw-mt-2 tw-shrink-0">{% trans "Related products" %}</h2>
             </div>


### PR DESCRIPTION
# Description

Removed `tw-flex` class for `wavy_line.html`.

Link to sample test page: go to PNI homepage -> product page -> scroll down on chrome browser
Related PRs/issues: #9554 