### PR TITLE
#9267 Enable profile snippet search

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/profiles.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/profiles.py
@@ -3,6 +3,7 @@ from django.utils.text import slugify
 from wagtail.admin.edit_handlers import FieldPanel
 from wagtail.core.models import TranslatableMixin
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 from wagtail_localize.fields import SynchronizedField, TranslatableField
 
@@ -16,7 +17,7 @@ class ProfileQuerySet(models.QuerySet):
 
 
 @register_snippet
-class Profile(TranslatableMixin, models.Model):
+class Profile(index.Indexed, TranslatableMixin, models.Model):
     name = models.CharField(max_length=70, blank=False)
 
     image = models.ForeignKey(
@@ -50,6 +51,13 @@ class Profile(TranslatableMixin, models.Model):
         TranslatableField("tagline"),
         TranslatableField("introduction"),
     ]
+
+    search_fields = [
+        index.SearchField("name", partial_match=True),
+        # Needed for locale filtering in the Wagtail admin. A helpful error message pointed this out.
+        index.FilterField("locale_id"),
+    ]
+
     objects = ProfileQuerySet.as_manager()
 
     def __str__(self):


### PR DESCRIPTION
# Description

This PR enables search for Profile snippets by name. 
This should help staff avoid creating duplicate entries and aid selection on pages. 

This PR also fixes the blog page factory to included the required search image. 
This should make it easier for testing on the example page, because you don't have to fix that issue before you can publish the blog page with a new author profile selected. 

Link to sample test page: http://localhost:8000/cms/pages/13/edit/
Related PRs/issues: #9267 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~ It's basic Wagtail configuration

**Changes in Models:**
- [x] Did I update or add new fake data?
- ~~[ ] Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
