### PR TITLE
#9555 Ensure buyer's guide CTA uses 100% width

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/call_to_action_box.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/call_to_action_box.html
@@ -1,6 +1,7 @@
 {% load static wagtailcore_tags wagtailimages_tags %}
 
 <div class="
+  tw-w-full
   tw-bg-gradient-to-b tw-from-yellow-10 tw-to-purple-05
   tw-rounded-2xl
   tw-p-[24px] {% if not large  %} medium:tw-p-[32px] {% else %} medium:tw-p-[40px] {% endif %}


### PR DESCRIPTION
# Description

It is the default behaviour for a div to fill 100% of the parent width and gets it's height from the content. When the parent uses flex box, the default width behaviour is overridden and the width is also based on the content.

The product grid uses a flex wrapper for the CTA to stretch it of the height of the other grid elements. This disables the default 100% width. We need to make the width behaviour explicit so it still uses 100% of the width in the flex container.

This issue becomes apparent when the CTA content is not long enough to fill the with of the 2 gird spaces.


Link to sample test page: http://localhost:8000/en/privacynotincluded/categories/entertainment/
Related PRs/issues: #9555

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
