### PR TITLE
PNI mobile search - added a 'x' control for closing the search bar

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
@@ -34,11 +34,19 @@
     <div class="d-flex align-items-center">
         {% include "fragments/buyersguide/pni_nav_links.html" with class="primary-nav-special-link pni-nav-link tw-hidden large:tw-block" %}
         {% if page.signup == None %}<button class="tw-btn-secondary btn-newsletter d-none d-lg-block ml-md-3">{% trans "Newsletter" %}</button>{% endif %}
-        <button class="tw-bg-transparent" id="mobile-search">
-            <img
-                class="large:tw-hidden tw-w-12 tw-h-12"
-                src="{% static "_images/buyers-guide/pni-search.svg" %}"
+        <label for="mobile-search" class=" large:tw-hidden tw-cursor-pointer">
+            <input id="mobile-search" type="checkbox"
+                class="tw-appearance-none
+                    tw-w-5
+                    tw-h-5
+                    tw-cursor-pointer
+                    tw-bg-[url('../_images/buyers-guide/pni-search.svg')]
+                    checked:tw-bg-[url('../_images/buyers-guide/pni-search-close.svg')]
+                    checked:tw-bg-8
+                    tw-bg-no-repeat
+                    tw-bg-center
+                "
             >
-        </button>
+        </label>
     </div>
 {% endblock %}

--- a/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
@@ -37,8 +37,8 @@
         <label for="mobile-search" class="large:tw-hidden tw-cursor-pointer tw-mb-0">
             <input id="mobile-search" type="checkbox"
                 class="tw-appearance-none
-                    tw-w-5
-                    tw-h-5
+                    tw-w-12
+                    tw-h-12
                     tw-cursor-pointer
                     tw-bg-[url('../_images/buyers-guide/pni-search.svg')]
                     checked:tw-bg-[url('../_images/buyers-guide/pni-search-close.svg')]

--- a/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
@@ -34,7 +34,7 @@
     <div class="d-flex align-items-center">
         {% include "fragments/buyersguide/pni_nav_links.html" with class="primary-nav-special-link pni-nav-link tw-hidden large:tw-block" %}
         {% if page.signup == None %}<button class="tw-btn-secondary btn-newsletter d-none d-lg-block ml-md-3">{% trans "Newsletter" %}</button>{% endif %}
-        <label for="mobile-search" class=" large:tw-hidden tw-cursor-pointer">
+        <label for="mobile-search" class="large:tw-hidden tw-cursor-pointer tw-mb-0">
             <input id="mobile-search" type="checkbox"
                 class="tw-appearance-none
                     tw-w-5

--- a/source/images/buyers-guide/pni-search-close.svg
+++ b/source/images/buyers-guide/pni-search-close.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_138_16069)" stroke="#3032D9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.857 1.143L1.143 14.857M1.143 1.143l13.714 13.714"/></g><defs><clipPath id="clip0_138_16069"><path fill="#fff" d="M0 0h16v16H0z"/></clipPath></defs></svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -67,9 +67,12 @@ module.exports = {
       cursor: {
         grabbing: "grabbing",
       },
-      backgroundSize: {
-        '8': '1rem'
-      }
+      backgroundSize: ({ theme }) => ({
+        auto: "auto",
+        cover: "cover",
+        contain: "contain",
+        ...theme("spacing"),
+      }),
     },
     // Overriding default spacing
     spacing: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -67,6 +67,9 @@ module.exports = {
       cursor: {
         grabbing: "grabbing",
       },
+      backgroundSize: {
+        '8': '1rem'
+      }
     },
     // Overriding default spacing
     spacing: {


### PR DESCRIPTION
# Description

Follow-up PR to address the new AC in #10051

> (on mobile) As a user, when search mode is activated, the top right magnifying glass icon becomes a 'x' button which can be used to close the search bar

Request came from https://github.com/mozilla/foundation.mozilla.org/issues/10051#issuecomment-1414493654

---

Link to sample test page: `/privacynotincluded`
Related PRs/issues: #10051

Steps to QA:
- go to PNI on small screen
- toggle search bar
- see if search icon changes from magnifying glass to x

Note: SVG file has been optimized.


https://user-images.githubusercontent.com/2896608/216536539-cb93edbe-8933-40c5-970d-31b305db00ae.mov

