### PR TITLE
9541 - related articles on category page when category changes

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/category_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/category_page.html
@@ -9,12 +9,10 @@
 
   {% for category in categories  %}
     {% with secondary_related_articles=category.get_secondary_related_articles  %}
-      {% comment %}
-        JS needs to handle the visibility switch for the related articles from one to the other category.
-      {% endcomment %}
       {% if secondary_related_articles %}
         <div
           id="category-secondary-related-articles"
+          data-show-for-category="{{ category.name }}"
           class="
             {% if category != current_category %}
               tw-hidden
@@ -53,7 +51,6 @@
       Each category has it's own set of related articles.
       So, for each category we render the full element into the markup.
       If the category is also the "current_category" (the one that is active when the page is first loaded) we display the related articles immediately, otherwise the element is initially hidden.
-      JS needs to handle the visibility switch for the related articles from one to the other category. The data attribute contains the name of the category which the articles are related to.
     {% endcomment %}
     {% with primary_related_articles=category.get_primary_related_articles  %}
       {% if primary_related_articles %}

--- a/source/js/buyers-guide/search/member-functions.js
+++ b/source/js/buyers-guide/search/member-functions.js
@@ -235,3 +235,17 @@ export function toggleProductReviewView() {
     nav.classList.add("active");
   }
 }
+
+export function toggleCategoryRelatedArticles(category) {
+  const relatedArticles = document.querySelectorAll("[data-show-for-category]");
+
+  // Probably means we are on PNI homepage!
+  if (!relatedArticles) return;
+  [...relatedArticles].forEach((relatedArticle) => {
+    if (category === relatedArticle.dataset.showForCategory) {
+      relatedArticle.classList.remove("tw-hidden");
+    } else {
+      relatedArticle.classList.add("tw-hidden");
+    }
+  });
+}

--- a/source/js/buyers-guide/search/search-filter.js
+++ b/source/js/buyers-guide/search/search-filter.js
@@ -8,6 +8,7 @@ import {
   setupGoBackToAll,
   setupReviewLinks,
   toggleProductReviewView,
+  toggleCategoryRelatedArticles,
 } from "./member-functions.js";
 /**
  * ...
@@ -228,6 +229,7 @@ export class SearchFilter {
       .querySelector("#pni-category-dropdown-select")
       .classList.add("tw-hidden");
     toggleProductReviewView();
+    toggleCategoryRelatedArticles(category);
     Utils.showProductsForCategory(category);
     this.categoryTitle.value = category;
     Utils.sortProductCards();


### PR DESCRIPTION
# Description

Toggle correct related articles/what to read next sections when starting from the category pages.
Related PRs/issues: #9541 

Best to test with factory new DB vs prod/staging.

1. To to any /category/ page and refresh to make sure you are on the right template.
2. Click on any category filter
3. Observe different related articles showing based on category selected!