### PR TITLE
So profile images aren't blurry on higher res screens

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_block_rounded.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/profile_block_rounded.html
@@ -8,8 +8,13 @@
                 <div class="tw-px-4 small:tw-w-full medium:tw-w-1/3 tw-mb-5">
                     <div class="card-regular tw-h-full tw-flex-col">
                         {% if card.image %}
-                            {% image card.image fill-140x140 as img %}
-                            <img src="{{ img.url }}" alt="{{ card.alt_text }}" class="tw-rounded-full tw-w-[140px] tw-h-[140px]" />
+                            <img
+                                class="tw-rounded-full tw-w-[140px] tw-h-[140px]"
+                                src="{% image_url card.image "fill-140x140" %}"
+                                srcset="{% image_url card.image "fill-280x280" %} 2x, {% image_url card.image "fill-420x420" %} 3x"
+                                alt="{{ card.alt_text }}"
+                                title="{{ card.name }}"
+                            />
                         {% endif %}
                         <div class="tw-flex tw-flex-1">
                             <div class="tw-bg-white tw-relative tw-py-4 tw-w-full tw-flex tw-flex-col">


### PR DESCRIPTION
# Description

This PR changes the image rendering in the new profiles block so images are a bit clearer. It's basically the same fix as https://github.com/mozilla/foundation.mozilla.org/pull/9765

### Before / After
![image](https://user-images.githubusercontent.com/2128707/214867727-7fc36a33-4269-4a38-a8d3-dd890dc2aa03.png)

Link to sample test page:
1. First go to snippets > profiles and upload an image for a profile.
2. Go and edit a banner page, e.g http://localhost:8000/en/campaigns/initial-test-bannered-campaign-with-fixed-title/ > Add a profile block with the profile you uploaded an image with.
3. View front end on different devices/zooms - there should be little to no degradation in the image quality


Related PRs/issues: #9804

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~ we don't test image quality

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~ This is just a template fix
- [ ] ~~Did I squash my migration?~~ This is just a template fix
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~ This is just a template fix

**Documentation:**
- [ ] ~~Is my code documented?~~ No
- [ ] ~~Did I update the READMEs or wagtail documentation?~~ No
