### PR TITLE
Added dependabot check to Percy CI

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -104,6 +104,7 @@ jobs:
 
   test_percy:
     name: Percy CI
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     services:
       postgres:


### PR DESCRIPTION
# Description
Lets try to add a check to not run percy when dependabots make a PR to save some screenshots on our free plan


