### PR TITLE
Restore Review App Deployment Messages

### DIFF
--- a/release-steps.sh
+++ b/release-steps.sh
@@ -73,12 +73,11 @@ restore_review_app_backup() {
 
   echo "Removing snapshot admin user (if present)..."
 
-  # This is safe: deletes 0 rows if no admin exists.
   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c \
     "DELETE FROM auth_user WHERE username = 'admin';"
 
   echo "Admin cleanup complete."
-  
+
   echo "Updating site bindings..."
   update_site_bindings
   echo "Site bindings update complete."


### PR DESCRIPTION
# Description

When restoring db from snapshot a generic random `admin` user may be present in the DB. This will drop that user if it exists so that the remaining workflow will generate a new admin and the corresponding review app message in heroku.

# To Test
1) Did the review app deploy successfully with a message in the #mofo-ra-foundation slack channel?