### PR TITLE
Fix for title block line loop

### DIFF
--- a/foundation_cms/static/scss/_dividers.scss
+++ b/foundation_cms/static/scss/_dividers.scss
@@ -34,16 +34,26 @@ $straight-line-image: "/static/foundation_cms/_images/handdrawn/straight-line-di
   background-size: $size;
 }
 
-@mixin loop-line-divider-bg($size: auto 100%) {
+@mixin loop-line-divider-bg(
+  $size: auto 100%,
+  $small-position: left 48% center,
+  $large-position: left 47% center
+) {
   @include divider-image(
     $loop-line-image,
     $height: null,
     $margin-y: null,
     $repeat: no-repeat,
-    $position: left 48% center,
+    $position: $small-position,
     $size: $size,
     $apply-base: false
   );
+
+  @if $large-position {
+    @include breakpoint(large up) {
+      background-position: $large-position;
+    }
+  }
 }
 
 @mixin loop-line-divider(
@@ -59,7 +69,6 @@ $straight-line-image: "/static/foundation_cms/_images/handdrawn/straight-line-di
 
   @include breakpoint(large up) {
     height: $desktop-height;
-    background-position: left 47% center;
   }
 }
 


### PR DESCRIPTION
# Description

This PR fixes the title component line divider position, which was not included in the last refactor and consolidates all positioning to a single mixin. Concretely, the title block was using the small viewport `left 47%` position instead of the large viewport one `left 48%` due to this disparity.

<img width="2056" height="800" alt="image" src="https://github.com/user-attachments/assets/6288f611-ec93-42b8-9bed-603431bed0f8" />

*Current state `left 48%` in desktop*

<img width="2056" height="893" alt="image" src="https://github.com/user-attachments/assets/c7fda09f-55be-4ecc-8435-0becc3e21779" />

*Fixed state `left 47%` in desktop*

Link to sample test page: [Dividers test page](https://foundation-s-fix-title--rz6l9m.mofostaging.net/en/dividers-test-page/)
Related PRs/issues: [Jira ticket](https://mozilla-hub.atlassian.net/browse/TP1-3177)