### PR TITLE
#9034 Apply Django template formatting with `djlint`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.html]
+indent_size = 4
+
 [*.py]
 indent_size = 4
 max_line_length = 119

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -94,9 +94,9 @@ jobs:
           flake8 .
           isort . --check-only
           black . --check
+          djlint . --check
       - name: Run HTML linting
         run: |
-          djlint . --check
           djlint . --lint
         continue-on-error: true
       - name: Run type checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ target-version = ['py39']
 [tool.djlint]
 profile = "django"
 use_gitignore = true
+format_attribute_template_tags = true
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,11 @@ line-length = 119
 target-version = ['py39']
 
 [tool.djlint]
+blank_line_before_tag="load,extends,include,block"
+blank_line_after_tag="load,extends,include,endblock"
+format_attribute_template_tags = true
 profile = "django"
 use_gitignore = true
-format_attribute_template_tags = true
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ line-length = 119
 target-version = ['py39']
 
 [tool.djlint]
-blank_line_before_tag="load,extends,include,block"
-blank_line_after_tag="load,extends,include,endblock"
+blank_line_before_tag="load,extends,include,include_block,block"
+blank_line_after_tag="load,extends,include,include_block,endblock"
 format_attribute_template_tags = true
 profile = "django"
 use_gitignore = true


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
This is a follow up PR to #9806. 

This PR sets activate the `djlint` format check for Django templates in CI.

Also, this also applies the `djlint` formatting to all templates in the repo.


Related PRs/issues: #9034 #9806

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
