### PR TITLE
Fix bug with featured_article_url

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/featured_article.html
@@ -32,7 +32,6 @@
         class="tw-w-full tw-aspect-video tw-rounded-xl tw-object-cover"
       />
     </a>
-    {% endwith %}
 
     <a
       href="{{ featured_article_url }}"
@@ -53,6 +52,7 @@
         {% endspaceless %}
       </div>
     </a>
+    {% endwith %}
 
     {% if supporting_articles %}
       <div id="supporting-articles" class="tw-col-span-full medium:tw-col-span-6 large:tw-col-span-5">


### PR DESCRIPTION
# Description

This is to fix a [bug](https://github.com/mozilla/foundation.mozilla.org/issues/9603#issuecomment-1346963720) I introduced in my previous PR where I had `endwith` too soon in the file and caused the variable `featured_article_url` to "die" too early.  

To test, go to `/privacynotincluded` and make sure the title of the featured article is linked to the article and not /privacynotincluded.

<!-- Describe the PR here -->

Link to sample test page: /privacynotincluded
Related PRs/issues: #9603

