### PR TITLE
Revert "Pass language code to Tito widget"

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
@@ -1,10 +1,7 @@
 {% extends "./base_streamfield_block.html" %}
-{% load i18n %}
-{% get_current_language as lang_code %}
-
 
 {% block block_content %}
     <script src='https://js.tito.io/v2' async></script>
 
-    <tito-button event="{{ value.event.event_id }}" locale="{{ lang_code }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-4">{{ value.button_label }}</tito-button>
+    <tito-button event="{{ value.event.event_id }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-4">{{ value.button_label }}</tito-button>
 {% endblock %}


### PR DESCRIPTION
Reverts mozilla/foundation.mozilla.org#9818

This work has been requested to be held from being pushed to production until we receive human translations. 

To prevent this ticket from keeping others getting pushed into prod, we are going to revert these changes, removing them from `main`, until they are ready to go into production!  


