### PR TITLE
fix(scss): correct input field stroke color to neutral-400

### DIFF
--- a/foundation_cms/static/scss/_mixins.scss
+++ b/foundation_cms/static/scss/_mixins.scss
@@ -96,7 +96,7 @@
     background-color: $white;
     background-image: url("/static/foundation_cms/_images/icons/select-caret-down-black.svg");
     color: $black;
-    border: 1px solid $black;
+    border: 1px solid color(neutral, "400");
   }
 
   option {

--- a/foundation_cms/static/scss/components/campaign_page/petition_form.scss
+++ b/foundation_cms/static/scss/components/campaign_page/petition_form.scss
@@ -3,11 +3,12 @@
 .petition__form-wrapper {
   $black: map.get($mofo-colors, black);
   $white: map.get($mofo-colors, white);
+  $border-color: color(neutral, "400");
   $error-color: color(orange, "600");
   $field-gap: 1rem;
 
   @mixin shared-style {
-    border: 1px solid $black;
+    border: 1px solid $border-color;
     background: $white;
     width: 100%;
     padding: 1rem;
@@ -109,7 +110,7 @@
       display: inline-block;
       position: relative;
       background-color: $white;
-      border: 1px solid color(neutral, "600");
+      border: 1px solid $border-color;
       cursor: pointer;
 
       &:checked {


### PR DESCRIPTION
This PR corrects petition input field stroke color to `neutral-400`.

Link to sample test page: https://foundation-s-tp1-3557-i-1yljmn.mofostaging.net/en/new-camapgin-page/
Related PRs/issues: [Jira TP1-3557](https://mozilla-hub.atlassian.net/browse/TP1-3557)
