### PR TITLE
Revert "chore(deps): switch Dependabot to pip-compile ecosystem"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: pip-compile
+- package-ecosystem: pip
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
   labels:
     - "engineering"
-    - "dependencies"
+    - "dependencies"  
     - "backend"
     - "pip"
-  files:
-    - requirements.in
-    - dev-requirements.in
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
Reverts MozillaFoundation/foundation.mozilla.org#15446

Got [some complaints](https://github.com/MozillaFoundation/foundation.mozilla.org/pull/15458/checks?check_run_id=64605148984) about this. Gonna revert the changes!