### PR TITLE
Include camo subscription for tito

### DIFF
--- a/foundation_cms/legacy_apps/events/views.py
+++ b/foundation_cms/legacy_apps/events/views.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 import basket
-import settings
+from django.conf import settings
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST


### PR DESCRIPTION
# Description

This PR adds a minimal re-write of tito signup to account for the new camo subscription changeover.

Mimicking the `foundation_cms/views.py` implementation for a quick fix.

Link to sample test page:
Related PRs/issues: #