### PR TITLE
9870 - Expand dropdown box and search bar to fit length of text

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
@@ -19,16 +19,14 @@
                     </div>
                     {% include "fragments/buyersguide/category_dropdown.html" %}
 
-                    <div id="product-filter-search" tabindex="0" class="tw-hidden large:tw-inline-flex tw-px-2 tw-items-center tw-bg-blue-05 tw-border-4 tw-border-blue-05 tw-w-[214px] tw-mr-2">
-                        <img
-                            class="tw-w-4 tw-h-4 tw-mr-2"
-                            src="{% static "_images/buyers-guide/pni-search.svg" %}"
-                        >
-                        <input type="text" role="searchbox" id="product-filter-search-input" placeholder="{% trans "Search all products" %}" value=""
-                            class="tw-bg-blue-05 tw-outline-none tw-py-2 tw-text-base tw-text-blue-60 tw-min-w-0 placeholder:tw-text-blue-60" />
-                        <label for="product-filter-search-input" class="clear-icon">&nbsp;</label>
-                    </div>
-                </div>
+            <div id="product-filter-search" tabindex="0" class="tw-hidden large:tw-inline-flex tw-px-2 tw-items-center tw-bg-blue-05 tw-border-4 tw-border-blue-05 tw-w-[250px] tw-mr-2">
+              <img
+                class="tw-w-4 tw-h-4 tw-mr-2"
+                src="{% static "_images/buyers-guide/pni-search.svg" %}"
+              >
+              <input type="text" role="searchbox" id="product-filter-search-input" placeholder="{% trans "Search all products" %}" value=""
+              class="tw-bg-blue-05 tw-outline-none tw-py-2 tw-text-base tw-text-blue-60 tw-min-w-0 placeholder:tw-text-blue-60 placeholder:tw-text-[14px] tw-w-full" />
+              <label for="product-filter-search-input" class="clear-icon">&nbsp;</label>
             </div>
         </div>
     </div>

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
@@ -19,15 +19,15 @@
                     </div>
                     {% include "fragments/buyersguide/category_dropdown.html" %}
 
-            <div id="product-filter-search" tabindex="0" class="tw-hidden large:tw-inline-flex tw-px-2 tw-items-center tw-bg-blue-05 tw-border-4 tw-border-blue-05 tw-w-[250px] tw-mr-2">
-              <img
-                class="tw-w-4 tw-h-4 tw-mr-2"
-                src="{% static "_images/buyers-guide/pni-search.svg" %}"
-              >
-              <input type="text" role="searchbox" id="product-filter-search-input" placeholder="{% trans "Search all products" %}" value=""
-              class="tw-bg-blue-05 tw-outline-none tw-py-2 tw-text-base tw-text-blue-60 tw-min-w-0 placeholder:tw-text-blue-60 placeholder:tw-text-[14px] tw-w-full" />
-              <label for="product-filter-search-input" class="clear-icon">&nbsp;</label>
+                    <div id="product-filter-search" tabindex="0" class="tw-hidden large:tw-inline-flex tw-px-2 tw-items-center tw-bg-blue-05 tw-border-4 tw-border-blue-05 tw-w-[250px] tw-mr-2">
+                        <img
+                            class="tw-w-4 tw-h-4 tw-mr-2"
+                            src="{% static "_images/buyers-guide/pni-search.svg" %}"
+                        >
+                        <input type="text" role="searchbox" id="product-filter-search-input" placeholder="{% trans "Search all products" %}" value=""
+                            class="tw-bg-blue-05 tw-outline-none tw-py-2 tw-text-base tw-text-blue-60 tw-min-w-0 placeholder:tw-text-blue-60 placeholder:tw-text-[14px] tw-w-full" />
+                        <label for="product-filter-search-input" class="clear-icon">&nbsp;</label>
+                    </div>
+                </div>
             </div>
-        </div>
-    </div>
-</nav>
+        </nav>

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
@@ -19,13 +19,15 @@
                     </div>
                     {% include "fragments/buyersguide/category_dropdown.html" %}
 
