### PR TITLE
9595 -Menu shaking when product grid reaches top of screen

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -54,7 +54,7 @@
   <div class="tw-container">
     <div class="tw-row">
       <div class="tw-w-full">
-        <div id="sticky-bar" class="creepiness-slider bg-white text-center tw-justify-center creep-o-meter-moved search-active tw-hidden">
+        <div id="sticky-bar" class="creepiness-slider bg-white text-center tw-justify-center creep-o-meter-moved search-active tw-opacity-0 tw-select-none">
           <div class="creep-o-meter-information">
             <p class="speech-bubble-container">
               <span class="speech-bubble tw-bg-gradient-to-t tw-from-purple-05 tw-to-blue-05">

--- a/source/js/buyers-guide/homepage-c-slider.js
+++ b/source/js/buyers-guide/homepage-c-slider.js
@@ -174,9 +174,9 @@ export default {
             productListPosition.top + offset < window.innerHeight &&
             productListPosition.bottom >= 0
           ) {
-            SEARCH_BAR.classList.remove("tw-hidden");
+            SEARCH_BAR.classList.remove("tw-opacity-0", "tw-select-none");
           } else {
-            SEARCH_BAR.classList.add("tw-hidden");
+            SEARCH_BAR.classList.add("tw-opacity-0", "tw-select-none");
             document.querySelector(".speech-bubble>.text").innerHTML = heroMsg;
             face.style.backgroundPositionY = `0px`;
           }


### PR DESCRIPTION
# Description

Looks like the creepy-face is causing the screen shaking when transitioning to `display: none` we can get a similar effect by changing the user-select and opacity.

Link to sample test page: pni homepage
Related PRs/issues: #9595 

