### PR TITLE
added use_wide_template flag to synchronized fields

### DIFF
--- a/network-api/networkapi/mozfest/models.py
+++ b/network-api/networkapi/mozfest/models.py
@@ -108,6 +108,8 @@ class MozfestPrimaryPage(FoundationMetadataPageMixin, FoundationBannerInheritanc
         TranslatableField('intro'),
         TranslatableField('signup'),
         TranslatableField('body'),
+        # Settings tab fields
+        SynchronizedField('use_wide_template'),
     ]
 
     def get_template(self, request):


### PR DESCRIPTION
# Description

This PR adds the wide_template_flag field as a `SynchronizedField` to the `MozfestPrimaryPage` model, that way this field's setting can remain consistent across translations if the user clicks "Sync All Translations".


Link to sample test page:
Related PRs/issues: #9645 


# Steps to test

1. Check this branch out and run inv new-db
2. Select any page underneath Mozfest (Eg: Spaces),  and create a French translation for it.
3. Make an update to the `use_wide_template` field in the English page, and publish.
4. Take a look at both pages, note that the change has not carried over to the french version of the page.
5. Go back to the CMS, select your page, and click "sync all translations".
6. Take a look at both pages, and note that the change is now carried over.
7. If everything is looking as expected, testing is complete! 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
