### PR TITLE
Fix incorrect page categorization in topic listings

### DIFF
--- a/foundation_cms/core/models/home_page.py
+++ b/foundation_cms/core/models/home_page.py
@@ -42,9 +42,12 @@ class HomePage(RoutablePageMixin, AbstractHomePage):
 
     @route(r"^topics/(?P<slug>[-\w]+)/$")
     def topic_listing(self, request, slug):
+        from foundation_cms.nothing_personal.models import NothingPersonalHomePage
+
         (DEFAULT_LOCALE, DEFAULT_LOCALE_ID) = get_default_locale()
 
         topic = get_object_or_404(Topic, slug=slug)
+        np_home = NothingPersonalHomePage.objects.live().first()
 
         # Grabbing all pages in the DB with this topic, in the default locale.
         base_qs = (
@@ -58,12 +61,13 @@ class HomePage(RoutablePageMixin, AbstractHomePage):
 
         total_pages_count = base_qs.count()
 
-        # Separating child pages of the NothingPersonalHomePage from the original queryset.
-        # todo: Ensure this self reference extracts the correct page.
-        np_pages = base_qs.child_of(self)
-
-        # All other pages with this topic, excluding the above child pages.
-        other_pages = base_qs.exclude(id__in=np_pages.values_list("id", flat=True))
+        if np_home:
+            np_pages = base_qs.child_of(np_home)
+            # All other pages with this topic, excluding the NP child pages.
+            other_pages = base_qs.exclude(id__in=np_pages.values_list("id", flat=True))
+        else:
+            np_pages = Page.objects.none()
+            other_pages = base_qs
 
         # Ordering both querysets by most recently published first, and converting to specific.
         np_pages = np_pages.order_by("-last_published_at").specific()


### PR DESCRIPTION
# Description
Topic listing was looking for children of `HomePage` instead of `NothingPersonalHomePage`, causing NP content to appear in the wrong section. This fix ensures NP pages (articles, podcasts, etc.) appear in the dedicated NP section.

Related PRs/issues: [Jira TP1-3556](https://mozilla-hub.atlassian.net/browse/TP1-3556) / GitHub https://github.com/MozillaFoundation/foundation.mozilla.org/issues/15230

## To Test

- Go to https://foundation-s-tp1-3556-t-9fxmrk.mofostaging.net/en/topics/test/
- Verify NP pages are listed under NP section (article pages, podcast pages etc) & Non-NP pages are listed under the Mozilla Foundation section