### PR TITLE
Update Portrait Card Set background colours

### DIFF
--- a/foundation_cms/static/scss/blocks/themes/default/portrait_card_set.scss
+++ b/foundation_cms/static/scss/blocks/themes/default/portrait_card_set.scss
@@ -16,10 +16,10 @@ $carousel-transition: transform 0.3s ease;
   $rotate-pos: 3deg;
   $rotate-neg: -3deg;
   $cardset-colors: (
-    1: color(blue, "300"),
-    2: color(yellow, "300"),
-    3: color(green, "300"),
-    4: color(orange, "200"),
+    1: color(orange, "200"),
+    2: color(blue, "300"),
+    3: color(yellow, "300"),
+    4: color(green, "300"),
   );
 
   @include breakpoint(large up) {


### PR DESCRIPTION
# Description

Update Portrait Card Set background colours to orange-blue-green-yellow

Link to sample test page: https://foundation-s-tp1-3519-p-jppux8.mofostaging.net/en/general-page-test/
Related PRs/issues: [Jira TP1-3519](https://mozilla-hub.atlassian.net/browse/TP1-3519) / GitHub #15177