### PR TITLE
Revert "Revert "Pass language code to Tito widget""

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
@@ -1,7 +1,10 @@
 {% extends "./base_streamfield_block.html" %}
+{% load i18n %}
+{% get_current_language as lang_code %}
+
 
 {% block block_content %}
     <script src='https://js.tito.io/v2' async></script>
 
-    <tito-button event="{{ value.event.event_id }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-4">{{ value.button_label }}</tito-button>
+    <tito-button event="{{ value.event.event_id }}" locale="{{ lang_code }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-4">{{ value.button_label }}</tito-button>
 {% endblock %}


### PR DESCRIPTION
In https://github.com/mozilla/foundation.mozilla.org/pull/9818, localization functionality for Tito widgets was merged into the code base. However, since the team was about to start our winter break / code freeze, we decided to revert the PR  with #9838 until we returned from break.

This PR reverts #9838, re-enabling localization for Tito widgets.

