### PR TITLE
updated template tickets to now include the needs grooming tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: engineering, bug 
+labels: engineering, bug, needs grooming
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/code_cleanup.md
+++ b/.github/ISSUE_TEMPLATE/code_cleanup.md
@@ -2,6 +2,6 @@
 name: Code cleanup
 about: Issue template for code cleanup issues
 title: ''
-labels: engineering, code cleanup
+labels: engineering, code cleanup, needs grooming
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/dependabot.md
+++ b/.github/ISSUE_TEMPLATE/dependabot.md
@@ -2,7 +2,7 @@
 name: Dependabot / Dependency Upgrades
 about: Issue template to account for effort spent on dependency upgrades in a sprint
 title: '[Dependabot]'
-labels: engineering, dependabot
+labels: engineering, dependabot, needs grooming
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/design-to-dev-handoff.md
+++ b/.github/ISSUE_TEMPLATE/design-to-dev-handoff.md
@@ -2,7 +2,7 @@
 name: Design to Dev Handoff
 about: Issue template that comes with a design to dev handoff checklist
 title: ''
-labels: engineering, design
+labels: engineering, design, needs grooming
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Request new or improved functionality
 title: ''
-labels: engineering, feature request
+labels: engineering, feature request, needs grooming
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/implementation_ticket.md
+++ b/.github/ISSUE_TEMPLATE/implementation_ticket.md
@@ -2,7 +2,7 @@
 name: Implementation issue
 about: Issue template for feature implementation issues
 title: ''
-labels: engineering
+labels: engineering, needs grooming
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/other_issue.md
+++ b/.github/ISSUE_TEMPLATE/other_issue.md
@@ -2,7 +2,7 @@
 name: Other issue
 about: For when none of the other categories cover it
 title: ''
-labels: ''
+labels: needs grooming
 assignees: ''
 
 ---


### PR DESCRIPTION
# Description
Related PRs/issues: #9746 

This PR updates the repo's existing github issue templates to now include the `needs grooming` tag by default.