-            <div id="product-filter-search" tabindex="0" class="tw-hidden large:tw-inline-flex tw-px-2 tw-items-center tw-bg-blue-05 tw-border-4 tw-border-blue-05 tw-w-[250px] tw-mr-2">
-              <img
-                class="tw-w-4 tw-h-4 tw-mr-2"
-                src="{% static "_images/buyers-guide/pni-search.svg" %}"
-              >
-              <input type="text" role="searchbox" id="product-filter-search-input" placeholder="{% trans "Search all products" %}" value=""
-              class="tw-bg-blue-05 tw-outline-none tw-py-2 tw-text-base tw-text-blue-60 tw-min-w-0 placeholder:tw-text-blue-60 placeholder:tw-text-[14px] tw-w-full" />
-              <label for="product-filter-search-input" class="clear-icon">&nbsp;</label>
+                    <div id="product-filter-search" tabindex="0" class="tw-hidden large:tw-inline-flex tw-px-2 tw-items-center tw-bg-blue-05 tw-border-4 tw-border-blue-05 tw-w-[250px] tw-mr-2">
+                        <img
+                            class="tw-w-4 tw-h-4 tw-mr-2"
+                            src="{% static "_images/buyers-guide/pni-search.svg" %}"
+                        >
+                        <input type="text" role="searchbox" id="product-filter-search-input" placeholder="{% trans "Search all products" %}" value=""
+                            class="tw-bg-blue-05 tw-outline-none tw-py-2 tw-text-base tw-text-blue-60 tw-min-w-0 placeholder:tw-text-blue-60 placeholder:tw-text-[14px] tw-w-full" />
+                        <label for="product-filter-search-input" class="clear-icon">&nbsp;</label>
+                    </div>
+                </div>
             </div>
         </nav>

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_sort_dropdown.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_sort_dropdown.html
@@ -2,37 +2,22 @@
 <ul
     id="pni-creepiness"
     class="
-      tw-list-none
-      tw-relative
-      tw-cursor-pointer
-      tw-m-0 tw-p-0 tw-ml-2
-      tw-flex
-      tw-items-center
-      tw-min-w-[250px]
-      "
-  >
+        tw-list-none
+        tw-relative
+        tw-cursor-pointer
+        tw-m-0 tw-p-0 tw-ml-2
+        tw-flex
+        tw-items-center
+        tw-min-w-[250px]
+    "
+>
     <li
         role="button"
         id="pni-creepiness__selected"
         class="tw-overflow-hidden tw-whitespace-nowrap tw-w-full tw-text-ellipsis tw-flex tw-items-center tw-m-0 tw-p-3"
         tabindex="0"
     >
-      <div id="pni-creepiness__selected-text" class="tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-black tw-font-sans tw-mr-auto">
-        <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2" />
-        {% trans "Creepiness: Least – Most" %}
-      </div>  
-
-      <svg width="11" height="7" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg" class="tw-ml-2 tw-origin-center">
-        <title>{% trans "Open drop down" %}</title>
-        <path d="M1 1L5.02504 5.02504L9.05007 1" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-      </svg>
-    </li>
-
-    
-    <li aria-expanded="false" role="list" class="pni-creepiness__list-container tw-absolute tw-top-0 tw-invisible tw-select-none tw-pointer-events-none tw-right-0 tw-z-50 tw-bg-white tw-border tw-border-gray-20">
-      <ul class="pni-creepiness__list tw-w-max tw-list-none tw-m-0 tw-p-0">
-        <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-1" data-value="ASCENDING">
-          <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
+        <div id="pni-creepiness__selected-text" class="tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-black tw-font-sans tw-mr-auto">
             <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2" />
             {% trans "Creepiness: Least – Most" %}
         </div>
@@ -40,21 +25,35 @@
         <svg width="11" height="7" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg" class="tw-ml-2 tw-origin-center">
             <title>{% trans "Open drop down" %}</title>
             <path d="M1 1L5.02504 5.02504L9.05007 1" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </li>
