### PR TITLE
Remove deprecate "delegated" option from volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
       - CHOKIDAR_INTERVAL=2000
     command: npm run watch
     volumes:
-      - .:/app:delegated
-      - node_modules:/app/node_modules/:delegated
-      - dockerpythonvenv:/app/dockerpythonvenv/:delegated
+      - .:/app
+      - node_modules:/app/node_modules/
+      - dockerpythonvenv:/app/dockerpythonvenv/
     depends_on:
       - backend
 
@@ -32,7 +32,7 @@ services:
       # We're only using this setting for local dev!
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
-      - postgres_data:/var/lib/postgresql/data/:delegated
+      - postgres_data:/var/lib/postgresql/data/
 
   backend:
     build:
@@ -45,8 +45,8 @@ services:
       - "8000:8000"
       - "8001:8001" # ptvsd port for debugging
     volumes:
-      - .:/app:delegated
-      - dockerpythonvenv:/app/dockerpythonvenv/:delegated
+      - .:/app
+      - dockerpythonvenv:/app/dockerpythonvenv/
     depends_on:
       - postgres
 


### PR DESCRIPTION
# Description

The `:delegated`  options for volume definitions is deprecated and has been removed from the documentation for `docker-compose.yml` files.

Your local setup should continue to work as before. 

See also:
* https://github.com/docker/for-mac/issues/5402
* https://docs.docker.com/compose/compose-file/#volumes

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
