### PR TITLE
Fixed CampaignPage "Keep Contributing" section bug

### DIFF
--- a/foundation_cms/campaigns/models/campaign_page.py
+++ b/foundation_cms/campaigns/models/campaign_page.py
@@ -310,7 +310,7 @@ class CampaignPage(AbstractBasePage):
     def get_keep_contributing_pages(self):
         # 1. If pages have been manually selected for this section, use those.
         if self.keep_contributing_pages.count() == 2:
-            return self.get_selected_keep_contributing_pages()
+            return self.get_selected_keep_contributing_pages
 
         # 2. Else, if a topic is set, use topic-related pages.
         elif self.keep_contributing_topic:


### PR DESCRIPTION
# Description

Currently, the `CampaignPage` model would return an error stating `PageQuerySet object is not callable` when trying to utilize the "Pick two pages to populate the `Keep Contributing` section of the page" functionality at the bottom of the CMS. 

After investigating, I found that this was due to us using `()` on the return statement, since this method returns a query set.

Removing the () from the line fixes the issue, and allows all 3 options of populating the "Keep Contributing" section:

- Selecting two pages
- Selecting a tag/topic and returning the two latest pages with that tag
- Returning two latest pages in the DB

working as expected.

# Screenshots

2 Pages selected in the CMS:
<img width="3456" height="1824" alt="Screenshot 2026-01-12 at 23-06-07 Editing Campaign Page (New) Test Campaign Page 1 - Wagtail" src="https://github.com/user-attachments/assets/7c49750e-d0c2-4c64-a288-9d8e444213b5" />

Those same two pages being rendered on the frontend:
<img width="3456" height="1824" alt="Screenshot 2026-01-12 at 23-08-16 Test Campaign Page 1 - Mozilla Foundation" src="https://github.com/user-attachments/assets/81346899-953f-4785-9c7a-3ac0d7aa3332" />

Tag selected on the CMS:
<img width="3456" height="1824" alt="Screenshot 2026-01-12 at 23-09-01 Editing Campaign Page (New) Test Campaign Page 1 - Wagtail" src="https://github.com/user-attachments/assets/d52c5486-1d99-46bf-826d-8906d17d732f" />

Tagged pages being shown:
<img width="3456" height="1824" alt="Screenshot 2026-01-12 at 23-09-29 Test Campaign Page 1 - Mozilla Foundation" src="https://github.com/user-attachments/assets/aa24c2fa-a68f-4a55-b5bf-5d613906530a" />


Neither field selected:
<img width="3456" height="1824" alt="Screenshot 2026-01-12 at 23-10-44 Editing Campaign Page (New) Test Campaign Page 1 - Wagtail" src="https://github.com/user-attachments/assets/cbe3783d-b4ab-4a87-8376-29e06bd66cc5" />

Two most recent campaign pages shown:
<img width="3456" height="1824" alt="Screenshot 2026-01-12 at 23-11-00 Test Campaign Page 1 - Mozilla Foundation" src="https://github.com/user-attachments/assets/c7f791d9-7485-4215-9c1b-e3aff52260fa" />