-        <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-2" data-value="DESCENDING">
-          <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
-            <img src="{% static "_images/buyers-guide/shock-face.svg" %}" class="tw-mr-2" />
-            {% trans "Creepiness: Most – Least" %}
-          </div>
-        </li>
-        <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-3" data-value="ALPHA">
-          <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none mr-auto">
-            <img src="{% static "_images/buyers-guide/alpha-emoji.png" %}" class="tw-mr-2" />
-            {% trans "Alphabetical" %}
-          </div>
-        </li>
-      </ul>
+        </svg>
+    </li>
+
+
+    <li aria-expanded="false" role="list" class="pni-creepiness__list-container tw-absolute tw-top-0 tw-invisible tw-select-none tw-pointer-events-none tw-right-0 tw-z-50 tw-bg-white tw-border tw-border-gray-20">
+        <ul class="pni-creepiness__list tw-w-max tw-list-none tw-m-0 tw-p-0">
+            <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-1" data-value="ASCENDING">
+                <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
+                    <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2" />
+                    {% trans "Creepiness: Least – Most" %}
+                </div>
+                <svg width="11" height="7" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg" class="tw-ml-4 tw-rotate-180 tw-origin-center tw-pointer-events-none">
+                    <title>{% trans "Close drop down" %}</title>
+                    <path d="M1 1L5.02504 5.02504L9.05007 1" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </li>
+            <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-2" data-value="DESCENDING">
+                <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
+                    <img src="{% static "_images/buyers-guide/shock-face.svg" %}" class="tw-mr-2" />
+                    {% trans "Creepiness: Most – Least" %}
+                </div>
+            </li>
+            <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-3" data-value="ALPHA">
+                <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none mr-auto">
+                    <img src="{% static "_images/buyers-guide/alpha-emoji.png" %}" class="tw-mr-2" />
+                    {% trans "Alphabetical" %}
+                </div>
+            </li>
+        </ul>
     </li>
 
 </ul>

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_sort_dropdown.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_sort_dropdown.html
@@ -2,15 +2,15 @@
 <ul
     id="pni-creepiness"
     class="
-      tw-list-none
-      tw-relative
-      tw-cursor-pointer
-      tw-m-0 tw-p-0 tw-ml-2
-      tw-flex
-      tw-items-center
-      tw-min-w-[250px]
-      "
-  >
+        tw-list-none
+        tw-relative
+        tw-cursor-pointer
+        tw-m-0 tw-p-0 tw-ml-2
+        tw-flex
+        tw-items-center
+        tw-min-w-[250px]
+    "
+>
     <li
         role="button"
         id="pni-creepiness__selected"
@@ -28,32 +28,32 @@
         </svg>
     </li>
 
-    
+
     <li aria-expanded="false" role="list" class="pni-creepiness__list-container tw-absolute tw-top-0 tw-invisible tw-select-none tw-pointer-events-none tw-right-0 tw-z-50 tw-bg-white tw-border tw-border-gray-20">
-      <ul class="pni-creepiness__list tw-w-max tw-list-none tw-m-0 tw-p-0">
-        <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-1" data-value="ASCENDING">
-          <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
-            <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2" />
-            {% trans "Creepiness: Least – Most" %}
-          </div>
-          <svg width="11" height="7" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg" class="tw-ml-4 tw-rotate-180 tw-origin-center tw-pointer-events-none">
-            <title>{% trans "Close drop down" %}</title>
-            <path d="M1 1L5.02504 5.02504L9.05007 1" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </li>
-        <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-2" data-value="DESCENDING">
-          <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
-            <img src="{% static "_images/buyers-guide/shock-face.svg" %}" class="tw-mr-2" />
-            {% trans "Creepiness: Most – Least" %}
-          </div>
-        </li>
-        <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-3" data-value="ALPHA">
-          <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none mr-auto">
-            <img src="{% static "_images/buyers-guide/alpha-emoji.png" %}" class="tw-mr-2" />
-            {% trans "Alphabetical" %}
-          </div>
-        </li>
-      </ul>
+        <ul class="pni-creepiness__list tw-w-max tw-list-none tw-m-0 tw-p-0">
+            <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-1" data-value="ASCENDING">
+                <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
+                    <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2" />
+                    {% trans "Creepiness: Least – Most" %}
+                </div>
+                <svg width="11" height="7" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg" class="tw-ml-4 tw-rotate-180 tw-origin-center tw-pointer-events-none">
+                    <title>{% trans "Close drop down" %}</title>
+                    <path d="M1 1L5.02504 5.02504L9.05007 1" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </li>
+            <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-2" data-value="DESCENDING">
+                <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
+                    <img src="{% static "_images/buyers-guide/shock-face.svg" %}" class="tw-mr-2" />
+                    {% trans "Creepiness: Most – Least" %}
+                </div>
+            </li>
+            <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-3" data-value="ALPHA">
+                <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none mr-auto">
+                    <img src="{% static "_images/buyers-guide/alpha-emoji.png" %}" class="tw-mr-2" />
+                    {% trans "Alphabetical" %}
+                </div>
+            </li>
+        </ul>
     </li>
 
 </ul>

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_sort_dropdown.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_sort_dropdown.html
@@ -6,7 +6,7 @@
         tw-relative
         tw-cursor-pointer
         tw-m-0 tw-p-0 tw-ml-2
-        tw-flex
+        tw-hidden
         tw-items-center
         tw-min-w-[250px]
     "
