### PR TITLE
Revert FA newsletter value

### DIFF
--- a/foundation_cms/legacy_apps/wagtailpages/templates/wagtailpages/fragments/formassembly_body_camo.html
+++ b/foundation_cms/legacy_apps/wagtailpages/templates/wagtailpages/fragments/formassembly_body_camo.html
@@ -23,7 +23,7 @@ If there are any updates to this form (which is unlikely), please follow the ins
             wFORMS.behaviors.condition.isConditionalSubmitAllowed = true;
         </script></div>
         <form method="post" action="https://mozillafoundation.tfaforms.net/api_v2/workflow/processor" class=" labelsAbove" id="187" role="form">
-            <input type="hidden" id="tfa_500" name="tfa_500" value="{{ thank_you_url_tfa_500 }}" class=""><input type="hidden" id="tfa_1" name="tfa_1" value="{{ campaign_id_tfa_1 }}" class=""><input type="hidden" id="tfa_498" name="tfa_498" value="{{ source_url_tfa_498 }}" class=""><input type="hidden" id="tfa_499" name="tfa_499" value="{{ lang_tfa_499 }}" class=""><input type="hidden" id="tfa_501" name="tfa_501" value="mozillafoundationorg" class=""><div class="oneField field-container-D    " id="tfa_28-D">
+            <input type="hidden" id="tfa_500" name="tfa_500" value="{{ thank_you_url_tfa_500 }}" class=""><input type="hidden" id="tfa_1" name="tfa_1" value="{{ campaign_id_tfa_1 }}" class=""><input type="hidden" id="tfa_498" name="tfa_498" value="{{ source_url_tfa_498 }}" class=""><input type="hidden" id="tfa_499" name="tfa_499" value="{{ lang_tfa_499 }}" class=""><input type="hidden" id="tfa_501" name="tfa_501" value="mozilla-foundation" class=""><div class="oneField field-container-D    " id="tfa_28-D">
                 <label id="tfa_28-L" class="label preField reqMark" for="tfa_28">{% trans "First Name" %}</label><br><div class="inputWrapper"><input aria-required="true" type="text" id="tfa_28" name="tfa_28" value="" title="{% trans "First Name" %}" class="required"></div>
             </div>
             <div class="oneField field-container-D    " id="tfa_30-D">


### PR DESCRIPTION
# Description

This PR reverts the form assembly newsletter name change from #14895. Per Kris, the FA api actually does still use `mozilla-foundation`