### PR TITLE
Add option to trigger visual regression test with label

### DIFF
--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   visual_regression_tests:
     name: Percy CI
-    if: (github.event_name == 'push' && github.event.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.label == 'run visual regression tests') || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+    if: (github.event_name == 'push' && github.event.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.label.name == 'run visual regression tests') || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
     runs-on: ubuntu-20.04
     services:
       postgres:

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -1,6 +1,8 @@
 name: Visual Regression Tests
 
 on:
+  pull_request:
+    types: [labeled]
   pull_request_review:
     types: [submitted]
   push:
@@ -9,7 +11,7 @@ on:
 jobs:
   visual_regression_tests:
     name: Percy CI
-    if: (github.event_name == 'push' && github.event.ref == 'refs/heads/main') || github.event.review.state == 'approved'
+    if: (github.event_name == 'push' && github.event.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.label == 'run visual regression tests') || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
     runs-on: ubuntu-20.04
     services:
       postgres:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -84,4 +84,9 @@ Note that any changes to model fields, field ordering, or factories, will likely
 
 It is possible that a PR has Percy-flagged changes, despite the PR not touching model/factory code nor introducing changes to the front-end code. In this case, please alert the engineering team: we've seen this happen in the past and it is unclear why it happens.
 
+Because we have run into the need to check visual regression manually pretty quickly after adding the above, you can also trigger visual regression tests by adding the label `run visual regression tests` to the PR.
+The **adding** is the trigger.
+So if you want to run the tests again, just remove and re-add the label.
+The PR approval trigger will also still run the regression tests.
+
 For more information on how to work with visual regression tests, see the [Percy docs](https://docs.percy.io/docs).


### PR DESCRIPTION
# Description

It came up for @mmmavis today and I was also running in to a case where I want to check visual regression again without a review. 

So I thought I add an option to trigger CI with a label. Adding the `run visual regression tests` label will trigger the run.  I have triggered this run: https://github.com/mozilla/foundation.mozilla.org/actions/runs/4079366797/jobs/7030666368

If you want to trigger it again, you remove the label and add it back (because the **adding** is the trigger). 



# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~ Self testing in a way. 

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~[ ] Is my code documented?~~
- [ ] Did I update the READMEs or wagtail documentation?
