### PR TITLE
9697 Remove top space above product tab header

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/product_tab_header.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/product_tab_header.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags bg_selector_tags l10n i18n localization static %}
 
 {% with tab_class="tw-bg-white tw-text-black tw-font-zilla tw-text-3xl tw-py-2 tw-px-5 tw-flex tw-justify-center tw-items-center medium:tw-flex-1 tw-shrink-0 tw-text-center tw-relative tw-cursor-pointer tw-ease-in tw-transform tw-duration-150 medium:tw-w-auto" %}
-    <div id="product-tab-group" class="tw-bg-white tw-px-4 medium:tw-px-6 tw-flex tw-border-b-4 tw-justify-center tw-mb-7 tw-no-scrollbar tw-overflow-auto tw-sticky medium:tw-static tw-top-[52px] tw-z-[1000] tw--mx-4 medium:tw--mx-6">
+    <div id="product-tab-group" class="tw-bg-white tw-px-4 medium:tw-px-6 tw-flex tw-border-b-4 tw-justify-center tw-mb-7 tw-no-scrollbar tw-overflow-auto tw-sticky medium:tw-static tw-top-0 tw-z-[1000] tw--mx-4 medium:tw--mx-6">
         <!-- Need this span for x-scrolling on smaller devices so the first tab doesn't get cut off -->
         <span class="tw-py-2 tw-px-7 medium:tw-flex-1 tw-shrink-0 tw-relative medium:tw-w-auto  tw-w-[100px] tw-opacity-0 small:tw-hidden">mobile</span>
         <span


### PR DESCRIPTION
# Description

This PR removed the top space above the tab header on the product page. 
Before, page text was visible above the tab header when scrolling down. 
This probably has something to do with the category navigation not being sticky to the top on product pages. 

Link to sample test page: http://localhost:8000/en/privacynotincluded/general-percy-product/
Related PRs/issues: #9697 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~ No migrations added. 
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
