### PR TITLE
Add new template filter 'should_wrap_block' to allow full bleed blocks

### DIFF
--- a/foundation_cms/settings/base.py
+++ b/foundation_cms/settings/base.py
@@ -387,6 +387,7 @@ TEMPLATES = [
                 "primary_page_tags": "foundation_cms.legacy_apps.wagtailpages.templatetags.primary_page_tags",
                 "settings_value": "foundation_cms.legacy_apps.utility.templatetags.settings_value",
                 "impact_numbers_tags": "foundation_cms.templatetags.impact_numbers_tags",
+                "streamfield_tags": "foundation_cms.templatetags.streamfield_tags",
                 "wagtailcustom_tags": (
                     "foundation_cms.legacy_apps" ".wagtailcustomization.templatetags.wagtailcustom_tags"
                 ),

--- a/foundation_cms/static/scss/redesign_main.scss
+++ b/foundation_cms/static/scss/redesign_main.scss
@@ -5,6 +5,7 @@
 @import "../scss/colors";
 @import "../scss/type";
 @import "../scss/buttons";
+@import "../scss/utilities";
 
 // Site-wide Blocks
 @import "../scss/blocks/themes/default/impact_number_block";

--- a/foundation_cms/static/scss/utilities.scss
+++ b/foundation_cms/static/scss/utilities.scss
@@ -1,0 +1,9 @@
+.grid-container {
+  // this class is useful if you need to have a full-bleed grid-container on mobile
+  &.mobile-padding-0 {
+    @include breakpoint(large down) {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
+}

--- a/foundation_cms/templates/patterns/components/streamfield.html
+++ b/foundation_cms/templates/patterns/components/streamfield.html
@@ -1,5 +1,15 @@
-{% load wagtailcore_tags %}
+{% load wagtailcore_tags streamfield_tags %}
 
 {% for block in streamfield %}
+  {% if block.block_type|should_wrap_block %}
+    <div class="grid-container">
+      <div class="grid-x">
+        <div class="cell">
+          {% include_block block %}
+        </div>
+      </div>
+    </div>
+  {% else %}
     {% include_block block %}
+  {% endif %}
 {% endfor %}

--- a/foundation_cms/templates/patterns/pages/core/home_page.html
+++ b/foundation_cms/templates/patterns/pages/core/home_page.html
@@ -26,13 +26,7 @@
   <!-- Main Content -->
   <main>
     {% if page.body %}
-      <div class="grid-container">
-        <div class="grid-x">
-          <div class="cell">
-            {% include "patterns/components/streamfield.html" with streamfield=page.body %}
-          </div>
-        </div>
-      </div>
+      {% include "patterns/components/streamfield.html" with streamfield=page.body %}
     {% endif %}
   </main>
 

--- a/foundation_cms/templatetags/streamfield_tags.py
+++ b/foundation_cms/templatetags/streamfield_tags.py
@@ -1,0 +1,12 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def should_wrap_block(block_type):
+    # This is used in streamfield.html to determine if a block should be pre-wrapped with .grid-container etc
+    NO_WRAP_BLOCKS = {
+        "spotlight_card_set_block",
+    }
+    return block_type not in NO_WRAP_BLOCKS


### PR DESCRIPTION
Add new template filter `'should_wrap_block'` to allow full bleed blocks.

To test locally,

1. Go to `foundation_cms/templatetags/streamfield_tags.py`
1. Add name of the block you wanna test to `NO_WRAP_BLOCKS`
1. Go to CMS and add the block to homepage
1. Inspect source code in dev tool
1. Verify the block itself is not pre-wrapped in `.grid-container`, `.grid-x`, and `.cell`

Related PRs/issues: N/A



┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2905)
