### PR TITLE
Fetch before push in continuous deployment workflow

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -67,7 +67,7 @@ jobs:
       XSS_PROTECTION: True
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9.9
           cache: "pip"
@@ -136,7 +136,7 @@ jobs:
       XSS_PROTECTION: True
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9.9
           cache: "pip"
@@ -204,7 +204,7 @@ jobs:
       CSP_STYLE_SRC: "'self' 'unsafe-inline' https://code.cdn.mozilla.net https://fonts.googleapis.com https://platform.twitter.com"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9.9
           cache: "pip"

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test_node:
     name: Node CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       ALLOWED_HOSTS: localhost,mozfest.localhost,default-site.com,secondary-site.com
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
 
   test_wagtail:
     name: Wagtail CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       postgres:
         image: postgres:13.2
@@ -103,7 +103,7 @@ jobs:
 
   test_percy:
     name: Percy CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       postgres:
         image: postgres:13.2
@@ -168,7 +168,7 @@ jobs:
 
   test_integration:
     name: Integration testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       postgres:
         image: postgres:13.2

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -34,7 +34,9 @@ jobs:
             password $HEROKU_DEPLOYMENT_USER_API_TOKEN
           " > ~/.netrc
       - name: Deploy to staging
-        run: git push heroku main
+        run: |
+          git fetch heroku
+          git push heroku main
 
   ci-failure:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Currently the continuous deployment workflow is failing:
https://github.com/mozilla/foundation.mozilla.org/actions/runs/3527634554/jobs/5917171535#step:6:9

Git is rejecting the push because it is not aware of the contents of the remote repository. We need to "fetch first".

Typically you would have fetched or pulled when you first got the code, but this is not the case here were we have not interacted with the remote before. Thus we must fetch.


Related PRs/issues: #9215

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
