### PR TITLE
9540 positioning of related articles on category page

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/category_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/category_page.html
@@ -25,27 +25,32 @@
                 </div>
               </div>
             </div>
-
           </div>
         {% endif %}
       {% endwith %}
 
+    {% endfor %}
+
+    {% if featured_cta %}
+      {% comment %}
+        We render the featured CTA only once into the markup if one exists.
+        The categories only have a toggle to define if the featured CTA should be shown when the page is filtered for the category.
+        The "current category" is the one the page is first loaded with. We show the CTA immediately if that category would, otherwise the CTA is initially hidden.
+        JS needs to handle the show and hide of the CTA when the active category is changed with JS. The data attribute contains the information for which categories the CTA should be shown.
+      {% endcomment %}
       <div
-      class="
-        {% if category != current_category %}
-          d-none
-        {% endif %}
-      "
-      >
+        class="{% if not current_category.show_cta %} d-none {% endif %}"
+        data-show-for-categories="{% for category in categories %}{% if category.show_cta %}{{ category.name }}, {% endif %}{% endfor %}"
+        >
         {% with cta=featured_cta %}
-          {% if current_category.show_cta %}
-            {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
-          {% endif %}
+          {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
         {% endwith %}
       </div>
+    {% endif %}
 
+    {% block extra_product_box_list_items %}
 
-    {% endfor %}
+    {% endblock extra_product_box_list_items %}
 
     {{ block.super }}
 

--- a/network-api/networkapi/templates/pages/buyersguide/category_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/category_page.html
@@ -4,76 +4,75 @@
 {% block body_id %}{{ category.slug }}{% endblock %}
 
 {% block guts %}
-  {% with editorial_content_index=page.get_editorial_content_index  %}
-    {% for category in categories  %}
-      {% with primary_related_articles=category.get_primary_related_articles  %}
-        {% comment %}
-          JS needs to handle the visibility switch for the related articles from one to the other category.
-        {% endcomment %}
-        {% if primary_related_articles %}
-          <div
-            class="
-              {% if category != current_category %}
-                d-none
-              {% endif %}
-            "
-          >
-            <div class="tw-container">
-              <div class="tw-row">
-                <div id="category-primary-related-articles" class="tw-w-full tw-px-4">
-                  {% include "fragments/buyersguide/related_reading.html" with articles=primary_related_articles index_page=editorial_content_index %}
-                </div>
-              </div>
-            </div>
-          </div>
-        {% endif %}
-      {% endwith %}
 
-    {% endfor %}
+  {{ block.super }}
 
-    {% if featured_cta %}
+  {% for category in categories  %}
+    {% with secondary_related_articles=category.get_secondary_related_articles  %}
       {% comment %}
-        We render the featured CTA only once into the markup if one exists.
-        The categories only have a toggle to define if the featured CTA should be shown when the page is filtered for the category.
-        The "current category" is the one the page is first loaded with. We show the CTA immediately if that category would, otherwise the CTA is initially hidden.
-        JS needs to handle the show and hide of the CTA when the active category is changed with JS. The data attribute contains the information for which categories the CTA should be shown.
+        JS needs to handle the visibility switch for the related articles from one to the other category.
       {% endcomment %}
-      <div
-        class="{% if not current_category.show_cta %} d-none {% endif %}"
-        data-show-for-categories="{% for category in categories %}{% if category.show_cta %}{{ category.name }}, {% endif %}{% endfor %}"
+      {% if secondary_related_articles %}
+        <div
+          id="category-secondary-related-articles"
+          class="
+            {% if category != current_category %}
+              tw-hidden
+            {% endif %}
+            tw-container
+            tw-my-7
+          "
         >
-        {% with cta=featured_cta %}
-          {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
-        {% endwith %}
-      </div>
-    {% endif %}
-
-    {% block extra_product_box_list_items %}
-
-    {% endblock extra_product_box_list_items %}
-
-    {{ block.super }}
-
-    {% for category in categories  %}
-      {% with secondary_related_articles=category.get_secondary_related_articles  %}
-        {% comment %}
-          JS needs to handle the visibility switch for the related articles from one to the other category.
-        {% endcomment %}
-        {% if secondary_related_articles %}
-          <div
-            id="category-secondary-related-articles"
-            class="
-              {% if category != current_category %}
-                tw-hidden
-              {% endif %}
-              tw-container
-              tw-my-7
-            "
-          >
-            {% include "fragments/buyersguide/article_listing_what_to_read_next.html" with articles=secondary_related_articles index_page=editorial_content_index use_wide_above="medium" %}
-          </div>
-        {% endif %}
-      {% endwith %}
-    {% endfor %}
-  {% endwith %}
+          {% include "fragments/buyersguide/article_listing_what_to_read_next.html" with articles=secondary_related_articles index_page=page.get_editorial_content_index use_wide_above="medium" %}
+        </div>
+      {% endif %}
+    {% endwith %}
+  {% endfor %}
 {% endblock guts %}
+
+{% block extra_product_box_list_items %}
+  {% if featured_cta %}
+    {% comment %}
+      We render the featured CTA only once into the markup if one exists.
+      The categories only have a toggle to define if the featured CTA should be shown when the page is filtered for the category.
+      The "current category" is the one the page is first loaded with. We show the CTA immediately if that category would, otherwise the CTA is initially hidden.
+      JS needs to handle the show and hide of the CTA when the active category is changed with JS. The data attribute contains the information for which categories the CTA should be shown.
+    {% endcomment %}
+    <div
+      class="tw-col-span-2 tw-flex tw-flex-row tw-w-full {% if not current_category.show_cta %} tw-hidden {% endif %}"
+      data-show-for-categories="{% for category in categories %}{% if category.show_cta %}{{ category.name }}, {% endif %}{% endfor %}"
+      >
+      {% with cta=featured_cta %}
+        {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url %}
+      {% endwith %}
+    </div>
+  {% endif %}
+
+  {% for category in categories  %}
+    {% comment %}
+      Each category has it's own set of related articles.
+      So, for each category we render the full element into the markup.
+      If the category is also the "current_category" (the one that is active when the page is first loaded) we display the related articles immediately, otherwise the element is initially hidden.
+      JS needs to handle the visibility switch for the related articles from one to the other category. The data attribute contains the name of the category which the articles are related to.
+    {% endcomment %}
+    {% with primary_related_articles=category.get_primary_related_articles  %}
+      {% if primary_related_articles %}
+        <div
+          class="
+          tw-col-span-2
+          tw-col-start-1 medium:tw-col-start-2 large:tw-col-start-3
+          tw-row-start-3 large:tw-row-start-2
+          tw-flex
+          tw-flex-row
+          tw-w-full
+          tw-p-4
+          {% if category != current_category %} tw-hidden {% endif %}
+          "
+          data-show-for-category="{{ category.name }}"
+          >
+          {% include "fragments/buyersguide/related_reading.html" with articles=primary_related_articles index_page=page.get_editorial_content_index %}
+        </div>
+      {% endif %}
+    {% endwith %}
+  {% endfor %}
+{% endblock extra_product_box_list_items %}


### PR DESCRIPTION
# Description

This PR positions the related articles (and while we are at is also the featured CTA) in the product grid on the category page. 
The previously used position was only used for backend development and was never the intended position.

Which category is actively displayed on the page can be changed with JS. 
This PR does not consider that. 
The display of the CTA and the related articles are only considering the category that is active when the page is first loaded.
Information about for which category the CTA should be displayed and which related articles are associated with which category is added to markup with data attributes. 
This is where the JS can get that data from when it is implemented in #9541. 

Link to sample test page: http://localhost:8000/en/privacynotincluded/categories/entertainment/
Related PRs/issues: #9540

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [x] Is my code documented? I have added some comments where I think they are needed / appropriate. 
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
