### PR TITLE
chore(deps): switch Dependabot to pip-compile ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,18 @@
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: pip-compile
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
   labels:
     - "engineering"
-    - "dependencies"  
+    - "dependencies"
     - "backend"
     - "pip"
+  files:
+    - requirements.in
+    - dev-requirements.in
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
I noticed that Dependabot has only been updating `requirements.txt` in its PRs and leaving `requirements.in` out of sync. In this PR I'm switching the config to `pip-compile` so Dependabot correctly updates the `.in` files and recompiles the `.txt` files as part of the PRs.