### PR TITLE
Fix alt text default error

### DIFF
--- a/foundation_cms/templates/patterns/components/nothing_personal/article_page_header.html
+++ b/foundation_cms/templates/patterns/components/nothing_personal/article_page_header.html
@@ -29,7 +29,7 @@
             src="{{ img_large.url }}"
             width="{{ img_large.width }}"
             height="{{ img_large.height }}"
-            alt="{{ page.hero_image_alt_text|default:img_large.alt }}"
+            alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}"
             loading="lazy"
           >
         </picture>


### PR DESCRIPTION
# Description

This PR fixes a [key] issue on hero images when finding the default alt text value, allowing users to upload images again.

Related PRs/issues: TP1-3184
Test page: https://foundation-s-tp1-3184-i-gadb87.herokuapp.com/en/np/article-page-w-gif/