### PR TITLE
tito widget now checking if language code is in supported list

### DIFF
--- a/network-api/networkapi/events/tests.py
+++ b/network-api/networkapi/events/tests.py
@@ -3,10 +3,12 @@ from unittest import mock
 
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
+from wagtail.core.models import Page, Site
 
-from .factory import TitoEventFactory
-from .utils import sign_tito_request
-from .views import tito_ticket_completed
+from networkapi.events.factory import TitoEventFactory
+from networkapi.events.utils import sign_tito_request
+from networkapi.events.views import tito_ticket_completed
+from networkapi.mozfest.factory import MozfestHomepageFactory
 
 
 class TitoTicketCompletedTest(TestCase):
@@ -105,3 +107,50 @@ class TitoTicketCompletedTest(TestCase):
             response = tito_ticket_completed(request)
             self.assertEqual(response.status_code, 202)
             self.assertIn("Basket subscription from Tito webhook failed", cm.output[0])
+
+
+class TitoWidgetBlockLocalizationTest(TestCase):
+    """
+    Making sure that the tito widget block template is being sent a language code supported by Tito.
+    If the user is visiting with an unsupported language, default to English.
+    (List of supported languages can be found in TitoWidgetBlock model definition)
+    """
+
+    def setUp(self):
+        # Setting up a mozfest site and homepage with a tito widget block.
+        self.site = Site.objects.first()
+        site_root = Page.objects.get(depth=1)
+        self.mozfest_homepage = MozfestHomepageFactory.create(parent=site_root)
+        self.mozfest_homepage.body = [
+            ("tito_widget", {"button_label": "test widget", "styling": "btn-primary", "event": TitoEventFactory()})
+        ]
+        self.mozfest_homepage.save()
+        self.site.root_page = self.mozfest_homepage
+        self.site.save()
+
+    def test_lang_code_with_default_language(self):
+        # English is the site's default language, so get_url() on the mozfest homepage should
+        # return "/en/", and the same language code should be sent to the tito widget block template.
+        response = self.client.get(self.mozfest_homepage.get_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["tito_widget_lang_code"], "en")
+        self.assertTemplateUsed(response, template_name="wagtailpages/blocks/tito_widget_block.html")
+
+    def test_lang_code_with_supported_non_default_language(self):
+        # Since FR is a Tito supported language, the tito widget block
+        # template should also be sent the language code "fr".
+        response = self.client.get("/fr/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["tito_widget_lang_code"], "fr")
+        self.assertTemplateUsed(response, template_name="wagtailpages/blocks/tito_widget_block.html")
+
+    def test_unsupported_language_defaults_to_english(self):
+        # Since fy-NL is a not a Tito supported language, the tito widget block
+        # template should default to the English language code "en".
+        response = self.client.get("/fy-NL/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["tito_widget_lang_code"], "en")
+        self.assertTemplateUsed(response, template_name="wagtailpages/blocks/tito_widget_block.html")

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
@@ -26,16 +26,19 @@ class TitoWidgetBlock(blocks.StructBlock):
 
     def get_context(self, request, parent_context=None):
         context = super().get_context(request, parent_context=parent_context)
-        language_code = get_language_from_request(request)
-        context["lang_code"] = self.get_widget_language_code(language_code)
+        request_language_code = get_language_from_request(context['request'])
+        context["lang_code"] = self.get_widget_language_code(request_language_code)
 
         return context
 
-    def get_widget_language_code(self, language_code):
+    # Checking if the user's requested language is currently supported by Tito.
+    # If not, default to English to prevent the Tito widget from crashing due to an unsupported language.
+    #
+    def get_widget_language_code(self, request_language_code):
+        tito_supported_language_codes = ["en", "de", "es", "fr", "nl", "pl"]
         default_language_code = settings.LANGUAGE_CODE
-        tito_supported_language_codes = {"en", "de", "es", "fr", "nl", "pl"}
 
-        if language_code in tito_supported_language_codes:
-            return language_code
+        if request_language_code in tito_supported_language_codes:
+            return request_language_code
         else:
             return default_language_code

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
@@ -26,7 +26,7 @@ class TitoWidgetBlock(blocks.StructBlock):
 
     def get_context(self, request, parent_context=None):
         context = super().get_context(request, parent_context=parent_context)
-        request_language_code = get_language_from_request(context['request'])
+        request_language_code = get_language_from_request(context["request"])
         context["lang_code"] = self.get_widget_language_code(request_language_code)
 
         return context

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
@@ -31,10 +31,12 @@ class TitoWidgetBlock(blocks.StructBlock):
 
         return context
 
-    # Checking if the user's requested language is currently supported by Tito.
-    # If not, default to English, to prevent the Tito widget from crashing due to an unsupported language.
-    # For more info see: https://github.com/mozilla/foundation.mozilla.org/issues/9790
     def get_widget_language_code(self, request_language_code):
+        """
+        Checking if the user's requested language is currently supported by Tito.
+        If not, default to English, to prevent the Tito widget from crashing due to an unsupported language.
+        For more info see: https://github.com/mozilla/foundation.mozilla.org/issues/9790
+        """
         tito_supported_language_codes = ["en", "de", "es", "fr", "nl", "pl"]
         default_language_code = settings.LANGUAGE_CODE
 

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
@@ -32,8 +32,8 @@ class TitoWidgetBlock(blocks.StructBlock):
         return context
 
     # Checking if the user's requested language is currently supported by Tito.
-    # If not, default to English to prevent the Tito widget from crashing due to an unsupported language.
-    #
+    # If not, default to English, to prevent the Tito widget from crashing due to an unsupported language.
+    # For more info see: https://github.com/mozilla/foundation.mozilla.org/issues/9790
     def get_widget_language_code(self, request_language_code):
         tito_supported_language_codes = ["en", "de", "es", "fr", "nl", "pl"]
         default_language_code = settings.LANGUAGE_CODE

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
@@ -27,7 +27,7 @@ class TitoWidgetBlock(blocks.StructBlock):
     def get_context(self, request, parent_context=None):
         context = super().get_context(request, parent_context=parent_context)
         request_language_code = get_language_from_request(context["request"])
-        context["lang_code"] = self.get_widget_language_code(request_language_code)
+        context["tito_widget_lang_code"] = self.get_widget_language_code(request_language_code)
 
         return context
 

--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
@@ -1,5 +1,8 @@
+from django.conf import settings
 from wagtail.core import blocks
 from wagtail.snippets.blocks import SnippetChooserBlock
+
+from networkapi.wagtailpages.utils import get_language_from_request
 
 
 class TitoWidgetBlock(blocks.StructBlock):
@@ -20,3 +23,19 @@ class TitoWidgetBlock(blocks.StructBlock):
     class Meta:
         icon = "form"
         template = "wagtailpages/blocks/tito_widget_block.html"
+
+    def get_context(self, request, parent_context=None):
+        context = super().get_context(request, parent_context=parent_context)
+        language_code = get_language_from_request(request)
+        context["lang_code"] = self.get_widget_language_code(language_code)
+
+        return context
+
+    def get_widget_language_code(self, language_code):
+        default_language_code = settings.LANGUAGE_CODE
+        tito_supported_language_codes = {"en", "de", "es", "fr", "nl", "pl"}
+
+        if language_code in tito_supported_language_codes:
+            return language_code
+        else:
+            return default_language_code

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
@@ -5,5 +5,5 @@
 {% block block_content %}
     <script src='https://js.tito.io/v2' async></script>
 
-    <tito-button event="{{ value.event.event_id }}" locale="{{ lang_code }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-4">{{ value.button_label }}</tito-button>
+    <tito-button event="{{ value.event.event_id }}" locale="{{ tito_widget_lang_code }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-4">{{ value.button_label }}</tito-button>
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
@@ -1,6 +1,5 @@
 {% extends "./base_streamfield_block.html" %}
 {% load i18n %}
-{% get_current_language as lang_code %}
 
 
 {% block block_content %}


### PR DESCRIPTION
# Description

This PR adds a new method to the Tito Widget Block titled `get_widget_language_code`, which checks the whether or not the user's requested language is supported in Tito.js. If so, let the Tito widget use that language. If not, default to EN, as sending an unsupported language will crash the widget.

Link to sample test page:
Related PRs/issues: #9790