@@ -18,7 +18,7 @@
         tabindex="0"
     >
         <div id="pni-creepiness__selected-text" class="tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-black tw-font-sans tw-mr-auto">
-            <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2" />
+            <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2 tw-w-[20px]" />
             {% trans "Creepiness: Least – Most" %}
         </div>
 
@@ -33,7 +33,7 @@
         <ul class="pni-creepiness__list tw-w-max tw-list-none tw-m-0 tw-p-0">
             <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-1" data-value="ASCENDING">
                 <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
-                    <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2" />
+                    <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2 tw-w-[20px]" />
                     {% trans "Creepiness: Least – Most" %}
                 </div>
                 <svg width="11" height="7" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg" class="tw-ml-4 tw-rotate-180 tw-origin-center tw-pointer-events-none">
@@ -43,17 +43,17 @@
             </li>
             <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-2" data-value="DESCENDING">
                 <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
-                    <img src="{% static "_images/buyers-guide/shock-face.svg" %}" class="tw-mr-2" />
+                    <img src="{% static "_images/buyers-guide/shock-face.svg" %}" class="tw-mr-2 tw-w-[20px]" />
                     {% trans "Creepiness: Most – Least" %}
                 </div>
             </li>
             <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-3" data-value="ALPHA">
                 <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none mr-auto">
-                    <img src="{% static "_images/buyers-guide/alpha-emoji.png" %}" class="tw-mr-2" />
-                    {% trans "Alphabetical" %}
+                    <img src="{% static "_images/buyers-guide/alpha-emoji.png" %}" class="tw-mr-2 tw-w-[20px]" />
+                    {% trans "Przerażające: od najmniej do najbardziej" %}
                 </div>
             </li>
-        </ul>
+        </ul tw-w-[20px]>
     </li>
 
 </ul>

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_sort_dropdown.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_sort_dropdown.html
@@ -2,15 +2,15 @@
 <ul
     id="pni-creepiness"
     class="
-        tw-list-none
-        tw-relative
-        tw-cursor-pointer
-        tw-m-0 tw-p-0 tw-ml-2
-        tw-flex
-        tw-items-center
-        tw-w-[250px]
-    "
->
+      tw-list-none
+      tw-relative
+      tw-cursor-pointer
+      tw-m-0 tw-p-0 tw-ml-2
+      tw-flex
+      tw-items-center
+      tw-min-w-[250px]
+      "
+  >
     <li
         role="button"
         id="pni-creepiness__selected"
@@ -28,32 +28,32 @@
         </svg>
     </li>
 
-
-    <li aria-expanded="false" role="list" class="tw-absolute tw-top-0 tw-hidden tw-left-0 pni-creepiness__list-container tw-w-[250px] tw-z-50 tw-bg-white tw-border tw-border-gray-20">
-        <ul class="pni-creepiness__list tw-w-full tw-list-none tw-m-0 tw-p-0">
-            <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-1" data-value="ASCENDING">
-                <div class="tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
-                    <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2" />
-                    {% trans "Creepiness: Least – Most" %}
-                </div>
-                <svg width="11" height="7" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg" class="tw-ml-4 tw-rotate-180 tw-origin-center tw-pointer-events-none">
-                    <title>{% trans "Close drop down" %}</title>
-                    <path d="M1 1L5.02504 5.02504L9.05007 1" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-            </li>
-            <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-2" data-value="DESCENDING">
-                <div class="tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
-                    <img src="{% static "_images/buyers-guide/shock-face.svg" %}" class="tw-mr-2" />
-                    {% trans "Creepiness: Most – Least" %}
-                </div>
-            </li>
-            <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-3" data-value="ALPHA">
-                <div class="tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none mr-auto">
-                    <img src="{% static "_images/buyers-guide/alpha-emoji.png" %}" class="tw-mr-2" />
-                    {% trans "Alphabetical" %}
-                </div>
-            </li>
-        </ul>
+    
+    <li aria-expanded="false" role="list" class="pni-creepiness__list-container tw-absolute tw-top-0 tw-invisible tw-select-none tw-pointer-events-none tw-right-0 tw-z-50 tw-bg-white tw-border tw-border-gray-20">
+      <ul class="pni-creepiness__list tw-w-max tw-list-none tw-m-0 tw-p-0">
+        <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-1" data-value="ASCENDING">
+          <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
+            <img src="{% static "_images/buyers-guide/cry-face.svg" %}" class="tw-mr-2" />
+            {% trans "Creepiness: Least – Most" %}
+          </div>
+          <svg width="11" height="7" viewBox="0 0 11 7" fill="none" xmlns="http://www.w3.org/2000/svg" class="tw-ml-4 tw-rotate-180 tw-origin-center tw-pointer-events-none">
+            <title>{% trans "Close drop down" %}</title>
+            <path d="M1 1L5.02504 5.02504L9.05007 1" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </li>
+        <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-2" data-value="DESCENDING">
+          <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none">
+            <img src="{% static "_images/buyers-guide/shock-face.svg" %}" class="tw-mr-2" />
+            {% trans "Creepiness: Most – Least" %}
+          </div>
+        </li>
+        <li class="pni-creepiness__list-item tw-whitespace-nowrap tw-p-3 tw-text-sm tw-font-bold tw-group tw-font-sans tw-flex tw-items-center tw-overflow-ellipsis" tabindex="0" id="option-3" data-value="ALPHA">
+          <div class="tw-pr-4 tw-w-full tw-flex tw-items-center tw-text-sm tw-font-bold tw-text-gray-40 group-hover:tw-text-black tw-font-sans tw-pointer-events-none mr-auto">
+            <img src="{% static "_images/buyers-guide/alpha-emoji.png" %}" class="tw-mr-2" />
+            {% trans "Alphabetical" %}
+          </div>
+        </li>
+      </ul>
     </li>
 
 </ul>

