### PR TITLE
Resolve Wagtail Deprecation Warnings

### DIFF
--- a/foundation_cms/blocks/link_block.py
+++ b/foundation_cms/blocks/link_block.py
@@ -1,6 +1,6 @@
 from wagtail import blocks
 from wagtail.documents.blocks import DocumentChooserBlock
-from wagtail.telepath import register
+from wagtail.admin.telepath import register
 
 from foundation_cms.blocks.common.link_block.base_link_block import (
     BaseLinkBlock,

--- a/foundation_cms/blocks/link_block.py
+++ b/foundation_cms/blocks/link_block.py
@@ -1,6 +1,6 @@
 from wagtail import blocks
-from wagtail.documents.blocks import DocumentChooserBlock
 from wagtail.admin.telepath import register
+from wagtail.documents.blocks import DocumentChooserBlock
 
 from foundation_cms.blocks.common.link_block.base_link_block import (
     BaseLinkBlock,

--- a/foundation_cms/blocks/media_block.py
+++ b/foundation_cms/blocks/media_block.py
@@ -4,7 +4,7 @@ from django.utils.functional import cached_property
 from wagtail.blocks import CharBlock, ChoiceBlock, StructBlockValidationError
 from wagtail.blocks.struct_block import StructBlockAdapter
 from wagtail.images.blocks import ImageBlock
-from wagtail.telepath import register
+from wagtail.admin.telepath import register
 
 from foundation_cms.base.models.base_block import BaseBlock
 from foundation_cms.validators import validate_vimeo_mp4_url

--- a/foundation_cms/blocks/media_block.py
+++ b/foundation_cms/blocks/media_block.py
@@ -1,10 +1,10 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.functional import cached_property
+from wagtail.admin.telepath import register
 from wagtail.blocks import CharBlock, ChoiceBlock, StructBlockValidationError
 from wagtail.blocks.struct_block import StructBlockAdapter
 from wagtail.images.blocks import ImageBlock
-from wagtail.admin.telepath import register
 
 from foundation_cms.base.models.base_block import BaseBlock
 from foundation_cms.validators import validate_vimeo_mp4_url

--- a/foundation_cms/legacy_apps/nav/blocks.py
+++ b/foundation_cms/legacy_apps/nav/blocks.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from wagtail import blocks
-from wagtail.images.blocks import ImageChooserBlock
 from wagtail.admin.telepath import register
+from wagtail.images.blocks import ImageChooserBlock
 
 from foundation_cms.legacy_apps.utility.images import SVGImageFormatValidator
 from foundation_cms.legacy_apps.wagtailpages.pagemodels.customblocks.common.base_link_block import (

--- a/foundation_cms/legacy_apps/nav/blocks.py
+++ b/foundation_cms/legacy_apps/nav/blocks.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from wagtail import blocks
 from wagtail.images.blocks import ImageChooserBlock
-from wagtail.telepath import register
+from wagtail.admin.telepath import register
 
 from foundation_cms.legacy_apps.utility.images import SVGImageFormatValidator
 from foundation_cms.legacy_apps.wagtailpages.pagemodels.customblocks.common.base_link_block import (

--- a/foundation_cms/legacy_apps/wagtailpages/pagemodels/customblocks/link_block.py
+++ b/foundation_cms/legacy_apps/wagtailpages/pagemodels/customblocks/link_block.py
@@ -1,6 +1,6 @@
 from wagtail import blocks
 from wagtail.documents.blocks import DocumentChooserBlock
-from wagtail.telepath import register
+from wagtail.admin.telepath import register
 
 from foundation_cms.legacy_apps.wagtailpages.pagemodels.customblocks.common.base_link_block import (
     BaseLinkBlock,

--- a/foundation_cms/legacy_apps/wagtailpages/pagemodels/customblocks/link_block.py
+++ b/foundation_cms/legacy_apps/wagtailpages/pagemodels/customblocks/link_block.py
@@ -1,6 +1,6 @@
 from wagtail import blocks
-from wagtail.documents.blocks import DocumentChooserBlock
 from wagtail.admin.telepath import register
+from wagtail.documents.blocks import DocumentChooserBlock
 
 from foundation_cms.legacy_apps.wagtailpages.pagemodels.customblocks.common.base_link_block import (
     BaseLinkBlock,

--- a/foundation_cms/navigation/blocks.py
+++ b/foundation_cms/navigation/blocks.py
@@ -1,5 +1,5 @@
 from wagtail import blocks
-from wagtail.telepath import register
+from wagtail.admin.telepath import register
 
 from foundation_cms.legacy_apps.wagtailpages.pagemodels.customblocks.common.base_link_block import (
     BaseLinkBlock,


### PR DESCRIPTION
# Description

Fix some wagtail deprecation warnings for code that will be removed in wagtail 8. Note: the fix is only for the warnings in our codebase. There are additional deprecation warnings from wagtail libraries themselves but these will likely be resolved by Wagtail 8 release.


Release logs before:
<img width="1210" height="215" alt="Screenshot 2026-04-16 at 1 52 55 PM" src="https://github.com/user-attachments/assets/a70bbabd-56f3-4548-b584-18342642f7e1" />


Release logs after:
<img width="1194" height="257" alt="Screenshot 2026-04-16 at 1 53 22 PM" src="https://github.com/user-attachments/assets/4937ece1-72d7-45cf-abaa-1332d34ce62c" />


Link to sample test page: https://foundation-s-tp1-3852-w-0b6bhn.mofostaging.net/en/
Related PRs/issues: TP1-3852