### PR TITLE
Revert "removed fundraise up script"

### DIFF
--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -42,6 +42,16 @@
       })(window,document,'script','dataLayer','GTM-MD3XGZ4');</script>
     {% endblock %}
 
+    {% block fundraiseup_script %}
+      <script nonce="{{ request.csp_nonce }}">(function(w,d,s,n,a){if(!w[n]){var l='call,catch,on,once,set,then,track'
+      .split(','),i,o=function(n){return'function'==typeof n?o.l.push([arguments])&&o
+      :function(){return o.l.push([n,arguments])&&o}},t=d.getElementsByTagName(s)[0],
+      j=d.createElement(s);j.async=!0;j.src='https://cdn.fundraiseup.com/widget/'+a;
+      t.parentNode.insertBefore(j,t);o.s=Date.now();o.v=4;o.h=w.location.href;o.l=[];
+      for(i=0;i<7;i++)o[l[i]]=o(l[i]);w[n]=o}
+      })(window,document,'script','FundraiseUp','ADCYPWMX');</script>
+    {% endblock %}
+    
     {% block commento_meta %}{% endblock %}
 
     {% block stylesheets %}


### PR DESCRIPTION
# Description 
Per request of Tyler, we have been asked to re-introduce the "Fundraise Up" Javascript snippet.
This PR reverts mozilla/foundation.mozilla.org#9796, which is the PR in which we **removed** the snippet code.

# Screenshots

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/18314510/203667729-5606bc5b-9f2d-4ccc-ac14-3f7234cfec85.png">

# Steps to test

1. Check this branch out
2. Update your CSP values in .env with the values found [here](https://help.fundraiseup.com/can-fundraise-up-be-used-on-a-site-with-a-csp)
3. Visit http://localhost:8000/en/?form=FUNWTEYJTEM and the Fundraiseup modal should render as expected!


