### PR TITLE
Restrict styles applied to migrated content

### DIFF
--- a/foundation_cms/static/scss/type.scss
+++ b/foundation_cms/static/scss/type.scss
@@ -242,34 +242,36 @@ $quote-text-styles: (
 // Heading
 // ===================================
 
-h1,
-.h1-style {
-  @include mofo-text-style($header-styles, "h1", $header-font-family);
-}
+body.redesign {
+  h1,
+  .h1-style {
+    @include mofo-text-style($header-styles, "h1", $header-font-family);
+  }
 
-h2,
-.h2-style {
-  @include mofo-text-style($header-styles, "h2", $header-font-family);
-}
+  h2,
+  .h2-style {
+    @include mofo-text-style($header-styles, "h2", $header-font-family);
+  }
 
-h3,
-.h3-style {
-  @include mofo-text-style($header-styles, "h3", $header-font-family);
-}
+  h3,
+  .h3-style {
+    @include mofo-text-style($header-styles, "h3", $header-font-family);
+  }
 
-h4,
-.h4-style {
-  @include mofo-text-style($header-styles, "h4", $header-font-family);
-}
+  h4,
+  .h4-style {
+    @include mofo-text-style($header-styles, "h4", $header-font-family);
+  }
 
-h5,
-.h5-style {
-  @include mofo-text-style($header-styles, "h5", $header-font-family);
-}
+  h5,
+  .h5-style {
+    @include mofo-text-style($header-styles, "h5", $header-font-family);
+  }
 
-h6,
-.h6-style {
-  @include mofo-text-style($header-styles, "h6", $header-font-family);
+  h6,
+  .h6-style {
+    @include mofo-text-style($header-styles, "h6", $header-font-family);
+  }
 }
 
 // ===================================

--- a/foundation_cms/templates/base.html
+++ b/foundation_cms/templates/base.html
@@ -39,7 +39,7 @@
         {% endblock fundraiseup_script %}
     </head>
 
-    <body class="{% block body_class %}{% endblock body_class %}">
+    <body class="{% block body_class %}{% endblock body_class %} redesign">
     {# Basic breadcrumbs for dev navigation #}
         {% with self as page %}
             <nav aria-label="Breadcrumb">


### PR DESCRIPTION
# Description

This PR implements a base body hardcoded `redesign` classname to cover all potential colliding styling rules that may apply to migrated content. This is considered a temporary measure and should be refactored to tailor the design spec for the migrated content.

![image](https://github.com/user-attachments/assets/444e104f-5ad4-417d-b55e-4c30e306d005)

# To test
In upcoming PRs, Percy results should not raise differences once the `redesign_migrated_content.scss` stylesheet collects all the needed modules.

Related PRs/issues: #14146

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2865)
