### PR TITLE
Fixed PNI mobile speech bubble bug by removing old SCSS

### DIFF
--- a/source/sass/buyers-guide/views/catalog.scss
+++ b/source/sass/buyers-guide/views/catalog.scss
@@ -66,115 +66,93 @@ body {
   }
 
   .product-box-list-wrapper {
-    // Mixin for setting product box styling in product box list
-    @mixin product-box-size($box-margin: 1px, $items-per-row: 2) {
-      $num-of-gutter: $items-per-row;
-      $gutter-width: $box-margin * 2;
-      $row-total-gutter-width: $gutter-width * $num-of-gutter;
+    figure.product-box {
+      $padding-x: 12px;
+      $padding-y: 12px;
+      $privacy-ding-width: 30px;
+      $privacy-ding-height: 25px;
+      $recommendation-width: 17px;
+      $recommendation-height: 15.8px;
 
-      .product-box-list {
-        margin-right: -$box-margin;
-        margin-left: -$box-margin;
+      // Needed for animation state while JS loads
+      opacity: 0;
+
+      display: inline-block;
+      position: relative;
+      padding: $padding-y $padding-x;
+      background: $pni-product-list-background;
+
+      .privacy-ding {
+        @include privacy-ding(
+          $padding-y,
+          $padding-x,
+          $privacy-ding-width,
+          $privacy-ding-height
+        );
+
+        position: static;
       }
 
-      figure.product-box {
-        $padding-x: 12px;
-        $padding-y: 12px;
-        $privacy-ding-width: 30px;
-        $privacy-ding-height: 25px;
-        $recommendation-width: 17px;
-        $recommendation-height: 15.8px;
+      .adult-content-badge {
+        @include adult-content-badge($padding-y, $padding-x, 41px, 35px);
+      }
 
-        // Needed for animation state while JS loads
-        opacity: 0;
+      .top-left-badge-container {
+        $badge-spacing: 0.5rem;
 
-        display: inline-block;
+        position: absolute;
+        top: $padding-y;
+        left: $padding-x;
+        width: calc(
+          #{$privacy-ding-width} + #{$recommendation-width} + #{$badge-spacing}
+        );
+        height: $privacy-ding-height;
+        display: flex;
+        justify-content: space-between;
+      }
+
+      .product-image {
+        img {
+          margin: 0 auto;
+
+          @media (min-width: $breakpoint) {
+            max-width: 78%;
+          }
+        }
+      }
+
+      .product-links {
+        @include hover-focus-active {
+          text-decoration: none;
+        }
+
+        @media screen and (max-width: $breakpoint) {
+          .product-company {
+            color: $gray-80;
+            font-size: 12px;
+            line-height: calc(16 / 12);
+          }
+
+          .product-name {
+            color: $black;
+            font-size: 12px;
+            line-height: calc(16 / 12);
+          }
+        }
+      }
+
+      figcaption {
+        color: $gray-40;
         position: relative;
-        padding: $padding-y $padding-x;
-        background: $pni-product-list-background;
+        bottom: -($padding-y/2); // to offset the extra bottom spacing from line-height
 
-        .privacy-ding {
-          @include privacy-ding(
-            $padding-y,
-            $padding-x,
-            $privacy-ding-width,
-            $privacy-ding-height
-          );
-
-          position: static;
-        }
-
-        .adult-content-badge {
-          @include adult-content-badge($padding-y, $padding-x, 41px, 35px);
-        }
-
-        .top-left-badge-container {
-          $badge-spacing: 0.5rem;
-
-          position: absolute;
-          top: $padding-y;
-          left: $padding-x;
-          width: calc(
-            #{$privacy-ding-width} + #{$recommendation-width} + #{$badge-spacing}
-          );
-          height: $privacy-ding-height;
-          display: flex;
-          justify-content: space-between;
-        }
-
-        .product-image {
-          img {
-            margin: 0 auto;
-
-            @media (min-width: $breakpoint) {
-              max-width: 78%;
-            }
-          }
-        }
-
-        .product-links {
-          @include hover-focus-active {
-            text-decoration: none;
-          }
-
-          @media screen and (max-width: $breakpoint) {
-            .product-company {
-              color: $gray-80;
-              font-size: 12px;
-              line-height: calc(16 / 12);
-            }
-
-            .product-name {
-              color: $black;
-              font-size: 12px;
-              line-height: calc(16 / 12);
-            }
-          }
-        }
-
-        figcaption {
-          color: $gray-40;
-          position: relative;
-          bottom: -($padding-y/2); // to offset the extra bottom spacing from line-height
-
-          .tw-body {
-            font-weight: initial;
-          }
+        .tw-body {
+          font-weight: initial;
         }
       }
     }
 
     overflow-x: hidden;
-
-    @include product-box-size(1px, 2);
-
-    @media (min-width: $bp-md) {
-      @include product-box-size(1px, 3);
-    }
-
-    @media (min-width: $bp-lg) {
-      @include product-box-size(1px, 4);
-    }
   }
 
   .project-list-section {


### PR DESCRIPTION
# Description

BUG: PNI homepage - Speech bubble and creep-o-meter emoji don't update on small screens (width < 768px)

The root cause of this bug is old SCSS adding "negative" 1px left/right margins to `product-box-list` which makes `product-box-list` wider than mobile viewport by 1px + 1px = 2px. This means `product-box`(children) in `product-box-list`(parent) can grow outisde of the viewport. We use [`isElementInViewport` function](https://github.com/mozilla/foundation.mozilla.org/blob/main/source/js/buyers-guide/homepage-c-slider.js#L30-L46) to check if an element is fully visibly in viewport so the speech bubble knows whether or not to update its content. An element that's bigger than viewport will always fail the check and that's the case for `product-box`. By removing old SCSS code, we make sure the parent container `product-box-list` is contained within the viewport size.

I also removed a bunch of SCSS code that isn't in use anymore. 

(For PR reviewer: It's easier to review code changes in this PR without whitespace differences.)

<!-- Describe the PR here -->

Link to sample test page: `/privacynotincluded` 
Related PRs/issues: #9942

### QA Steps
  - view PNI on mobile screen size
  - scroll up and down and verify speech bubble face/content get updated
  - note that speech bubble can act a little glitchy if products are sorted alphabetically instead of by creepiness. This is not a bug but more of a design issue. I filed ticket #10056 to address that.


