### PR TITLE
9540 Increase padding around related articles on category page

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/category_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/category_page.html
@@ -65,7 +65,7 @@
           tw-flex
           tw-flex-row
           tw-w-full
-          tw-p-4
+          tw-p-6
           {% if category != current_category %} tw-hidden {% endif %}
           "
           data-show-for-category="{{ category.name }}"


### PR DESCRIPTION
# Description

This PR increases the padding around relate articles on the Buyer's Guide category page. This is following QA feedback.

See: https://github.com/mozilla/foundation.mozilla.org/issues/9540


Link to sample test page: http://localhost:8000/en/privacynotincluded/categories/entertainment/
Related PRs/issues: #9540

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
