### PR TITLE
chore(deps): ignore major version bumps for legacy npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,12 @@ updates:
     - "dependencies"
     - "frontend"
     - "npm"
+  ignore:
+    - dependency-name: "tailwindcss"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "react"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "react-dom"
+      update-types: ["version-update:semver-major"]
+    - dependency-name: "locomotive-scroll"
+      update-types: ["version-update:semver-major"]


### PR DESCRIPTION
The legacy frontend is in maintenance mode and several dependencies have breaking major-version changes that require significant migration effort before upgrading:

- **tailwindcss** 3 → 4: complete config rewrite (JS config removed, PostCSS plugin changed, 7 custom plugins affected)
- **react / react-dom** 18 → 19: `react-ga@3.3.1` is incompatible, `propTypes` removed from core
- **locomotive-scroll** 4 → 5: full API rewrite, constructor options removed

This PR adds `dependabot.ignore` rules to suppress major version PRs for these packages. Minor and patch updates will continue to be proposed automatically.