### PR TITLE
updated spacing for fade effect

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -76,7 +76,7 @@
         <div class="container">
             <div class="row tw-mb-6 medium:tw-mb-4">
                 <div class="tw-w-full tw-px-4 xlarge:tw-px-0 tw-flex tw-relative tw-flex-wrap medium:tw-flex-nowrap medium:tw-left-auto medium:tw-ml-0 medium:tw-static">
-                    <div class="tw-flex tw-items-end tw-space-x-2 tw-overflow-auto tw-pb-2 tw-no-scrollbar tw-touch-pan-x tw-w-full subcategory-header medium:tw-mr-3 medium:tw-pr-3 medium:[mask:linear-gradient(to_right,black_calc(100%-25px),transparent)]">
+                    <div class="tw-flex tw-items-end tw-space-x-2 tw-overflow-auto tw-pb-2 tw-no-scrollbar tw-touch-pan-x tw-w-full subcategory-header medium:tw-mr-3 medium:tw-pr-5 medium:[mask:linear-gradient(to_right,black_calc(100%-24px),transparent)]">
 
                         <span id="product-filter-pni" class="tw-flex tw-cursor-pointer tw-text-gray-60 border tw-border-gray-20 tw-px-2 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3] tw-bg-white hover:tw-border-blue-10 hover:tw-bg-blue-10">
                             <input type="checkbox" id="product-filter-pni-toggle" autocomplete="off">


### PR DESCRIPTION
# Description
Link to sample test page: http://localhost:8000/en/privacynotincluded/categories/smart-home/

Related PRs/issues: #9871 


After QA testing the fade effect on the subcategory bar for privacy not included, it was found that the fade effect can be seen on the last item in the list:

![image](https://user-images.githubusercontent.com/18314510/216686301-8b592839-dbd3-4f66-b095-765a77a7b6a8.png)


This PR updates the spacing so that no longer occurs:

![Screenshot 2023-02-03 at 11-02-19 Privacy Not Included A Buyer’s Guide for Connected Products](https://user-images.githubusercontent.com/18314510/216686365-26534a9a-0090-478d-b3f5-8f1e39e24f4e.png)

![Screenshot 2023-02-03 at 11-02-25 Privacy Not Included A Buyer’s Guide for Connected Products](https://user-images.githubusercontent.com/18314510/216686374-58ecfa2c-dfe3-4e71-8963-8d3dc46c70b2.png)

