### PR TITLE
Pushdown Donate Banner fix - prevents child margin from collapsing through .main-content-wrapper

### DIFF
--- a/foundation_cms/static/scss/_layout.scss
+++ b/foundation_cms/static/scss/_layout.scss
@@ -1,5 +1,6 @@
 @use "sass:map";
 
 .main-content-wrapper {
+  padding-top: 1px; // prevents child margin from collapsing
   background-color: map.get($mofo-colors, white);
 }


### PR DESCRIPTION
# Description

Fix gap between nav and body content on NP pages by improving CSS to prevent child margin from collapsing through `.main-content-wrapper`

Link to sample test page:
Related PRs/issues: [Jira TP1-3349](https://mozilla-hub.atlassian.net/browse/TP1-3349) / https://github.com/MozillaFoundation/foundation.mozilla.org/issues/14928

# To test

1. check out this branch locally and run it
2. set up a Pushdown Donate Banner
3. go to NP pages to test

