### PR TITLE
Add OG Images and Wagtail Metadata

### DIFF
--- a/foundation_cms/templates/base.html
+++ b/foundation_cms/templates/base.html
@@ -25,7 +25,6 @@
             {% meta_tags %}
         {% endblock wagtail_metadata %}
 
-
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     {# Force all links in the live preview panel to be opened in a new tab #}
         {% if request.in_preview_panel %}


### PR DESCRIPTION
# Description

This PR updates the `base.html` template to include wagtail metadata like `og:image`

Related PRs/issues: TP1-3056

# Test
1) Open a redesign homepage and view page source
2) Note there are no meta tags for "og:image"
3) Check out this branch and refresh the homepage
4) Note meta tags for "og:image" are now loading properly