### PR TITLE
updated z index of donate-banner

### DIFF
--- a/network-api/networkapi/templates/partials/banner.html
+++ b/network-api/networkapi/templates/partials/banner.html
@@ -1,7 +1,7 @@
 {% load settings_value i18n static %}
 
 {% with wrapper_class="tw-py-7" background_class="tw-bg-cover tw-bg-center" btn_class="tw-text-white tw-border-black tw-bg-blue-40 hover:tw-bg-blue-80 tw-shadow-black"%}
-<div class="donate-banner {{background_class}} tw-bg-[url(../_images/mozilla-donate-dear-internet-mobile.png)] large:tw-bg-[url(../_images/mozilla-donate-dear-internet.png)] {{wrapper_class}} print:tw-hidden tw-w-full tw-hidden">
+<div class="donate-banner tw-relative tw-z-20 {{background_class}} tw-bg-[url(../_images/mozilla-donate-dear-internet-mobile.png)] large:tw-bg-[url(../_images/mozilla-donate-dear-internet.png)] {{wrapper_class}} print:tw-hidden tw-w-full tw-hidden">
     <a href="#" 
        class="tw-p-4
               tw-box-content


### PR DESCRIPTION
# Description

Link to sample test page: http://localhost:8000/en/youtube/user-controls/
Related PRs/issues: #9784


# Screenshot of the bug
This PR is a hotfix to a bug found on the youtube/user-controls page, in which the locomotive scroll elements were overlapping the donate banner:
![Screenshot 2022-11-29 at 16-15-30 Does This Button Work Investigating YouTube’s ineffective user controls](https://user-images.githubusercontent.com/18314510/204676666-fa4cd117-4d6d-413d-b75d-64b54f83b894.png)





# Screenshot of hotfix
This PR updates the Z-Index of the donate banner so the content passes behind it:
![Screenshot 2022-12-02 at 14-50-17 Does This Button Work Investigating YouTube’s ineffective user controls](https://user-images.githubusercontent.com/18314510/205402748-c38eed06-17c4-4d1e-ab58-c676e831ead0.png)



However, as mentioned in the branch name this is a hotfix, and the expected behavior is to work the same as everywhere else on the site. (EX: Scrolls out of the way, but leaves the nav bar as sticky)


# Steps to test

1. Check this branch out and run `inv copy-stage-db`
2. Navigate to http://localhost:8000/en/youtube/user-controls/
3. Scroll down, and the page content should scroll behind the navbar/ donate banner
4. If desired, visit other pages on the site to make sure the donate banner is behaving as expected

