### PR TITLE
9545 product grid performance

### DIFF
--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -150,10 +150,19 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         response = self.client.get(self.bg.url)
         self.assertEqual(response.status_code, 200)
 
-    def test_serve(self):
+    def test_serve_page(self):
         response = self.client.get(self.bg.url)
 
         self.assertEqual(response.status_code, 200)
+
+    def test_serve_page_queries(self):
+        """Check queries with only 1 product existing."""
+        query_number_limit = 100
+
+        with self.assertNumQueries(query_number_limit):
+            response = self.client.get(self.bg.url)
+
+            self.assertEqual(response.status_code, 200)
 
     def about_url_test(self, view_name, target_url, template):
         url = self.bg.reverse_subpage(view_name)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -194,6 +194,21 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
 
             self.assertEqual(response.status_code, 200)
 
+    def test_serve_page_many_products_logged_in(self):
+        reseed(12345)
+        additional_products_count = 49
+        for _ in range(additional_products_count):
+            buyersguide_factories.ProductPageFactory(parent=self.bg)
+        products = ProductPage.objects.descendant_of(self.bg)
+        self.assertEqual(products.count(), additional_products_count + 1)
+        query_number = 966
+        self.client.force_login(user=self.create_test_user())
+
+        with self.assertNumQueries(query_number):
+            response = self.client.get(self.bg.url)
+
+            self.assertEqual(response.status_code, 200)
+
     def test_get_context_no_products(self):
         products = ProductPage.objects.descendant_of(self.bg)
         products.delete()

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -150,6 +150,11 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         response = self.client.get(self.bg.url)
         self.assertEqual(response.status_code, 200)
 
+    def test_serve(self):
+        response = self.client.get(self.bg.url)
+
+        self.assertEqual(response.status_code, 200)
+
     def about_url_test(self, view_name, target_url, template):
         url = self.bg.reverse_subpage(view_name)
         self.assertEqual(url, target_url)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth.models import AnonymousUser, User
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from wagtail.core.models import Locale, Page, Site
@@ -9,6 +9,7 @@ from networkapi.wagtailpages.pagemodels.base import Homepage
 from networkapi.wagtailpages.pagemodels.buyersguide.homepage import BuyersGuidePage
 from networkapi.wagtailpages.pagemodels.buyersguide.products import (
     BuyersGuideProductCategory,
+    ProductPage,
     ProductPageCategory,
 )
 from networkapi.wagtailpages.tests.buyersguide.base import BuyersGuideTestCase
@@ -145,6 +146,8 @@ class BuyersGuideViewTest(TestCase):
 @override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}})
 @override_settings(STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage")
 class TestBuyersGuidePage(BuyersGuideTestCase):
+    request_factory = RequestFactory()
+
     def test_buyersguide_url(self):
         self.assertEqual(self.bg.slug, "privacynotincluded")
         response = self.client.get(self.bg.url)
@@ -155,14 +158,76 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    def test_serve_page_queries(self):
-        """Check queries with only 1 product existing."""
-        query_number_limit = 100
+    def test_serve_page_no_products(self):
+        products = ProductPage.objects.descendant_of(self.bg)
+        products.delete()
+        self.assertEqual(products.count(), 0)
+        query_number = 156
 
-        with self.assertNumQueries(query_number_limit):
+        with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
 
             self.assertEqual(response.status_code, 200)
+
+    def test_serve_page_one_product(self):
+        products = ProductPage.objects.descendant_of(self.bg)
+        self.assertEqual(products.count(), 1)
+        query_number = 186
+
+        with self.assertNumQueries(query_number):
+            response = self.client.get(self.bg.url)
+
+            self.assertEqual(response.status_code, 200)
+
+    def test_serve_page_many_products(self):
+        additional_products_count = 49
+        for _ in range(additional_products_count):
+            buyersguide_factories.ProductPageFactory(parent=self.bg)
+        products = ProductPage.objects.descendant_of(self.bg)
+        self.assertEqual(products.count(), additional_products_count + 1)
+        query_number = 888
+
+        with self.assertNumQueries(query_number):
+            response = self.client.get(self.bg.url)
+
+            self.assertEqual(response.status_code, 200)
+
+    def test_get_context_no_products(self):
+        products = ProductPage.objects.descendant_of(self.bg)
+        products.delete()
+        self.assertEqual(products.count(), 0)
+        request = self.request_factory.get(self.bg.url)
+        request.user = AnonymousUser()
+        request.LANGUAGE_CODE = "en"
+        query_number = 4
+
+        with self.assertNumQueries(query_number):
+            self.bg.get_context(request=request)
+
+    def test_get_context_one_product(self):
+        products = ProductPage.objects.descendant_of(self.bg)
+        self.assertEqual(products.count(), 1)
+        request = self.request_factory.get(self.bg.url)
+        request.user = AnonymousUser()
+        request.LANGUAGE_CODE = "en"
+        query_number = 9
+
+        with self.assertNumQueries(query_number):
+            self.bg.get_context(request=request)
+
+    def test_get_context_many_products(self):
+        additional_products_count = 49
+        for _ in range(additional_products_count):
+            buyersguide_factories.ProductPageFactory(parent=self.bg)
+        products = ProductPage.objects.descendant_of(self.bg)
+        self.assertEqual(products.count(), additional_products_count + 1)
+        request = self.request_factory.get(self.bg.url)
+        request.user = AnonymousUser()
+        request.LANGUAGE_CODE = "en"
+        query_number = 89
+
+        with self.assertNumQueries(query_number):
+            self.bg.get_context(request=request)
 
     def about_url_test(self, view_name, target_url, template):
         url = self.bg.reverse_subpage(view_name)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -3,6 +3,7 @@ from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from wagtail.core.models import Locale, Page, Site
 
+from networkapi.utility.faker.helpers import reseed
 from networkapi.wagtailpages.factory import buyersguide as buyersguide_factories
 from networkapi.wagtailpages.factory.homepage import WagtailHomepageFactory
 from networkapi.wagtailpages.pagemodels.base import Homepage
@@ -180,12 +181,13 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             self.assertEqual(response.status_code, 200)
 
     def test_serve_page_many_products(self):
+        reseed(12345)
         additional_products_count = 49
         for _ in range(additional_products_count):
             buyersguide_factories.ProductPageFactory(parent=self.bg)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 888
+        query_number = 955
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -216,6 +218,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             self.bg.get_context(request=request)
 
     def test_get_context_many_products(self):
+        reseed(12345)
         additional_products_count = 49
         for _ in range(additional_products_count):
             buyersguide_factories.ProductPageFactory(parent=self.bg)
@@ -224,7 +227,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 89
+        query_number = 209
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test": "npm run lint",
     "watch": "wait-on http://backend:8000/cms && run-s build:clean && run-p build:js:dev build:common watch:**",
     "watch:images": "chokidar \"source/images/**/*\" -c \"npm run build:images\"",
-    "watch:sass": "chokidar \"source/**/*.scss\" \"**/*.html\" -c \"npm run build:sass\""
+    "watch:sass": "chokidar \"source/**/*.scss\" \"network-api/**/*.html\" -c \"npm run build:sass\""
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
# Description

This PR does not introduce any production code changes. 
However, it does add some tests for the buyer's guide homepage type to check the number of database queries that are generated under certain conditions. 
These test should be helpful tool in the future when trying to improve the performance of the buyer's guide homepage by reducing the number of queries needed to render the page. 


Link to sample test page: http://localhost:8000/en/privacynotincluded
Related PRs/issues: #9545 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~ No migrations added.
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [x] Is my code documented? Tests are self documenting. 
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
