### PR TITLE
#9921 Update data-gtm attribute value for related articles

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/article_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/article_page.html
@@ -90,7 +90,7 @@
   {% with related_articles=page.get_related_articles  %}
     {% if related_articles %}
       {% get_bg_home_page as bg_home_page %}
-      <div class="tw-container tw-mt-7" data-gtm="article-what-to-read-next">
+      <div class="tw-container tw-mt-7" data-gtm="related-articles">
         {% include "fragments/buyersguide/article_listing_what_to_read_next.html" with articles=related_articles index_page=bg_home_page.get_editorial_content_index use_wide_above="medium" %}
       </div>
     {% endif %}


### PR DESCRIPTION
# Description

Small change of the `data-gtm` attribute for tracking. 
Based on discussion on the ticket. See #9921.

Link to sample test page: http://localhost:8000/en/privacynotincluded/articles/allow-watch-summer-coach/
Related PRs/issues: #9921

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
