### PR TITLE
9766 - Stop translating slugs on multiple pages

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/article_page.py
@@ -9,6 +9,7 @@ from wagtail.core import blocks, fields
 from wagtail.core import models as wagtail_models
 from wagtail.images import edit_handlers as image_panels
 from wagtail.snippets import edit_handlers as snippet_panels
+from wagtail_localize.fields import SynchronizedField, TranslatableField
 
 from networkapi.utility import orderables
 from networkapi.wagtailpages.pagemodels import customblocks
@@ -90,6 +91,22 @@ class BuyersGuideArticlePage(foundation_metadata.FoundationMetadataPageMixin, wa
         panels.PublishingPanel(),
         panels.FieldPanel("first_published_at"),
         panels.PrivacyModalPanel(),
+    ]
+
+    translatable_fields = [
+        # Content tab fields
+        TranslatableField("title"),
+        TranslatableField("body"),
+        SynchronizedField("hero_image"),
+        SynchronizedField("content_category_relations"),
+        SynchronizedField("related_article_relations"),
+        SynchronizedField("author_profile_relations"),
+        # Promote tab fields
+        SynchronizedField("slug"),
+        TranslatableField("seo_title"),
+        SynchronizedField("show_in_menus"),
+        TranslatableField("search_description"),
+        SynchronizedField("search_image"),
     ]
 
     def get_context(self, request: http.HttpRequest, *args, **kwargs) -> dict:

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/editorial_content_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/editorial_content_index.py
@@ -8,6 +8,7 @@ from wagtail.admin.edit_handlers import PageChooserPanel, InlinePanel
 from wagtail.core import models as wagtail_models
 from wagtail.core.models import Orderable, TranslatableMixin
 from wagtail.contrib.routable_page import models as routable_models
+from wagtail_localize.fields import SynchronizedField, TranslatableField
 
 from networkapi.wagtailpages.pagemodels.buyersguide.utils import (
     get_categories_for_locale,
@@ -44,6 +45,18 @@ class BuyersGuideEditorialContentIndexPage(
     ]
 
     items_per_page: int = 10
+
+    translatable_fields = [
+        # Content tab fields
+        TranslatableField("title"),
+        SynchronizedField("related_article_relations"),
+        # Promote tab fields
+        SynchronizedField("slug"),
+        TranslatableField("seo_title"),
+        SynchronizedField("show_in_menus"),
+        TranslatableField("search_description"),
+        SynchronizedField("search_image"),
+    ]
 
     def serve(self, request: "http.HttpRequest", *args, **kwargs) -> "http.HttpResponse":
         if request.htmx:

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
@@ -5,6 +5,7 @@ from wagtail import images as wagtail_images
 from wagtail.core import models as wagtail_models
 from wagtail.contrib.routable_page import models as routable_models
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail_localize.fields import SynchronizedField, TranslatableField
 
 from networkapi.wagtailpages import utils
 from networkapi.wagtailpages.pagemodels import profiles
@@ -32,6 +33,17 @@ class ResearchAuthorsIndexPage(
 
     content_panels = wagtail_models.Page.content_panels + [
         ImageChooserPanel("banner_image"),
+    ]
+
+    translatable_fields = [
+        # Content tab fields
+        SynchronizedField("banner_image"),
+        # Promote tab fields
+        SynchronizedField("slug"),
+        TranslatableField("seo_title"),
+        SynchronizedField("show_in_menus"),
+        TranslatableField("search_description"),
+        SynchronizedField("search_image"),
     ]
 
     def get_context(self, request):

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/library_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/library_page.py
@@ -9,6 +9,7 @@ from wagtail import images as wagtail_images
 from wagtail.admin import edit_handlers as panels
 from wagtail.images import edit_handlers as image_panels
 from wagtail.core import models as wagtail_models
+from wagtail_localize.fields import SynchronizedField, TranslatableField
 
 from networkapi.wagtailpages import utils
 from networkapi.wagtailpages.pagemodels import profiles as profile_models
@@ -71,6 +72,17 @@ class ResearchLibraryPage(research_base.ResearchHubBasePage):
         SORT_ALPHABETICAL.value: SORT_ALPHABETICAL,
         SORT_ALPHABETICAL_REVERSED.value: SORT_ALPHABETICAL_REVERSED,
     }
+
+    translatable_fields = [
+        # Content tab fields
+        TranslatableField("title"),
+        # Promote tab fields
+        SynchronizedField("slug"),
+        TranslatableField("seo_title"),
+        SynchronizedField("show_in_menus"),
+        TranslatableField("search_description"),
+        SynchronizedField("search_image"),
+    ]
 
     def get_context(self, request):
         search_query = request.GET.get("search", "")


### PR DESCRIPTION
Making sure [these slugs](https://pontoon.mozilla.org/fr/foundation-website-content/all-resources/?search=slug&status=translated) get removed from Pontoon