### PR TITLE
#9902 Add anchor links to image teaser block headings

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/image_teaser_block.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/image_teaser_block.py
@@ -1,7 +1,15 @@
 from django.forms.utils import ErrorList
+from django.utils import functional as func_utils
+from django.utils import text as text_utils
 from wagtail.core import blocks
 from wagtail.core.blocks.struct_block import StructBlockValidationError
 from wagtail.images.blocks import ImageChooserBlock
+
+
+class ImageTeaserValue(blocks.StructValue):
+    @func_utils.cached_property
+    def slug(self):
+        return text_utils.slugify(self.get("title", ""))
 
 
 class ImageTeaserBlock(blocks.StructBlock):
@@ -60,3 +68,4 @@ class ImageTeaserBlock(blocks.StructBlock):
         label = "Image teaser"
         icon = "doc-full"
         template = "wagtailpages/blocks/image_teaser_block.html"
+        value_class = ImageTeaserValue

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_teaser_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/image_teaser_block.html
@@ -3,9 +3,9 @@
 
 {% block block_content %}
     {% with card=value %}
-        <section class="tw-grid tw-grid-cols-1 large:tw-grid-cols-2 tw-gap-5 large:tw-gap-[60px] tw-mb-7 {{ divider_styles }}">
+        <section id="{{ card.slug }}" class="tw-grid tw-grid-cols-1 large:tw-grid-cols-2 tw-gap-5 large:tw-gap-[60px] tw-mb-7 {{ divider_styles }}">
             <div class="tw-row-start-2 large:tw-row-start-1">
-                <h2 class="tw-mb-4">{{ card.title }}</h2>
+                <h2 class="tw-mb-4">{{ card.title }}<a href="#{{ card.slug }}"></a></h2>
                 {{ card.text|richtext }}
                 {% if card.url and card.url_label %}
                     <a class="tw-{{ card.styling }} link-button tw-mt-4" href="{{ card.url }}">


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

This PR adds anchor tags to the headings of the image teaser block. 
The anchor are set to link to the section id, which is a slug generated from the heading. 

The anchor does not have any content and thus will have no visual representation. 
While this is not ideal, this is a pattern that staff is already used to based on how anchor elements are generated for h2 headings in richtext (see https://github.com/mozilla/foundation.mozilla.org/blob/main/network-api/networkapi/wagtailcustomization/templatetags/wagtailcustom_tags.py#L33). 

The difference to the richtext headings is that the anchor has an `href` attribute in stead of an `id` and that the `id` is set on the surrounding `section`. This was chosen to make sure that the whole section scrolls into view properly. 

This is best tested with production data (`inv copy-prod-db`) on this page: http://mozfest.localhost:8000/en/issues-and-spaces/transparency/#mozone
When on `main` the page will load scrolled to the top.
With this branch it will scroll the MoZone section into view. 

Link to sample test page: http://mozfest.localhost:8000/en/issues-and-spaces/transparency/#mozone
Related PRs/issues: #9902 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
