### PR TITLE
#9415 Sync translations for featured hero article (and other related article fields)

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/ask_jen_advice_section.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/ask_jen_advice_section.html
@@ -30,9 +30,9 @@
     <div class="tw-relative tw-w-screen large:tw-absolute large:tw-bottom-0 large:tw-right-0 tw-bg-[url('../_images/buyers-guide/jen-bg-shape-mobile.png')] medium:tw-bg-[url('../_images/buyers-guide/jen-bg-shape-tablet.png')] large:tw-bg-[url('../_images/buyers-guide/jen-bg-shape.png')] large:tw-w-[905px] tw-h-[1200px] medium:tw-h-[730px] tw-bg-[length:700px] medium:tw-bg-[length:750px] large:tw-bg-auto large:tw-h-[498px] tw-bg-no-repeat tw-bg-top medium:tw-bg-right-top large:tw-bg-center">
         <div class="tw-px-6 tw-pt-[150px] medium:tw-pt-[50px] large:tw-pt-0 tw-absolute tw-top-0 medium:tw-top-auto  large:tw-top-1/2 tw-left-1/2 medium:tw-left-auto large:tw-left-1/2 medium:tw-right-4 large:tw-right-auto -tw-translate-x-1/2 medium:tw-translate-x-0 large:-tw-translate-x-1/2 -tw-translate-y-0 large:-tw-translate-y-1/2 tw-flex tw-flex-col large:tw-grid tw-grid-cols-[auto,1fr] tw-grid-rows-[auto,auto,auto] tw-gap-4 tw-w-full medium:tw-w-1/2 large:tw-w-[600px]">
             <div class="tw-col-start-1 tw-text-blue-40 tw-font-bold tw-text-5xl tw-leading-[36px] tw-self-start tw-font-zilla">{% trans "Q:" context "Short for ‘question’, please keep this translation short" %}</div>
-            <div class="tw-col-start-2 tw-row-start-1 tw-line-clamp-5 large:tw-line-clamp-3 tw-font-zilla tw-text-2xl large:tw-text-3xl">{{ featured_advice_article.localized.title }}</div>
+            <div class="tw-col-start-2 tw-row-start-1 tw-line-clamp-5 large:tw-line-clamp-3 tw-font-zilla tw-text-2xl large:tw-text-3xl">{{ featured_advice_article.title }}</div>
             <div class="tw-col-start-1 tw-text-blue-40 tw-font-bold tw-text-5xl tw-leading-[36px] tw-self-start tw-font-zilla">{% trans "A:" context "Short for ‘answer’, please keep this translation short" %}</div>
-            <div class="tw-col-start-2 tw-line-clamp-5 large:tw-line-clamp-3 tw-text-2xl large:tw-text-xl">{{ featured_advice_article.localized.get_meta_description }}</div>
+            <div class="tw-col-start-2 tw-line-clamp-5 large:tw-line-clamp-3 tw-text-2xl large:tw-text-xl">{{ featured_advice_article.get_meta_description }}</div>
 
             <div class="tw-col-start-2">
               {% pageurl featured_advice_article as link_href %}

--- a/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
@@ -17,6 +17,7 @@
       class="
         tw-col-span-full large:tw-col-span-7
         large:tw-row-span-2
+        [&_~_a>h2]:hover:tw-underline
       "
     >
       <span class="tw-sr-only">{{ featured_article.title }}</span>

--- a/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
@@ -11,20 +11,20 @@
     tw-gap-y-6
   ">
 
-    {% image hero_featured_article.hero_image original as img %}
+    {% image featured_article.hero_image original as img %}
     <a
-      href="{% pageurl hero_featured_article %}"
+      href="{% pageurl featured_article %}"
       class="
         tw-col-span-full large:tw-col-span-7
         large:tw-row-span-2
       "
     >
-      <span class="tw-sr-only">{{ hero_featured_article.title }}</span>
+      <span class="tw-sr-only">{{ featured_article.title }}</span>
       <img src="{{ img.url }}" alt="{{ img.alt }}" class="tw-w-full tw-aspect-video tw-rounded-xl tw-object-cover " />
     </a>
 
     <a
-      href="{% pageurl hero_featured_article %}"
+      href="{% pageurl featured_article %}"
       class="
         tw-col-span-full medium:tw-col-span-6 large:tw-col-span-5
         tw-no-underline
