### PR TITLE
Homepage extra margin removal

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/home.html
+++ b/network-api/networkapi/templates/pages/buyersguide/home.html
@@ -27,7 +27,7 @@
       {% endif %}
     {% endwith %}
 
-    <div class="tw-container tw-my-6">
+    <div class="tw-container">
       <div class="tw-row">
         {% with row_item_classes="tw-px-4 tw-w-full large:tw-w-1/3 tw-py-5 large:tw-py-0" %}
 


### PR DESCRIPTION
# Description

Small fix to account for not including some of the extra homepage content

Removing this extra margin
![image](https://user-images.githubusercontent.com/2374073/200974533-c3b696b8-1788-48d5-852f-2d9ea76cb92a.png)
