### PR TITLE
Center the image vertically in an image teaser block

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_teaser_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_teaser_block.html
@@ -13,7 +13,7 @@
           </a>
         {% endif %}
       </div>
-      <div>
+      <div class="tw-flex tw-items-center">
         {% image card.image fill-540x305-c100 format-jpeg as img %}
         <img src="{{ img.url }}" alt="{{ card.altText }}" class="tw-w-full" width="{{ img.width|unlocalize }}" height="{{ img.height|unlocalize }}">
       </div>


### PR DESCRIPTION
Resolves #9621 

Before:
![image-teaser-before](https://user-images.githubusercontent.com/27112/201904791-c0432cfc-22e7-422e-9992-93b7468f91c1.png)

After:
![image-teaser-after](https://user-images.githubusercontent.com/27112/201904797-9d415d39-41d7-4e45-819f-771e0105b9b9.png)
