### PR TITLE
Add locale to main navigation listing

### DIFF
--- a/foundation_cms/navigation/models.py
+++ b/foundation_cms/navigation/models.py
@@ -76,7 +76,7 @@ class NavigationMenu(
         verbose_name_plural = "Navigation Menus"
 
     def __str__(self) -> str:
-        return self.title
+        return f"{self.title} ({self.locale.language_code})"
 
 
 @register_setting(icon="nav-menu")

--- a/foundation_cms/navigation/wagtail_hooks.py
+++ b/foundation_cms/navigation/wagtail_hooks.py
@@ -30,7 +30,7 @@ class NavigationMenuViewSet(SnippetViewSet):
     icon = "nav-menu"
     menu_order = 100
     menu_label = "Navigation Menus"
-    list_display = ("title",)
+    list_display = ("title", "locale")
     search_fields = ("title",)
     ordering = ("title",)
 


### PR DESCRIPTION
# Description

This PR adds `locale name` to the main navigation list **_to help identify translations_** and avoid using filtering during syncing, as this adds an additional `/results` parameter, which then leads to a _broken screen_. 

`Note: This appears to be added directly by wagtail-localize, as discussed in the` [ticket](https://mozilla-hub.atlassian.net/browse/TP1-3777?focusedCommentId=1367865).

Related issue: [TP1-3777](https://mozilla-hub.atlassian.net/browse/TP1-3777)
Review app: https://foundation-s-tp1-3777-a-kqg5zd.mofostaging.net/cms/snippets/navigation/navigationmenu/

#### Main changes
- The locale name is added next to the title of each snippet version

#### How to test
1. Go to [Navigation Menus](https://foundation-s-tp1-3777-a-kqg5zd.mofostaging.net/cms/snippets/navigation/navigationmenu/) in the admin dashboard (left navigation).
2. You will see a list of menus with titles and locale names (to help identify them).
3. Click the “…” action button on the English Menu

### Images
<img width="1532" height="541" alt="image" src="https://github.com/user-attachments/assets/4e4ca27e-2af0-4b4d-a079-094ce659c0cf" />

