### PR TITLE
9613 Remove news updates count limit

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -155,9 +155,7 @@
       {% with product_updates=product.updates.all  %}
         {% if product_updates %}
           <div class="tw-col-span-full medium:tw-col-span-1 large:tw-row-span-2">
-            <div class="tw-max-w-[410px] tw-mb-5">
-              {% include "fragments/buyersguide/dive_deeper.html" with updates=product_updates %}
-            </div>
+            {% include "fragments/buyersguide/dive_deeper.html" with updates=product_updates %}
           </div>
         {% endif %}
       {% endwith %}

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -151,10 +151,10 @@
       </div>
     </div>
 
-    <div class="tw-container tw-mt-7 tw-grid tw-grid-cols-1 medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-gap-7">
+    <div class="tw-container tw-mt-7 tw-grid tw-grid-cols-1 medium:tw-grid-cols-2 large:tw-grid-cols-3 tw-grid-rows-3 medium:tw-grid-rows-2 large:tw-grid-rows-[min-content_1fr] tw-gap-7">
       {% with product_updates=product.updates.all  %}
         {% if product_updates %}
-          <div class="tw-col-span-full medium:tw-col-span-1">
+          <div class="tw-col-span-full medium:tw-col-span-1 large:tw-row-span-2">
             <div class="tw-max-w-[410px] tw-mb-5">
               {% include "fragments/buyersguide/dive_deeper.html" with updates=product_updates %}
             </div>

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -871,6 +871,7 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
                 InlinePanel('updates', label='Update', max_num=7)
             ],
             heading='News Links',
+            classname='collapsible',
         ),
         MultiFieldPanel(
             [

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -868,7 +868,7 @@ class ProductPage(AirtableMixin, FoundationMetadataPageMixin, Page):
         ),
         MultiFieldPanel(
             [
-                InlinePanel('updates', label='Update', max_num=7)
+                InlinePanel('updates', label='Update')
             ],
             heading='News Links',
             classname='collapsible',


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

This PR removes the maximum limit of news updates that can be added to a product page. 
This was apparently not a required limit and is not removed. 

This PR also slightly adjusts how the grid rows are handled in the "related" section of the product page so that the "what to read next" and the "related products" sections float at the top of the grid regardless of the news updates / dive deeper section being expanded or not. (This change is only needed for the desktop layout, and would not be visible on mobile or tablet screens). 


Link to sample test page: http://localhost:8000/en/privacynotincluded/general-percy-product/
Related PRs/issues: #9613 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
