### PR TITLE
updated margins to align better

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/dive_deeper.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/dive_deeper.html
@@ -1,6 +1,6 @@
 {% load static wagtailcore_tags i18n %}
 
-<div id="dive-deeper">
+<div id="dive-deeper" class="large:tw-mt-2">
     {% include "./wavy_line.html" %}
     <h2 class="tw-h3-heading tw-mt-2">{% trans "Dive Deeper" %}</h2>
 

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -173,7 +173,7 @@
           <div class="tw-col-span-full medium:tw-col-span-2 large:tw-col-start-2">
             <div class="tw-flex tw-flex-col medium:tw-items-center large:tw-items-baseline medium:tw-flex-row-reverse medium:tw-gap-5">
               {% include "fragments/buyersguide/wavy_line.html" %}
-              <h2 class="tw-h3-heading tw-mt-2 tw-shrink-0">{% trans "Related products" %}</h2>
+              <h2 class="tw-h3-heading tw-mt-2 large:tw-mt-0 tw-shrink-0">{% trans "Related products" %}</h2>
             </div>
             <div class="tw-grid tw-grid-cols-2 medium:tw-grid-cols-4 tw-gap-6">
               {% for related_product_page in related_products  %}


### PR DESCRIPTION
# Description
Related PRs/issues: #9604 

<!-- Describe the PR here -->
This PR updates some of the margins for the headings of the "Dive Deeper", "What to read next" and "Related Products" Section. 

As mentioned in the ticket, they previously were not aligning too well:
![image](https://user-images.githubusercontent.com/18314510/200969595-fb996aba-32c8-4341-afb8-3f46704f9d4c.png)


# Screenshots 
**With "What to read next" Section (Large):**
![Screenshot 2022-11-09 at 16-13-30 Privacy Not Included review Yeah security deep really](https://user-images.githubusercontent.com/18314510/200969675-2e46c4b7-9655-48e4-a9f0-b001144a99a2.png)

**With "What to read next" Section (Medium):**
<img width="600" alt="Screen Shot 2022-11-08 at 2 36 02 PM" src="https://user-images.githubusercontent.com/18314510/200969682-7e744254-27c6-4909-8fac-1c41f578b600.png">


**Without "What to read next" Section (Large):**
![Screenshot 2022-11-09 at 16-14-28 Privacy Not Included review Yeah security deep really](https://user-images.githubusercontent.com/18314510/200969771-a58bcd3a-7de4-4963-80e8-9057ce17173f.png)

**Without "What to read next" Section (Medium):**
<img width="600" alt="Screen Shot 2022-11-08 at 2 36 02 PM" src="https://user-images.githubusercontent.com/18314510/200969776-1601a59d-6a58-4266-a84d-9d03ebd168c0.png">


# Steps to test

1. Check this branch out, and run `inv new-db`
2. Visit any PNI product page
3. Take a look at the sections pictured above
4. If everything looks as expected, testing is complete! 
