### PR TITLE
9709 - Fix lazy image loading + width/height attr

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/item.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/item.html
@@ -41,10 +41,12 @@
         srcset="{{ img_1x.url }} 1x, {{ img_2x.url}} 2x"
       >
       <img
-        class="product-thumbnail"
+        class="product-thumbnail tw-w-full"
         {% image product.image fill-600x600 as img %}
         loading="lazy"
         src="{{ img.url }}"
+        width="500"
+        height="500"
         alt="{% blocktrans with product=product.title %}link to {{product}}{% endblocktrans %}"
       >
     </picture>

--- a/network-api/networkapi/templates/fragments/buyersguide/item.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/item.html
@@ -45,8 +45,8 @@
         {% image product.image fill-600x600 as img %}
         loading="lazy"
         src="{{ img.url }}"
-        width="500"
-        height="500"
+        width="600"
+        height="600"
         alt="{% blocktrans with product=product.title %}link to {{product}}{% endblocktrans %}"
       >
     </picture>


### PR DESCRIPTION
# Description

Working on the image spike, after adding width/height to the element I reduced the numbered of images loaded on the homepage from the products from ~44 > 14. I had to play with the width/height values a bit.
```
<img
        class="product-thumbnail tw-w-full" <---- added class
        {% image product.image fill-600x600 as img %}
        loading="lazy"
        src="{{ img.url }}"
        width="500"     <---- added attr
        height="500"    <---- added attr
        alt="{% blocktrans with product=product.title %}link to {{product}}{% endblocktrans %}"
      >
 ```
The width and height are way higher then the image actually is because we just set the width to 100% but having the width/height attribute actually affects how loading="lazy" works. So by just adding these attrs we don't lose anything + we get no visual regressions. Increasing with width+height to a higher value then 500+ doesn't decrease the amount of images loaded which is strange.
I think if we want to get that 14 product images > 4 or less we should probably use a js implementation of lazy loading since with using the loading tag does not really give us control of the viewport threshold that is used to detect what gets loaded. But I am not sure that optimization is as high priority/high reward imo.
At the meantime, I am going to add this change as a PR since this is a small change without any setbacks or visual regressions I have found so far.

Link to sample test page: /en/privacynotincluded
Related PRs/issues: #9709 

