### PR TITLE
fixed merge conflict markers

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/accordion_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/accordion_block.html
@@ -6,17 +6,12 @@
     <div class="tw-row">
         {% for block in self.accordion_items %}
             <details class="tw-w-full tw-font-sans tw-font-light tw-mx-8">
-<<<<<<< HEAD
                 <summary class="tw-list-none [&::-webkit-details-marker]:tw-hidden tw-w-full tw-text-lg tw-leading-7 tw-min-h-40 py-3 d-flex align-items-center tw-border-t-gray-20 tw-border-t">
                     <span class="tw-mr-auto">{{block.title}}</span>
-=======
-                <summary class="tw-list-none tw-w-full tw-text-lg tw-leading-7 tw-min-h-40 py-3 d-flex align-items-center tw-border-t-gray-20 tw-border-t">
-                    <span class="tw-mr-auto">{{ block.title }}</span>
->>>>>>> origin/main
                     <img src="{% static "_images/plus-circle.svg" %}" alt="" data-state="open" class="summary-open:tw-hidden" />
                     <img src="{% static "_images/minus-circle.svg" %}" alt="" data-state="close" class="tw-hidden summary-open:tw-block" />
                 </summary>
-                {% with item=block count=self.accordion_items|length %}
+                {% with istem=block count=self.accordion_items|length %}
                     {{ item.content }}
                 {% endwith %}
             </details>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/accordion_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/accordion_block.html
@@ -11,7 +11,7 @@
                     <img src="{% static "_images/plus-circle.svg" %}" alt="" data-state="open" class="summary-open:tw-hidden" />
                     <img src="{% static "_images/minus-circle.svg" %}" alt="" data-state="close" class="tw-hidden summary-open:tw-block" />
                 </summary>
-                {% with istem=block count=self.accordion_items|length %}
+                {% with item=block count=self.accordion_items|length %}
                     {{ item.content }}
                 {% endwith %}
             </details>


### PR DESCRIPTION
# Description

Link to sample test page:
Related PRs/issues: #10155 


It looks like I did not save the accordion block template file after fixing a merge conflict, and the diff markers got merged into the template:

<img width="552" alt="image" src="https://user-images.githubusercontent.com/18314510/220802542-7b7e361c-e134-4381-a5fd-839332667807.png">


This PR fixes this by removing them.