### PR TITLE
updated one link to test on staging

### DIFF
--- a/network-api/networkapi/templates/partials/primary_nav.html
+++ b/network-api/networkapi/templates/partials/primary_nav.html
@@ -63,7 +63,7 @@
 
               {% block donate_and_newsletter %}
               <div class="d-flex align-items-center">
-                <a id="donate-header-btn" class="primary-nav-special-link tw-heart-glyph tw-flex" href="https://donate.mozilla.org/?utm_source=foundation.mozilla.org&utm_medium=referral&utm_campaign=fmonav&utm_content=header" target="_blank" rel="noopener noreferrer">{% trans "Donate" %}</a>
+               <a id="donate-header-btn" class="primary-nav-special-link tw-heart-glyph tw-flex" href="?utm_source=foundation.mozilla.org&utm_medium=referral&utm_campaign=fmonav&utm_content=header&form=donate">{% trans "Donate" %}</a>
                 {% if page.signup == None %}<button class="tw-btn-secondary btn-newsletter d-none d-lg-block ml-md-3">{% trans "Newsletter" %}</button>{% endif %}
               </div>
               {% endblock %}


### PR DESCRIPTION
# Description

This PR updates one link in the foundation site that used to link to donate.mozilla.org, to instead be a relative link which includes `?form=donate`, so we can render the FRU modal.

Link to sample test page:
Related PRs/issues: #9856
