### PR TITLE
9672 Set up formatting of Python with black

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -91,6 +91,9 @@ jobs:
           python network-api/manage.py compilemessages
       - name: Run linting
         run: flake8 tasks.py network-api/
+      - name: Run format check
+        run: black . --check
+        continue-on-error: true
       - name: Run type checks
         run: mypy network-api
       - name: Run Tests

--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ Check available commands with `inv -l`.
 
 ### Formatting
 
-If `inv lint` shows linting errors for either JS/JSX or CSS/SCSS, you can run `inv format` for fix style issues.
-`inv format` should automatically fix most formatting issues in JS and CSS files.
+If `inv lint` shows linting errors you can try running `inv format` to fix style issues.
+`inv format` should automatically fix most formatting issues.
+
+There might be some linting issues that can not be fixed automatically.
 
 ## Testing
 

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,4 +1,5 @@
 -c requirements.txt
+black
 coveralls
 django-debug-toolbar
 flake8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,8 @@ asgiref==3.5.0
     # via
     #   -c requirements.txt
     #   django
+black==22.10.0
+    # via -r dev-requirements.in
 certifi==2021.10.8
     # via
     #   -c requirements.txt
@@ -21,6 +23,8 @@ charset-normalizer==2.0.12
     # via
     #   -c requirements.txt
     #   requests
+click==8.1.3
+    # via black
 coverage==5.5
     # via coveralls
 coveralls==3.2.0
@@ -50,7 +54,13 @@ mccabe==0.6.1
 mypy==0.971
     # via -r dev-requirements.in
 mypy-extensions==0.4.3
-    # via mypy
+    # via
+    #   black
+    #   mypy
+pathspec==0.10.1
+    # via black
+platformdirs==2.5.3
+    # via black
 ptvsd==4.3.2
     # via -r dev-requirements.in
 pycodestyle==2.7.0
@@ -79,7 +89,9 @@ sqlparse==0.4.2
     #   django
     #   django-debug-toolbar
 tomli==2.0.1
-    # via mypy
+    # via
+    #   black
+    #   mypy
 types-python-slugify==6.1.0
     # via -r dev-requirements.in
 types-requests==2.28.3
@@ -87,7 +99,9 @@ types-requests==2.28.3
 types-urllib3==1.26.16
     # via types-requests
 typing-extensions==4.3.0
-    # via mypy
+    # via
+    #   black
+    #   mypy
 urllib3[secure]==1.26.8
     # via
     #   -c requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 119
+target-version = ['py39']

--- a/tasks.py
+++ b/tasks.py
@@ -321,7 +321,20 @@ def lint_js(ctx):
 @task
 def lint_python(ctx):
     """Run python linting."""
+    flake8(ctx)
+    black_check(ctx)
+
+
+@task
+def flake8(ctx):
+    """Run flake8."""
     pyrun(ctx, "flake8 tasks.py network-api")
+
+
+@task
+def black_check(ctx):
+    """Run black code formatter in check mode."""
+    black(ctx, ". --check")
 
 
 # Formatting
@@ -342,6 +355,19 @@ def format_css(ctx):
 def format_js(ctx):
     """Run javascript formatting."""
     npm(ctx, "run fix:js")
+
+
+@task
+def format_python(ctx):
+    """Run python formatting."""
+    black(ctx)
+
+
+@task(help={"args": "Override the arguments passed to black."})
+def black(ctx, args=None):
+    """Run black code formatter."""
+    args = args or "."
+    pyrun(ctx, command=f"black {args}")
 
 
 # Translation

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,4 @@
 [flake8]
 exclude=*migrations*
+extend-ignore = E203
 max-line-length=119


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

We are already using code formatting for SCSS and JavaScript. 
But, we have not been formatting our Python code consistently. 

This PR adds the [`black` code formatter](https://black.readthedocs.io/en/stable/index.html) for Python code. 
To make it easy to check if the code base is formatted correctly and fix issues, `inv` tasks are added for both cases. 

CI is adjusted to run the formatting check but it is allowed to fail. 
The actual formatting of the codebase will be done in a follow up PR. 
This is, to make it easier to review these changes here. 
The follow up PR will format the entire codebase and require correct formatting in CI.

There are editor integrations for pretty much all the relevant editors: https://black.readthedocs.io/en/stable/integrations/editors.html#visual-studio-code

This PR should only be merged once #9677 is merged into `main` because it is based on those changes.

Related PRs/issues: #9672 #9677

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [x] Did I update the READMEs or wagtail documentation?