@@ -32,12 +32,12 @@
       "
     >
       <h2 class="tw-h3-heading group-hover:tw-underline">
-        {{ hero_featured_article.title }}
+        {{ featured_article.title }}
       </h2>
 
       <div class="tw-space-x-1 tw-text-black tw-font-sans tw-font-extrabold tw-text-sm">
         {% trans "By" %}
-        {% with author_profiles=hero_featured_article.get_author_profiles %}
+        {% with author_profiles=featured_article.get_author_profiles %}
           {% if author_profiles %}
             {% for author_profile in author_profiles %}
               <span>{{ author_profile.name }}</span>

--- a/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
@@ -48,13 +48,11 @@
       </div>
     </a>
 
-    {% with hero_supporting_articles=page.get_hero_supporting_articles %}
-      {% if hero_supporting_articles %}
-        <div class="tw-col-span-full medium:tw-col-span-6 large:tw-col-span-5">
-          {% include "fragments/buyersguide/related_reading.html" with heading=page.hero_supporting_articles_heading heading_level=3 heading_classes='tw-font-sans tw-text-base tw-leading-5 tw-uppercase tw-my-4' articles=hero_supporting_articles %}
-        </div>
-      {% endif %}
-    {% endwith %}
+    {% if supporting_articles %}
+      <div class="tw-col-span-full medium:tw-col-span-6 large:tw-col-span-5">
+        {% include "fragments/buyersguide/related_reading.html" with heading=supporting_articles_heading heading_level=3 heading_classes='tw-font-sans tw-text-base tw-leading-5 tw-uppercase tw-my-4' articles=supporting_articles %}
+      </div>
+    {% endif %}
 
   </div>
 </div>

--- a/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
@@ -12,8 +12,9 @@
   ">
 
     {% image featured_article.hero_image original as img %}
+    {% pageurl featured_article as featured_article_url %}
     <a
-      href="{% pageurl featured_article %}"
+      href="{{ featured_article_url }}"
       class="
         tw-col-span-full large:tw-col-span-7
         large:tw-row-span-2
@@ -25,7 +26,7 @@
     </a>
 
     <a
-      href="{% pageurl featured_article %}"
+      href="{{ featured_article_url }}"
       class="
         tw-col-span-full medium:tw-col-span-6 large:tw-col-span-5
         tw-no-underline

--- a/network-api/networkapi/templates/pages/buyersguide/home.html
+++ b/network-api/networkapi/templates/pages/buyersguide/home.html
@@ -10,7 +10,7 @@
     {% with hero_featured_article=page.get_hero_featured_article %}
       {% if hero_featured_article %}
         <div class="tw-container">
-          {% include "fragments/buyersguide/featured_article.html" with featured_article=hero_featured_article %}
+          {% include "fragments/buyersguide/featured_article.html" with featured_article=hero_featured_article supporting_articles=page.get_hero_supporting_articles supporting_articles_heading=page.hero_supporting_articles_heading %}
         </div>
       {% endif %}
     {% endwith %}

--- a/network-api/networkapi/templates/pages/buyersguide/home.html
+++ b/network-api/networkapi/templates/pages/buyersguide/home.html
@@ -7,11 +7,13 @@
   {{ block.super }}
   <div class="editorial-content">
 
-    {% if page.hero_featured_article %}
-      <div class="tw-container">
-        {% include "fragments/buyersguide/featured_article.html" with hero_featured_article=page.hero_featured_article %}
-      </div>
-    {% endif %}
+    {% with hero_featured_article=page.get_hero_featured_article %}
+      {% if hero_featured_article %}
+        <div class="tw-container">
+          {% include "fragments/buyersguide/featured_article.html" with featured_article=hero_featured_article %}
+        </div>
+      {% endif %}
+    {% endwith %}
 
     {% if page.featured_advice_article %}
       <div class="large:tw-container tw-my-6">

--- a/network-api/networkapi/templates/pages/buyersguide/home.html
+++ b/network-api/networkapi/templates/pages/buyersguide/home.html
@@ -15,11 +15,13 @@
       {% endif %}
     {% endwith %}
 
