### PR TITLE
Disable Percy check temporarily

### DIFF
--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -83,7 +83,9 @@ jobs:
           python ./manage.py block_inventory
           python ./manage.py load_redesign_data
           python ./manage.py legacy_load_fake_data
-      - name: Percy Test
-        run: yarn workspace legacy percy
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      # TODO: Percy is currently experiencing "stuck processing" issues
+      # Re-enable this step once the issues are fixed
+      # - name: Percy Test
+      #   run: yarn workspace legacy percy
+      #   env:
+      #     PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
Percy is currently experiencing "stuck processing" issues. Disabling it for now so the pipeline can move again