### PR TITLE
update topic choices to default locale (english)

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog_topic.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog_topic.py
@@ -8,6 +8,7 @@ from wagtail.snippets.models import register_snippet
 from networkapi.wagtailpages.pagemodels.customblocks.base_rich_text_options import (
     base_rich_text_options,
 )
+from networkapi.wagtailpages.utils import get_default_locale
 
 
 @register_snippet
@@ -48,7 +49,11 @@ class BlogPageTopic(TranslatableMixin, models.Model):
 
     @classmethod
     def get_topics(cls):
-        choices = [(topic.name, topic.name) for topic in BlogPageTopic.objects.all().order_by("name")]
+        (DEFAULT_LOCALE, DEFAULT_LOCALE_ID) = get_default_locale()
+        choices = [
+            (topic.name, topic.name)
+            for topic in BlogPageTopic.objects.filter(locale_id=DEFAULT_LOCALE_ID).order_by("name")
+        ]
         choices.insert(0, ("All", "All"))
         return choices
 


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page:
Related PRs/issues: Issue:#8224, PR:#9493

This PR provides a hotfix, as while the previous PR did make sure that the choices were dynamic, the list wass pulling in topics of all locales:
<img width="1941" alt="Screenshot 2022-11-15 at 10 49 03 AM" src="https://user-images.githubusercontent.com/18314510/202008584-9865e5dd-975f-4a65-9097-8b66000bea7d.png">


This PR updates the list to only show topics of the default/original locale, which is English:
<img width="1941" alt="Screenshot 2022-11-15 at 10 51 04 AM" src="https://user-images.githubusercontent.com/18314510/202008667-9acfe652-9b06-4ef0-9a07-ba3b835f1708.png">


# Steps to test

1. Check out this branch and run inv copy-prod-db
2. Visit any page that is using the "recent_blog_entries" block, or create your own
3. Take a look at the choices, only English topics should be shown
4. If you would like to test further, make a new Topic snippet and revisit the list of choices, it should include the new topic.


# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