-    {% if page.featured_advice_article %}
-      <div class="large:tw-container tw-my-6">
-        {% include "fragments/buyersguide/ask_jen_advice_section.html" with featured_advice_article=page.featured_advice_article %}
-      </div>
-    {% endif %}
+    {% with featured_advice_article=page.get_featured_advice_article  %}
+      {% if featured_advice_article %}
+        <div class="large:tw-container tw-my-6">
+          {% include "fragments/buyersguide/ask_jen_advice_section.html" with featured_advice_article=featured_advice_article %}
+        </div>
+      {% endif %}
+    {% endwith %}
 
     <div class="tw-container tw-my-6">
       <div class="tw-row">

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -420,10 +420,16 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         return [a.localized for a in articles]
 
     def get_featured_articles(self) -> list['BuyersGuideArticlePage']:
-        return orderables.get_related_items(
+        articles = orderables.get_related_items(
             self.featured_article_relations.all(),
             'article',
         )
+        # FIXME: This implementation does return the localized version of each article.
+        #        But, it is inefficient. It would be better to pull all articles
+        #        for the correct locale at once. This would require the above returns
+        #        a queryset of the articles (rather than a list) and that we have an
+        #        efficient way of pulling all items for a given locale.
+        return [a.localized for a in articles]
 
     def get_featured_updates(self) -> list['Update']:
         return orderables.get_related_items(

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -195,6 +195,9 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         # Featured articles should be translatable too. See above explanation for
         # hero supporting articles.
         SynchronizedField('featured_article_relations'),
+        # Featured advice article should be translatable. But this faces the same issue
+        # as the hero featured article.
+        SynchronizedField('featured_advice_article'),
         SynchronizedField('cutoff_date'),
         SynchronizedField('excluded_categories'),
         TranslatableField('call_to_action'),

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -192,6 +192,9 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         # See also: https://github.com/wagtail/wagtail-localize/issues/640
         SynchronizedField('hero_supporting_article_relations'),
         TranslatableField('hero_supporting_articles_heading'),
+        # Featured articles should be translatable too. See above explanation for
+        # hero supporting articles.
+        SynchronizedField('featured_article_relations'),
         SynchronizedField('cutoff_date'),
         SynchronizedField('excluded_categories'),
         TranslatableField('call_to_action'),

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-import typing
+from typing import TYPE_CHECKING, Optional
 
 from django.apps import apps
 from django.conf import settings
@@ -43,7 +43,7 @@ from networkapi.wagtailpages.utils import (
 )
 
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from networkapi.wagtailpages.models import BuyersGuideArticlePage, Update
 
 
@@ -390,8 +390,13 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         indexes = BuyersGuideEditorialContentIndexPage.objects.descendant_of(self)
         return indexes.first()
 
-    def get_hero_featured_article(self) -> 'BuyersGuideArticlePage':
-        return self.hero_featured_article
+    def get_hero_featured_article(self) -> Optional['BuyersGuideArticlePage']:
+        try:
+            return self.hero_featured_article.localized
+        except AttributeError:
+            # If no hero featured article is set (because `None` has no `localized`
+            # attribute)
+            return None
 
     def get_hero_supporting_articles(self) -> list['BuyersGuideArticlePage']:
         return orderables.get_related_items(

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -434,6 +434,14 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         #        efficient way of pulling all items for a given locale.
         return [a.localized for a in articles]
 
+    def get_featured_advice_article(self) -> Optional['BuyersGuideArticlePage']:
+        try:
+            return self.featured_advice_article.localized
+        except AttributeError:
+            # If no featured advice article is set (because `None` has no `localized`
+            # attribute)
+            return None
+
     def get_featured_updates(self) -> list['Update']:
         return orderables.get_related_items(
             self.featured_update_relations.all(),

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -390,6 +390,9 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
         indexes = BuyersGuideEditorialContentIndexPage.objects.descendant_of(self)
         return indexes.first()
 
+    def get_hero_featured_article(self) -> 'BuyersGuideArticlePage':
+        return self.hero_featured_article
+
     def get_hero_supporting_articles(self) -> list['BuyersGuideArticlePage']:
         return orderables.get_related_items(
             self.hero_supporting_article_relations.all(),

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -183,7 +183,9 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
     translatable_fields = [
         TranslatableField('title'),
         TranslatableField('intro_text'),
-        TranslatableField('hero_featured_article'),
+        # Hero featured article should be translatable.
+        # Using sync field as workaround for https://github.com/wagtail/wagtail-localize/issues/430
+        SynchronizedField('hero_featured_article'),
         TranslatableField('hero_supporting_article_relations'),
         TranslatableField('hero_supporting_articles_heading'),
         SynchronizedField('cutoff_date'),

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -405,10 +405,16 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
             return None
 
     def get_hero_supporting_articles(self) -> list['BuyersGuideArticlePage']:
-        return orderables.get_related_items(
+        articles = orderables.get_related_items(
             self.hero_supporting_article_relations.all(),
             'article',
         )
+        # FIXME: This implementation does return the localized version of each article.
+        #        But, it is inefficient. It would be better to pull all articles
+        #        for the correct locale at once. This would require the above returns
+        #        a queryset of the articles (rather than a list) and that we have an
+        #        efficient way of pulling all items for a given locale.
+        return [a.localized for a in articles]
 
     def get_featured_articles(self) -> list['BuyersGuideArticlePage']:
         return orderables.get_related_items(

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -183,10 +183,14 @@ class BuyersGuidePage(RoutablePageMixin, FoundationMetadataPageMixin, Page):
     translatable_fields = [
         TranslatableField('title'),
         TranslatableField('intro_text'),
-        # Hero featured article should be translatable.
-        # Using sync field as workaround for https://github.com/wagtail/wagtail-localize/issues/430
+        # Hero featured article should be translatable, but that is causing issues.
+        # Using sync field as workaround.
+        # See also: https://github.com/wagtail/wagtail-localize/issues/430
         SynchronizedField('hero_featured_article'),
-        TranslatableField('hero_supporting_article_relations'),
+        # Hero supporting article relations should also be translatable, but that is
+        # also causing issues. Using sync filed as a workaround.
+        # See also: https://github.com/wagtail/wagtail-localize/issues/640
+        SynchronizedField('hero_supporting_article_relations'),
         TranslatableField('hero_supporting_articles_heading'),
         SynchronizedField('cutoff_date'),
         SynchronizedField('excluded_categories'),

--- a/network-api/networkapi/wagtailpages/tests/base.py
+++ b/network-api/networkapi/wagtailpages/tests/base.py
@@ -37,6 +37,9 @@ class WagtailpagesTestCase(wagtail_test.WagtailPageTests):
         )
         assert cls.fr_locale != cls.default_locale
 
+    def setUp(self):
+        self.activate_locale(self.default_locale)
+
     def synchronize_tree(self):
         synctree.synchronize_tree(
             source_locale=self.default_locale,

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/base.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/base.py
@@ -12,7 +12,7 @@ from networkapi.wagtailpages.utils import create_wagtail_image
 
 
 @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})
-class BuyersGuideTestMixin(test_base.WagtailpagesTestCase):
+class BuyersGuideTestCase(test_base.WagtailpagesTestCase):
 
     @classmethod
     def setUpTestData(cls):

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/base.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/base.py
@@ -3,57 +3,42 @@ from os.path import abspath, join
 from django.conf import settings
 from django.test.utils import override_settings
 
-from networkapi.wagtailpages.factory.homepage import WagtailHomepageFactory
-from networkapi.wagtailpages.pagemodels.base import Homepage
 from networkapi.wagtailpages.pagemodels.buyersguide.homepage import BuyersGuidePage
 from networkapi.wagtailpages.pagemodels.buyersguide.products import (
     ProductPage,
 )
+from networkapi.wagtailpages.tests import base as test_base
 from networkapi.wagtailpages.utils import create_wagtail_image
-
-from wagtail.core.models import Page, Site
-from wagtail.tests.utils import WagtailPageTests
 
 
 @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})
-class BuyersGuideTestMixin(WagtailPageTests):
+class BuyersGuideTestMixin(test_base.WagtailpagesTestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
         # Ensure there's always a BuyersGuide Page
-        self.bg = self.get_or_create_buyers_guide()
-        self.product_page = self.get_or_create_product_page()
+        cls.bg = cls.get_or_create_buyers_guide()
+        cls.product_page = cls.get_or_create_product_page()
 
-        site = Site.objects.first()
-        site.root_page = self.homepage
-        site.save()
-
-    def get_or_create_buyers_guide(self):
+    @classmethod
+    def get_or_create_buyers_guide(cls):
         """
         Return the first BuyersGuidePage, or create a new one.
         Will generate a Homepage if needed.
         """
         buyersguide = BuyersGuidePage.objects.first()
         if not buyersguide:
-            homepage = Homepage.objects.first()
-            if not homepage:
-                page_tree_root = Page.objects.get(depth=1)
-                homepage = WagtailHomepageFactory.create(
-                    parent=page_tree_root,
-                    title='Homepage',
-                    slug='homepage',
-                    hero_image__file__width=1080,
-                    hero_image__file__height=720
-                )
             # Create the buyersguide page.
             buyersguide = BuyersGuidePage()
             buyersguide.title = 'Privacy not included'
             buyersguide.slug = 'privacynotincluded'
-            homepage.add_child(instance=buyersguide)
+            cls.homepage.add_child(instance=buyersguide)
             buyersguide.save_revision().publish()
-        self.homepage = Homepage.objects.first()
         return buyersguide
 
-    def get_or_create_product_page(self):
+    @classmethod
+    def get_or_create_product_page(cls):
         product_page = ProductPage.objects.first()
         if not product_page:
             image_path = abspath(join(
@@ -70,6 +55,6 @@ class BuyersGuideTestMixin(WagtailPageTests):
                 live=True,
                 image=wagtail_image
             )
-            self.bg.add_child(instance=product_page)
+            cls.bg.add_child(instance=product_page)
             product_page.save_revision().publish()
         return product_page

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -367,4 +367,22 @@ class TestBuyersGuidePageRelatedArticles(BuyersGuideTestCase):
         self.assertQuerysetEqual(qs=result, values=articles)
 
     def test_get_hero_supporting_articles_non_default_locale(self):
-        pass
+        articles = []
+        for i in range(1, 4):
+            article = buyersguide_factories.BuyersGuideArticlePageFactory(
+                parent=self.content_index,
+            )
+            buyersguide_factories.BuyersGuidePageHeroSupportingArticleRelationFactory(
+                page=self.bg,
+                article=article,
+                sort_order=i,
+            )
+            articles.append(article)
+        self.synchronize_tree()
+        articles_fr = [a.get_translation(self.fr_locale) for a in articles]
+        buyersguide_homepage_fr = self.bg.get_translation(self.fr_locale)
+        self.activate_locale(self.fr_locale)
+
+        result = buyersguide_homepage_fr.get_hero_supporting_articles()
+
+        self.assertQuerysetEqual(qs=result, values=articles_fr)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -301,3 +301,29 @@ class TestBuyersGuidePage(BuyersGuideTestMixin):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(cta, response.context['featured_cta'])
+
+class TestBuyersGuidePageRelatedArticles(BuyersGuideTestMixin):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.content_index = buyersguide_factories.BuyersGuideEditorialContentIndexPageFactory(
+            parent=cls.bg,
+        )
+
+    def test_get_hero_featured_article(self):
+        pass
+
+    def test_get_hero_featured_article_not_set(self):
+        pass
+
+    def test_get_hero_featured_article_non_default_locale(self):
+        pass
+
+    def test_get_hero_supporting_articles(self):
+        pass
+
+    def test_get_hero_supporting_articles_not_set(self):
+        pass
+
+    def test_get_hero_supporting_articles_non_default_locale(self):
+        pass

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -386,3 +386,48 @@ class TestBuyersGuidePageRelatedArticles(BuyersGuideTestCase):
         result = buyersguide_homepage_fr.get_hero_supporting_articles()
 
         self.assertQuerysetEqual(qs=result, values=articles_fr)
+
+    def test_get_featured_articles(self):
+        articles = []
+        for i in range(1, 4):
+            article = buyersguide_factories.BuyersGuideArticlePageFactory(
+                parent=self.content_index,
+            )
+            buyersguide_factories.BuyersGuidePageFeaturedArticleRelationFactory(
+                page=self.bg,
+                article=article,
+                sort_order=i,
+            )
+            articles.append(article)
+
+        result = self.bg.get_featured_articles()
+
+        self.assertQuerysetEqual(qs=result, values=articles)
+
+    def test_get_featured_articles_not_set(self):
+        articles = []
+
+        result = self.bg.get_featured_articles()
+
+        self.assertQuerysetEqual(qs=result, values=articles)
+
+    def test_get_featured_articles_non_default_locale(self):
+        articles = []
+        for i in range(1, 4):
+            article = buyersguide_factories.BuyersGuideArticlePageFactory(
+                parent=self.content_index,
+            )
+            buyersguide_factories.BuyersGuidePageFeaturedArticleRelationFactory(
+                page=self.bg,
+                article=article,
+                sort_order=i,
+            )
+            articles.append(article)
+        self.synchronize_tree()
+        articles_fr = [a.get_translation(self.fr_locale) for a in articles]
+        buyersguide_homepage_fr = self.bg.get_translation(self.fr_locale)
+        self.activate_locale(self.fr_locale)
+
+        result = buyersguide_homepage_fr.get_featured_articles()
+
+        self.assertQuerysetEqual(qs=result, values=articles_fr)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -311,10 +311,21 @@ class TestBuyersGuidePageRelatedArticles(BuyersGuideTestCase):
         )
 
     def test_get_hero_featured_article(self):
-        pass
+        article_page = buyersguide_factories.BuyersGuideArticlePageFactory.create(
+            parent=self.content_index,
+        )
+        self.bg.hero_featured_article = article_page
+
+        result = self.bg.get_hero_featured_article()
+
+        self.assertEqual(result, article_page)
 
     def test_get_hero_featured_article_not_set(self):
-        pass
+        self.bg.hero_featured_article = None
+
+        result = self.bg.get_hero_featured_article()
+
+        self.assertIsNone(result)
 
     def test_get_hero_featured_article_non_default_locale(self):
         pass

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -328,7 +328,19 @@ class TestBuyersGuidePageRelatedArticles(BuyersGuideTestCase):
         self.assertIsNone(result)
 
     def test_get_hero_featured_article_non_default_locale(self):
-        pass
+        article_page = buyersguide_factories.BuyersGuideArticlePageFactory(
+            parent=self.content_index,
+        )
+        self.bg.hero_featured_article = article_page
+        self.bg.save()
+        self.synchronize_tree()
+        buyersguide_homepage_fr = self.bg.get_translation(self.fr_locale)
+        article_page_fr = article_page.get_translation(self.fr_locale)
+        self.activate_locale(self.fr_locale)
+
+        result = buyersguide_homepage_fr.get_hero_featured_article()
+
+        self.assertEqual(result, article_page_fr)
 
     def test_get_hero_supporting_articles(self):
         pass

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -10,7 +10,7 @@ from networkapi.wagtailpages.pagemodels.buyersguide.products import (
     ProductPageCategory,
     BuyersGuideProductCategory,
 )
-from networkapi.wagtailpages.tests.buyersguide.base import BuyersGuideTestMixin
+from networkapi.wagtailpages.tests.buyersguide.base import BuyersGuideTestCase
 
 
 class TestFactories(TestCase):
@@ -135,7 +135,7 @@ class BuyersGuideViewTest(TestCase):
 # Use dummy caching for BuyersGuide URLs.
 @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})
 @override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
-class TestBuyersGuidePage(BuyersGuideTestMixin):
+class TestBuyersGuidePage(BuyersGuideTestCase):
 
     def test_buyersguide_url(self):
         self.assertEqual(self.bg.slug, 'privacynotincluded')
@@ -302,7 +302,7 @@ class TestBuyersGuidePage(BuyersGuideTestMixin):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(cta, response.context['featured_cta'])
 
-class TestBuyersGuidePageRelatedArticles(BuyersGuideTestMixin):
+class TestBuyersGuidePageRelatedArticles(BuyersGuideTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -343,10 +343,28 @@ class TestBuyersGuidePageRelatedArticles(BuyersGuideTestCase):
         self.assertEqual(result, article_page_fr)
 
     def test_get_hero_supporting_articles(self):
-        pass
+        articles = []
+        for i in range(1, 4):
+            article = buyersguide_factories.BuyersGuideArticlePageFactory(
+                parent=self.content_index,
+            )
+            buyersguide_factories.BuyersGuidePageHeroSupportingArticleRelationFactory(
+                page=self.bg,
+                article=article,
+                sort_order=i,
+            )
+            articles.append(article)
+
+        result = self.bg.get_hero_supporting_articles()
+
+        self.assertQuerysetEqual(qs=result, values=articles)
 
     def test_get_hero_supporting_articles_not_set(self):
-        pass
+        articles = []
+
+        result = self.bg.get_hero_supporting_articles()
+
+        self.assertQuerysetEqual(qs=result, values=articles)
 
     def test_get_hero_supporting_articles_non_default_locale(self):
         pass

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -431,3 +431,35 @@ class TestBuyersGuidePageRelatedArticles(BuyersGuideTestCase):
         result = buyersguide_homepage_fr.get_featured_articles()
 
         self.assertQuerysetEqual(qs=result, values=articles_fr)
+
+    def test_get_featured_advice_article(self):
+        article_page = buyersguide_factories.BuyersGuideArticlePageFactory.create(
+            parent=self.content_index,
+        )
+        self.bg.featured_advice_article = article_page
+
+        result = self.bg.get_featured_advice_article()
+
+        self.assertEqual(result, article_page)
+
+    def test_get_featured_advice_article_not_set(self):
+        self.bg.featured_advice_article = None
+
+        result = self.bg.get_featured_advice_article()
+
+        self.assertIsNone(result)
+
+    def test_get_featured_advice_article_non_default_locale(self):
+        article_page = buyersguide_factories.BuyersGuideArticlePageFactory(
+            parent=self.content_index,
+        )
+        self.bg.featured_advice_article = article_page
+        self.bg.save()
+        self.synchronize_tree()
+        buyersguide_homepage_fr = self.bg.get_translation(self.fr_locale)
+        article_page_fr = article_page.get_translation(self.fr_locale)
+        self.activate_locale(self.fr_locale)
+
+        result = buyersguide_homepage_fr.get_featured_advice_article()
+
+        self.assertEqual(result, article_page_fr)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -302,6 +302,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(cta, response.context['featured_cta'])
 
+
 class TestBuyersGuidePageRelatedArticles(BuyersGuideTestCase):
     @classmethod
     def setUpTestData(cls):

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
@@ -12,10 +12,10 @@ from networkapi.wagtailpages.pagemodels.buyersguide.products import (
     ProductPageCategory,
     BuyersGuideProductCategory,
 )
-from networkapi.wagtailpages.tests.buyersguide.base import BuyersGuideTestMixin
+from networkapi.wagtailpages.tests.buyersguide.base import BuyersGuideTestCase
 
 
-class TestProductPage(BuyersGuideTestMixin):
+class TestProductPage(BuyersGuideTestCase):
 
     def setUp(self):
         super().setUp()
@@ -458,7 +458,7 @@ class TestProductPage(BuyersGuideTestMixin):
 
 
 @override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
-class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestMixin):
+class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestCase):
 
     def test_successful_vote(self):
         product_page = self.product_page


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
This PR sets the different fields on the Buyer's Guide homepage to be synchronized with the original version of the page. 
Actually, we would prefer them to be translated (which means they would always point to the translated version of an object automatically). 
But, there are two bugs in Wagtail Localize that prevent this. 
Specifically: 
* https://github.com/wagtail/wagtail-localize/issues/430, and
* https://github.com/wagtail/wagtail-localize/issues/640

As a workaround, we can use synchronized fields. The caveat is that we need to make sure that we still point to the translated/localized version of the articles in the frontend. 
To handle this, I have added/adjusted the getter methods for the different field. 

To test that the synchronization works:
1. Login to the admin
2. Navigate to the edit view of the **french** version of the buyer's guide homepage. 
3. Click the "translate this page" button.
4. Check the "french" locale tickbox and click the "submit" button.
1. Open the **french** version of the buyer's guide homepage: http://localhost:8000/fr/privacynotincluded/
4. See the titles of the different featured articles (hero, hero supporting, advice, popular)
5. Navigate to the edit view of the **english** version of the buyer's guide homepage. 
6. Pick different pages for the related links and publish the **english** page.
7. Synchronize the buyer's guide homepage translation (in the tree view click the "more" button)  <img width="200" alt="Screen Shot 2022-11-04 at 17 01 56" src="https://user-images.githubusercontent.com/24797493/200091345-eeda29b7-f8da-44b9-9ca9-ce0d7af684aa.png">7. 
8. Synchronize and publish the translations.8. 
9. Reload the **french** version of the buyer's guide homepage: http://localhost:8000/fr/privacynotincluded/
10. Observe that the featured articles should be updated according to the changes you have made.

Test that the localization works: 
1. Open the translated version of the buyer's guide homepage: http://localhost:8000/fr/privacynotincluded/
2. Follow the related articles links and notice that the active locale is still the translated one (you can notice this in the URL -- if you started with `http://localhost:8000/fr/privacynotincluded/` you should still see the `fr/` bit in the URL.

Link to sample test page: http://localhost:8000/fr/privacynotincluded/
Related PRs/issues: #9415

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~ No migrations.
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [x] Is my code documented? Through tests.
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
