### PR TITLE
test: Remove formAssembly external API tests from CI

### DIFF
--- a/frontend/legacy/tests/integration/petition/001-petition-form.spec.js
+++ b/frontend/legacy/tests/integration/petition/001-petition-form.spec.js
@@ -125,25 +125,4 @@ test.describe("FormAssembly petition form", () => {
     await submitButton.dispatchEvent("click");
     await navigationPromise;
   });
-
-  for (const locale of supportedLocales) {
-    test(`(${locale}) Signing petition`, async ({ page }) => {
-      localeToTest = locale;
-      // Form has been submitted successfully. Page should be redirected to thank you page
-      expect(
-        utility.isExpectedThankYouUrl(page.url(), thankYouUrlInputValue, true)
-      ).toBe(true);
-    });
-
-    test(`(${locale}) Signing petition using the same email`, async ({
-      page,
-    }) => {
-      localeToTest = locale;
-      // We turned off a config so that Salesforce errors won't be visible to the user.
-      // This means signing the petition using the same email address should still send users to the thank you page
-      expect(
-        utility.isExpectedThankYouUrl(page.url(), thankYouUrlInputValue, true)
-      ).toBe(true);
-    });
-  }
 });


### PR DESCRIPTION
# Description

Remove tests that verify FormAssembly's redirect to thank you page, as these depend on an external third-party API that returns 500 errors in CI.

Related PRs/issues: [Jira TP1-3580](https://mozilla-hub.atlassian.net/browse/TP1-3580) / GitHub #15279
