### PR TITLE
Pass language code to Tito widget

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
@@ -1,7 +1,10 @@
 {% extends "./base_streamfield_block.html" %}
+{% load i18n %}
+{% get_current_language as lang_code %}
+
 
 {% block block_content %}
     <script src='https://js.tito.io/v2' async></script>
 
-    <tito-button event="{{ value.event.event_id }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-4">{{ value.button_label }}</tito-button>
+    <tito-button event="{{ value.event.event_id }}" locale="{{ lang_code }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-4">{{ value.button_label }}</tito-button>
 {% endblock %}


### PR DESCRIPTION
# Description

This passes the current language to the Tito widget so it shows in the same language as the page.

There may be cases where the language code and value expected by Tito don't match, but for `en` and `es` which are the planned supported languages for now, this is not an issue.
