### PR TITLE
updated newsletter unsubscribe form error message

### DIFF
--- a/foundation_cms/templates/patterns/components/newsletter_unsubscribe_form.html
+++ b/foundation_cms/templates/patterns/components/newsletter_unsubscribe_form.html
@@ -3,7 +3,7 @@
 <div class="newsletter-signup newsletter-unsubscribe__container" data-signup-id="{{ newsletter_unsubscribe.id }}" data-layout="expand_on_focus">
 
   <div class="newsletter-signup__error-message newsletter-signup__error-message--hidden">
-    {% trans "Something went wrong and your signup wasn't completed. Please try again later." %}
+    {% trans "Something went wrong and your unsubscribe wasn't completed. Please try again later." %}
   </div>
 
   <form class="newsletter-signup__form" novalidate>


### PR DESCRIPTION
# Description
This PR updates the error message in the newsletter unsubscribe block to say "unsubscribe" instead of "signup".