### PR TITLE
9720 - Implement sticky nav

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_nav.html
@@ -1,7 +1,7 @@
 {% load bg_nav_tags localization i18n static wagtailroutablepage_tags %}
 {% get_bg_home_page as home_page %}
 
-<div class="d-md-none mt-0 mb-0" id="pni-nav-mobile">
+<div class="d-md-none mt-0 mb-0 tw-bg-white" id="pni-nav-mobile">
     <div class="container">
         <div class="row px-3 px-sm-0">
             <div class="col-12 tw-border-0">

--- a/network-api/networkapi/templates/pages/buyersguide/base.html
+++ b/network-api/networkapi/templates/pages/buyersguide/base.html
@@ -76,7 +76,7 @@
 
   {% get_bg_home_page as home_page %}
 
-  <div class="primary-nav-container-wrapper tw-border-b tw-border-blue-10 tw-fixed tw-z-[999] tw-top-0 tw-w-full tw-transition-all tw-overflow-hidden">
+  <div class="primary-nav-container-wrapper tw-border-b tw-border-blue-10 tw-fixed tw-z-[999] tw-top-0 tw-w-full tw-transition-all">
     {% include "fragments/buyersguide/primary_nav.html" %}
     {% include "fragments/buyersguide/pni_mobile_nav.html" with pagetype=pagetype categories=categories current_category=current_category %}
     {% block category_nav %}

--- a/network-api/networkapi/templates/pages/buyersguide/base.html
+++ b/network-api/networkapi/templates/pages/buyersguide/base.html
@@ -62,7 +62,7 @@
 {% endblock %}
 
 
-{% block bodyclass %}pni{% endblock %}
+{% block bodyclass %}pni tw-pt-[150px]{% endblock %}
 
 
 {% block script_bundle %}
@@ -76,7 +76,7 @@
 
   {% get_bg_home_page as home_page %}
 
-  <div class="primary-nav-container-wrapper tw-border-b tw-border-blue-10">
+  <div class="primary-nav-container-wrapper tw-border-b tw-border-blue-10 tw-fixed tw-z-[999] tw-top-0 tw-w-full tw-transition-all tw-overflow-hidden">
     {% include "fragments/buyersguide/primary_nav.html" %}
     {% include "fragments/buyersguide/pni_mobile_nav.html" with pagetype=pagetype categories=categories current_category=current_category %}
     {% block category_nav %}

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -2,7 +2,7 @@
 
 {% load static env i18n static wagtailimages_tags cache bg_nav_tags localization %}
 
-{% block bodyclass %}pni catalog{% endblock %}
+{% block bodyclass %}pni catalog tw-pt-[150px]{% endblock %}
 
 {% block main_content_class %}{% endblock %}
 

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -17,6 +17,7 @@ import RelatedArticles from "./related-articles.js";
 import AnalyticsEvents from "./analytics-events.js";
 import initializeSentry from "../common/sentry-config.js";
 import PNIMobileNav from "./pni-mobile-nav.js";
+import PNIStickyNav from "./pni-sticky-nav.js";
 
 // Initializing component a11y browser console logging
 if (
@@ -77,6 +78,7 @@ let main = {
         document.body.classList.add(`react-loaded`);
         this.initPageSpecificScript();
         PNIMobileNav.init();
+        PNIStickyNav.init();
         // bind custom analytics only once everything's up and loaded
         // Analytics events does give errors quite often, do not add JS after this
         AnalyticsEvents.init();

--- a/source/js/buyers-guide/pni-sticky-nav.js
+++ b/source/js/buyers-guide/pni-sticky-nav.js
@@ -8,7 +8,7 @@ const PNIStickyNav = {
     window.addEventListener("scroll", () => {
       let currentScroll = window.pageYOffset;
       if (currentScroll - lastScroll > 0 && currentScroll >= 300) {
-        navContainer.classList.add("tw-h-0");
+        navContainer.classList.add("tw-h-0", "tw-overflow-hidden");
       } else {
         // scrolled up -- header
         navContainer.classList.remove("tw-h-0");

--- a/source/js/buyers-guide/pni-sticky-nav.js
+++ b/source/js/buyers-guide/pni-sticky-nav.js
@@ -1,0 +1,21 @@
+const PNIStickyNav = {
+  init: () => {
+    const navContainer = document.querySelector(".primary-nav-container");
+
+    if (!navContainer) return;
+
+    let lastScroll = 0;
+    window.addEventListener("scroll", () => {
+      let currentScroll = window.pageYOffset;
+      if (currentScroll - lastScroll > 0 && currentScroll >= 300) {
+        navContainer.classList.add("tw-h-0");
+      } else {
+        // scrolled up -- header
+        navContainer.classList.remove("tw-h-0");
+      }
+      lastScroll = currentScroll;
+    });
+  },
+};
+
+export default PNIStickyNav;


### PR DESCRIPTION
# Description

Need to use position fixed instead of sticky since removing the top half of the nav with position sticky conflicts with the scroll event listener and makes the navigation shake and change the scrolling context. Since we are using position fixed, we are adding some padding top on the body to fill the space where the navigation would usually take

Implement sticky navigation for PNI pages when scrolling down the top half of the nav is hidden and is visible again if you scroll up.

Link to sample test page:  All PNI related pages
Related PRs/issues: #9720 

![image](https://user-images.githubusercontent.com/2374073/207763645-db91f412-379f-4fae-b625-2bf52d71761f.png)
![image](https://user-images.githubusercontent.com/2374073/207763689-12371368-b89b-49f0-b78e-5314925b1e5a.png)
![image](https://user-images.githubusercontent.com/2374073/207764108-ea6faf48-e6b2-4d38-a992-e95ffe3168c6.png)
