### PR TITLE
9821 - Potential Safari Delay fix for Search

### DIFF
--- a/source/js/buyers-guide/search/search-filter.js
+++ b/source/js/buyers-guide/search/search-filter.js
@@ -62,7 +62,7 @@ export class SearchFilter {
         )
     ).then(() => {
       if (this.categoryTitle.value === "None") {
-        Utils.toggleScrollAnimation(true);
+        Utils.toggleScrollAnimation();
       } else {
         Utils.toggleCategoryAnimation(true);
       }
@@ -92,7 +92,9 @@ export class SearchFilter {
     const debounce = (fn, ms = 0) => {
       let timeoutId;
       return function (...args) {
-        clearTimeout(timeoutId);
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
         timeoutId = setTimeout(() => fn.apply(this, args), ms);
       };
     };

--- a/source/js/buyers-guide/search/utils.js
+++ b/source/js/buyers-guide/search/utils.js
@@ -176,43 +176,36 @@ export class Utils {
   /**
    * Scroll Animation used solely for the 'All Products' section
    */
-  static toggleScrollAnimation(initialLoad = false) {
-    ScrollTrigger.clearScrollMemory();
-    ScrollTrigger.refresh(true);
+  static toggleScrollAnimation() {
     gsap.set("figure.product-box.d-flex", { opacity: 0, y: 100 });
 
-    if (initialLoad) {
-      gsap.set("figure.product-box.d-flex:nth-child(-n+8)", {
-        opacity: 1,
-        y: 0,
-      });
-    }
+    gsap.set("figure.product-box.d-flex:nth-child(-n+8)", {
+      opacity: 1,
+      y: 0,
+    });
 
     // group products stagger animation based on mobile breakpoint
     const responsiveBatch =
       window.innerWidth > 991 ? 8 : window.innerWidth > 767 ? 6 : 4;
 
-    ScrollTrigger.batch(
-      initialLoad
-        ? "figure.product-box.d-flex:nth-child(n+8)"
-        : "figure.product-box.d-flex",
-      {
-        batchMax: responsiveBatch, // maximum batch size (targets)
-        onEnter: (batch) =>
-          gsap.to(batch, {
-            opacity: 1,
-            y: 0,
-            stagger: 0.1,
-            overwrite: true,
-          }),
-      }
-    );
+    ScrollTrigger.batch("figure.product-box.d-flex:nth-child(n+8)", {
+      batchMax: responsiveBatch, // maximum batch size (targets)
+      id: "scroll-products",
+      onEnter: (batch) =>
+        gsap.to(batch, {
+          opacity: 1,
+          y: 0,
+          stagger: 0.1,
+          overwrite: true,
+        }),
+    });
   }
 
   /**
    * Animation used for category selections
    */
   static toggleCategoryAnimation(initialLoad = false) {
+    ScrollTrigger.getById("scroll-products")?.kill(true);
     if (document.querySelectorAll("figure.product-box.d-flex")) {
       gsap.set("figure.product-box.d-flex", { opacity: 0, y: 100 });
     }
@@ -252,12 +245,7 @@ export class Utils {
         product.classList.remove(`d-flex`);
       }
     });
-
-    if (category === "None") {
-      Utils.toggleScrollAnimation();
-    } else {
-      Utils.toggleCategoryAnimation();
-    }
+    Utils.toggleCategoryAnimation();
   }
 
   /**
@@ -266,6 +254,7 @@ export class Utils {
    */
   static toggleCtaForCategory(category) {
     const categoryPageCta = document.getElementById("category-featured-cta");
+    if (!categoryPageCta) return;
     const categoriesWithShowCtaEnabled =
       categoryPageCta.dataset.showForCategories;
 


### PR DESCRIPTION
# Description

What I came up after using safaris profile tools. (when it wasn't crashing)

* minor fix for `toggleCtaForCategory`
* Making it so only `toggleScrollAnimation()` is triggered only on load on non-category pages instead of triggered every time we search products. Reasoning for this, was noticing that a lot of the stalling on safari might be coming from resetting the ScrollTrigger libraries "triggers" whenever the products change.  `toggleCategoryAnimation()` will be used instead since the animation is way less performance reliant then the scrollTrigger() one. Doing this change made my safari browser had less issues with using the searchbox.
* There is still a chance that there might be other root causes of this issue but, I still think these changes are important to include since I think maintaining some of the scrollanimation stuff in this situation.

Link to sample test page: en/privacynotincluded
Related PRs/issues: #9821 
