### PR TITLE
Update Percy workflow to only run on legacy file changes

### DIFF
--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -19,6 +19,7 @@ jobs:
   visual_regression_tests:
     name: Percy CI - Legacy
     if: |
+      # [TODO:FIXME] remove github.event.ref == 'refs/heads/2025-code-freeze' after code freeze ends
       (github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/2025-code-freeze')) ||
       (github.event_name == 'pull_request' && github.event.label.name == 'run:visual-regression:legacy') ||
       (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')


### PR DESCRIPTION
This PR updates how visual regression test CI triggered.

Related PRs/issues: [Jira TP1-3453](https://mozilla-hub.atlassian.net/browse/TP1-3453) / GitHub https://github.com/MozillaFoundation/foundation.mozilla.org/issues/15075

## Current

Visual regression test is triggered when
- when a PR gets R+
- or when `run visual regression tests` label is added to the PR

## New

- a new label `run:visual-regression:legacy` has been created
- `run visual regression tests` label will be deprecated once this PR is in `main`
- CI test name is now `Visual Regression Tests - Legacy`


Visual regression test is triggered when
- The PR has changes made in `foundation_cms/legacy_apps/**` or `frontend/legacy/**`
- **AND** 
  - when it gets R+
  - or when `run:visual-regression:legacy` label is added to the PR


## To Test

- Use this PR (no code change to legacy codebase) to confirm visual regression tests won't get triggered
- Use https://github.com/MozillaFoundation/foundation.mozilla.org/pull/15124 (contains code change to legacy codebase) to confirm visual regression will trigger when the conditions are met

