### PR TITLE
9608 - Author photos look a little pixelated

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/article_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/article_page.html
@@ -75,7 +75,7 @@
                   <img 
                     class="tw-rounded-full tw-border-2 tw-border-white tw-w-[75px] tw-h-[75px]"
                     src="{% image_url author_profile.image "fill-75x75" %}"
-                    srcset="{% image_url author_profile.image "fill-150x150" %} 2x"
+                    srcset="{% image_url author_profile.image "fill-150x150" %} 2x, {% image_url author_profile.image "fill-225x225" %} 3x"
                     alt="{{ author_profile.name }}"
                     title="{{ author_profile.name }}"
                   />

--- a/network-api/networkapi/templates/pages/buyersguide/article_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/article_page.html
@@ -72,7 +72,7 @@
             <div class="col-lg-8 tw-flex tw-py-4">
               {% if author_profile.image %}
                 <div class="tw-mr-4 tw-flex tw-items-start tw-flex-shrink-0">
-                  <img class="tw-rounded-full tw-border-2 tw-border-white" src="{% image_url author_profile.image "fill-75x75" %}" alt="{{ author_profile.name }}" title="{{ author_profile.name }}" />
+                  <img class="tw-rounded-full tw-border-2 tw-border-white tw-w-[75px] tw-h-[75px]" src="{% image_url author_profile.image "fill-225x225" %}" alt="{{ author_profile.name }}" title="{{ author_profile.name }}" />
                 </div>
               {% endif %}
               <div class="">

--- a/network-api/networkapi/templates/pages/buyersguide/article_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/article_page.html
@@ -72,7 +72,7 @@
             <div class="col-lg-8 tw-flex tw-py-4">
               {% if author_profile.image %}
                 <div class="tw-mr-4 tw-flex tw-items-start tw-flex-shrink-0">
-                  <img class="tw-rounded-full tw-border-2 tw-border-white tw-w-[75px] tw-h-[75px]" src="{% image_url author_profile.image "fill-225x225" %}" alt="{{ author_profile.name }}" title="{{ author_profile.name }}" />
+                  <img class="tw-rounded-full tw-border-2 tw-border-white tw-w-[75px] tw-h-[75px]" src="{% image_url author_profile.image "fill-150x150" %}" alt="{{ author_profile.name }}" title="{{ author_profile.name }}" />
                 </div>
               {% endif %}
               <div class="">

--- a/network-api/networkapi/templates/pages/buyersguide/article_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/article_page.html
@@ -72,7 +72,13 @@
             <div class="col-lg-8 tw-flex tw-py-4">
               {% if author_profile.image %}
                 <div class="tw-mr-4 tw-flex tw-items-start tw-flex-shrink-0">
-                  <img class="tw-rounded-full tw-border-2 tw-border-white tw-w-[75px] tw-h-[75px]" src="{% image_url author_profile.image "fill-150x150" %}" alt="{{ author_profile.name }}" title="{{ author_profile.name }}" />
+                  <img 
+                    class="tw-rounded-full tw-border-2 tw-border-white tw-w-[75px] tw-h-[75px]"
+                    src="{% image_url author_profile.image "fill-75x75" %}"
+                    srcset="{% image_url author_profile.image "fill-150x150" %} 2x"
+                    alt="{{ author_profile.name }}"
+                    title="{{ author_profile.name }}"
+                  />
                 </div>
               {% endif %}
               <div class="">


### PR DESCRIPTION
# Description

<img width="802" alt="image" src="https://user-images.githubusercontent.com/2374073/203880583-5be48af5-9808-40b2-8edc-ef779f532938.png">

Increased the author photo image (more then doubled) fill size so the profile pics would be less pixelated.

Best way to check is grabbing a high def stock photo from unsplash and applying it to an author photo on a pni article page

Related PRs/issues: #9608 
