### PR TITLE
#9034 setup djhtml for indentation

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -96,7 +96,13 @@ jobs:
           black . --check
       - name: Run HTML linting
         run: |
-          djlint . --check
+          # Skipping djlint format checking because it has consistency issues and issues with blocktrans.
+          # This should change when formatting is moved to a version using and AST.
+          # See also: https://github.com/Riverside-Healthcare/djLint/issues/493
+          # djlint . --check
+          #
+          # Using djhtml indent check in the meantime.
+          djhtml -c maintenance/ network-api/
           djlint . --lint
         continue-on-error: true
       - name: Run type checks

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -2,6 +2,7 @@
 black
 coveralls
 django-debug-toolbar
+djhtml
 djlint
 flake8
 isort

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -46,6 +46,8 @@ django==3.2.16
     #   django-debug-toolbar
 django-debug-toolbar==3.5.0
     # via -r dev-requirements.in
+djhtml==1.5.2
+    # via -r dev-requirements.in
 djlint==1.19.7
     # via -r dev-requirements.in
 docopt==0.6.2

--- a/tasks.py
+++ b/tasks.py
@@ -300,7 +300,13 @@ def lint(ctx):
 @task
 def lint_html(ctx):
     """Run HTML linting."""
-    djlint_check(ctx)
+    # Skipping djlint format checking because it has consistency issues and issues with blocktrans.
+    # This should change when formatting is moved to a version using and AST.
+    # See also: https://github.com/Riverside-Healthcare/djLint/issues/493
+    # djlint_check(ctx)
+    #
+    # Use djhtml indent checking until format checking with djlint becomes possible.
+    djhtml_check(ctx)
     djlint_lint(ctx)
 
 
@@ -337,7 +343,13 @@ def format(ctx):
 @task
 def format_html(ctx):
     """Run HTML formatting."""
-    djlint_format(ctx)
+    # Skipping djlint formatting because it has consistency issues and issues with blocktrans.
+    # This should change when formatting is moved to a version using and AST.
+    # See also: https://github.com/Riverside-Healthcare/djLint/issues/493
+    # djlint_format(ctx)
+    #
+    # Indent HTML until full formatting with djlint becomes possible
+    djhtml_format(ctx)
 
 
 @task
@@ -371,6 +383,25 @@ def black(ctx, args=None):
 def black_check(ctx):
     """Run black code formatter in check mode."""
     black(ctx, ". --check")
+
+
+@task(help={"args": "Override the arguments passed to djhtml."})
+def djhtml(ctx, args=None):
+    """Run djhtml code indenter."""
+    args = args or "-h"
+    pyrun(ctx, command=f"djhtml {args}")
+
+
+@task
+def djhtml_check(ctx):
+    """Run djhtml code indenter in check mode."""
+    djhtml(ctx, args="-c maintenance/ network-api/")
+
+
+@task
+def djhtml_format(ctx):
+    """Run djhtml code indenter in formatting mode."""
+    djhtml(ctx, args="-i maintenance/ network-api/")
 
 
 @task(help={"args": "Override the arguments passed to djlint."})


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
This PR installs [`djhtml`](https://github.com/rtts/djhtml). `djhtml` is a Django template indenter. 

I previously set up `djlint` which is a Django template linter and also has a HTML formatter. 
But, trying to reformat the codebase with `djlint` showed some consistency issues and is currently broken for the `blocktrans` block (they don't get indented at all, see also https://github.com/Riverside-Healthcare/djLint/issues/493). 
A version 2.0 for `djlint` is in the works that will refactor the functionality to use an AST which should make the reformatting more reliable. 

In the meantime, we can use `djhtml` to make sure our templates are indented correctly (it does not do any other formatting) and use `djlint` to check the templates for [issues](https://djlint.com/docs/linter/) (other than formatting). 

Invoke tasks are added to make running `djhtml` easy.

* `inv djhtml-check` to check if the indentation is correct.
* `inv djhtml-format` to fix any indentation issues.
* These tasks are also run when doing `inv lint-html` or `inv format-html` respectively.


I have updated the CI step for HTML linting. The HTML linting step is still allowed to fail and I will move the linting and indent checking to the active linting step in the same PRs that fix the issues. 


Related PRs/issues: #9034

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [x] Is my code documented? -> Tasks have docs strings and comments where necessary. 
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