--- a/source/js/buyers-guide/search/pni-sort-dropdown.js
+++ b/source/js/buyers-guide/search/pni-sort-dropdown.js
@@ -76,6 +76,8 @@ export class PNISortDropdown {
         )
         .click();
     }
+    // Used to recalculate dropdown width based on absolute select options
+    this.dropdown.style.width = `${this.list.getBoundingClientRect().width}px`;
   }
 
   setSelectedListItem(e, pushUpdate = true) {
@@ -95,7 +97,11 @@ export class PNISortDropdown {
   }
 
   closeList() {
-    this.listContainer.classList.add("tw-hidden");
+    this.listContainer.classList.add(
+      "tw-invisible",
+      "tw-select-none",
+      "tw-pointer-events-none"
+    );
     this.listContainer.setAttribute("aria-expanded", false);
   }
 
@@ -108,11 +114,19 @@ export class PNISortDropdown {
     }
 
     if (e.type === "click" || openDropDown) {
-      this.listContainer.classList.remove("tw-hidden");
+      this.listContainer.classList.remove(
+        "tw-invisible",
+        "tw-select-none",
+        "tw-pointer-events-none"
+      );
 
       this.listContainer.setAttribute(
         "aria-expanded",
-        this.listContainer.classList.contains("tw-hidden")
+        this.listContainer.classList.contains(
+          "tw-invisible",
+          "tw-select-none",
+          "tw-pointer-events-none"
+        )
       );
     }
 

--- a/source/js/buyers-guide/search/pni-sort-dropdown.js
+++ b/source/js/buyers-guide/search/pni-sort-dropdown.js
@@ -25,6 +25,8 @@ export class PNISortDropdown {
       );
     }
 
+    this.dropdown.classList.add("tw-flex");
+    this.dropdown.classList.remove("tw-hidden");
     this.dropdownSelectedNode.addEventListener("click", (e) =>
       this.toggleListVisibility(e)
     );
@@ -76,8 +78,14 @@ export class PNISortDropdown {
         )
         .click();
     }
+
     // Used to recalculate dropdown width based on absolute select options
-    this.dropdown.style.width = `${this.list.getBoundingClientRect().width}px`;
+    // addEventListener is there to calc width after images are loaded properly
+    window.addEventListener("load", () => {
+      this.dropdown.style.width = `${
+        this.listContainer.getBoundingClientRect().width
+      }px`;
+    });
   }
 
   setSelectedListItem(e, pushUpdate = true) {


### PR DESCRIPTION
# Description

* We removed the fixed width on the sort dropdown since it can support the text change in other locales
* @nancyt1 and I walked through what we can do for the search-box. Since the placeholder text doesn't really control the width of the search-box we increased the size of the input and decreased the size of the placeholder to fit the rest of the locale length changes!

![image](https://user-images.githubusercontent.com/2374073/213573321-beea7283-a522-408e-a88e-5f2ecc500833.png)
![image](https://user-images.githubusercontent.com/2374073/213573414-d332c10d-8357-4484-ad5b-b30e978f528d.png)


Link to sample test page: `/<locale>/privacynotincluded`
Related PRs/issues: #9870 

