### PR TITLE
#9667 Set up `isort`

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on:
   push:
-    branches: ["main", "pni-2022"]
+    branches: ["main"]
     paths-ignore:
       - maintenance/**/*.*
   pull_request:
@@ -91,8 +91,11 @@ jobs:
           python network-api/manage.py compilemessages
       - name: Run linting
         run: |
-          flake8 tasks.py network-api/
+          flake8 .
           black . --check
+      - name: Run isort (allowed to fail)
+        run: isort . --check-only
+        continue-on-error: true
       - name: Run type checks
         run: mypy network-api
       - name: Run Tests

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -3,6 +3,7 @@ black
 coveralls
 django-debug-toolbar
 flake8
+isort
 mypy
 ptvsd
 types-python-slugify

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -49,6 +49,8 @@ idna==3.3
     #   -c requirements.txt
     #   requests
     #   urllib3
+isort==5.10.1
+    # via -r dev-requirements.in
 mccabe==0.6.1
     # via flake8
 mypy==0.971

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [tool.black]
 line-length = 119
 target-version = ['py39']
+
+[tool.isort]
+profile = "black"
+skip_glob = ["dockerpythonvenv/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,5 @@ target-version = ['py39']
 
 [tool.isort]
 profile = "black"
-skip_glob = ["dockerpythonvenv/*"]
+extend_skip = ["network-api/media", "network-api/staticfiles"]
+skip_gitignore = true

--- a/tasks.py
+++ b/tasks.py
@@ -320,6 +320,7 @@ def lint_python(ctx):
     """Run python linting."""
     flake8(ctx)
     black_check(ctx)
+    isort_check(ctx)
 
 
 @task
@@ -346,6 +347,7 @@ def format(ctx):
     """Run formatters."""
     format_css(ctx)
     format_js(ctx)
+    format_python(ctx)
 
 
 @task
@@ -364,6 +366,7 @@ def format_js(ctx):
 def format_python(ctx):
     """Run python formatting."""
     black(ctx)
+    isort(ctx)
 
 
 @task(help={"args": "Override the arguments passed to black."})

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,7 @@
 import os
 import re
 from sys import platform
+
 from invoke import task
 
 ROOT = os.path.dirname(os.path.realpath(__file__))
@@ -364,6 +365,13 @@ def black(ctx, args=None):
     """Run black code formatter."""
     args = args or "."
     pyrun(ctx, command=f"black {args}")
+
+
+@task(help={"args": "Override the arguments passed to isort."})
+def isort(ctx, args=None):
+    """Run isort code formatter."""
+    args = args or "."
+    pyrun(ctx, command=f"isort {args}")
 
 
 # Translation

--- a/tasks.py
+++ b/tasks.py
@@ -326,7 +326,7 @@ def lint_python(ctx):
 @task
 def flake8(ctx):
     """Run flake8."""
-    pyrun(ctx, "flake8 tasks.py network-api")
+    pyrun(ctx, "flake8 .")
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -334,6 +334,12 @@ def black_check(ctx):
     black(ctx, ". --check")
 
 
+@task
+def isort_check(ctx):
+    """Run isort code formatter in check mode."""
+    isort(ctx, ". --check-only")
+
+
 # Formatting
 @task
 def format(ctx):

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
-exclude=*migrations*
+extend-exclude=*migrations*,dockerpythonvenv/*,network-api/media/*,network-api/staticfiles/*
 extend-ignore = E203
 max-line-length=119


### PR DESCRIPTION
# Description

This PR adds the [isort](https://pycqa.github.io/isort/index.html) code formatter for consistent import sorting for Python and configures that all Python files are checked during CI. Currently the CI step is allowed to fail. It will be made mandatory with a follow-up PR that also formats all existing files.

This PR also adds `inv isort-check` and `inv isort` commands to run isort locally. These commands are also run then  `inv lint` or `inv format` are run respectively. 

This PR also configures which files `flake8` should ignore in the config. This makes it unnecessary to always specific the files to check on the command line and thus more reproducible and less error prone.

Related PRs/issues: #9667

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [x] Is my code documented? The commands have help strings.
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
