### PR TITLE
9872 - design tweaks for PNI speech bubble

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -56,11 +56,11 @@
       <div class="tw-w-full">
         <div id="sticky-bar" class="creepiness-slider bg-white text-center tw-justify-center creep-o-meter-moved search-active">
           <div class="creep-o-meter-information tw-flex tw-items-center tw-whitespace-nowrap">
-            <div class="speech-bubble-container tw-inline-block tw-mr-4">
-              <div class="speech-bubble tw-relative tw-inline-block tw-whitespace-normal tw-text-left tw-bg-gradient-to-t tw-from-purple-05 tw-to-blue-05">
+            <div class="speech-bubble-container tw-inline-block tw-mr-4 tw-max-w-[280px]">
+              <div class="speech-bubble tw-relative tw-inline-block tw-whitespace-normal tw-bg-gradient-to-t tw-from-purple-05 tw-to-blue-05">
                 <p class="text tw-text-base tw-mb-0">
                   {% blocktrans trimmed %}
-                    Scroll to see how creepy <br/> people find these products!
+                    Scroll to see how creepy people find these products!
                   {% endblocktrans %}
                 </p>
               </div>

--- a/source/sass/buyers-guide/views/catalog.scss
+++ b/source/sass/buyers-guide/views/catalog.scss
@@ -243,7 +243,7 @@ body {
           background-position: right 60%;
           position: absolute;
           top: 0;
-          right: -14px;
+          right: -12px;
           width: 14px;
           height: 100%;
         }


### PR DESCRIPTION
# Description

Implemented design tweaks based on Nancy's feedback.

- set max width 280px on PNI homepage speech bubble
- removed the hardcoded line break `<br/>` from text
- made bubble text center aligned

Link to sample test page: `/privacynotincluded`
Related PRs/issues: #9872

I've shared screen recordings of my localhost PNI homepage with Nancy and got her okay on these design tweaks.