### PR TITLE
Fix donate banner content alignment on Safari

### DIFF
--- a/foundation_cms/static/scss/components/donate_banner/donate_banner.scss
+++ b/foundation_cms/static/scss/components/donate_banner/donate_banner.scss
@@ -64,6 +64,7 @@
     align-content: center;
     background: $white;
     padding: 0 1rem 1rem;
+    align-self: center;
 
     @include breakpoint(medium up) {
       padding: 0;


### PR DESCRIPTION
# Description

Ensure content in each donate banner section is vertically positioned at center.

Related PRs/issues: [Jira TP1-3344](https://mozilla-hub.atlassian.net/browse/TP1-3344) / https://github.com/MozillaFoundation/foundation.mozilla.org/issues/14928

---

# To Test

- Check out this branch and run it locally
- Set up a donate banner
- Check donate banner on Safari and verify content in each donate banner section is vertically positioned at center like below
<img width="1306" height="642" alt="image" src="https://github.com/user-attachments/assets/ae78fea9-bcdc-46f9-87cf-945692adf22a" />
