### PR TITLE
TP1-4016 Fix nav search with pushdown banner

### DIFF
--- a/foundation_cms/static/js/components/primary_nav/search.js
+++ b/foundation_cms/static/js/components/primary_nav/search.js
@@ -1,17 +1,26 @@
 import { CLASSNAMES, EVENTS, SELECTORS } from "./config.js";
 
+const SEARCH_TOP_CUSTOM_PROPERTY = "--primary-nav-search-top";
+
 /**
  * Controls the open/close state for the primary-nav search drawer.
  */
 class PrimaryNavSearchDrawerController {
   /**
-   * @param {{ searchToggleEl: HTMLElement, searchInputContainerEl: HTMLElement, searchInputEl: HTMLInputElement }} options
+   * @param {{ searchToggleEl: HTMLElement, searchInputContainerEl: HTMLElement, searchInputEl: HTMLInputElement, primaryNavEl?: HTMLElement | null }} options
    */
-  constructor({ searchToggleEl, searchInputContainerEl, searchInputEl }) {
+  constructor({
+    searchToggleEl,
+    searchInputContainerEl,
+    searchInputEl,
+    primaryNavEl = null,
+  }) {
     this.searchToggleEl = searchToggleEl;
     this.searchInputContainerEl = searchInputContainerEl;
     this.searchInputEl = searchInputEl;
+    this.primaryNavEl = primaryNavEl;
     this.backdropEl = this.ensureBackdrop();
+    this.handleViewportChange = this.handleViewportChange.bind(this);
   }
 
   isOpen() {
@@ -26,16 +35,25 @@ class PrimaryNavSearchDrawerController {
     // Let other modules close themselves first (ex: mobile nav).
     document.dispatchEvent(new CustomEvent(EVENTS.searchWillOpen));
 
+    this.updateSearchTop();
     this.searchToggleEl.classList.add(CLASSNAMES.searchOpen);
     this.searchInputContainerEl.classList.add(CLASSNAMES.searchOpen);
-    this.searchInputContainerEl.style.maxHeight =
-      this.searchInputContainerEl.scrollHeight + "px";
+    this.updateDrawerHeight();
     this.searchInputContainerEl.setAttribute("aria-expanded", "true");
+    this.addViewportListeners();
     this.searchInputEl.focus({ preventScroll: true });
+
+    requestAnimationFrame(() => {
+      if (!this.isOpen()) return;
+
+      this.updateSearchTop();
+      this.updateDrawerHeight();
+    });
   }
 
   close() {
     if (!this.isOpen()) return;
+    this.removeViewportListeners();
     this.searchToggleEl.classList.remove(CLASSNAMES.searchOpen);
     this.searchInputContainerEl.classList.remove(CLASSNAMES.searchOpen);
     this.searchInputContainerEl.style.maxHeight = null;
@@ -69,6 +87,42 @@ class PrimaryNavSearchDrawerController {
     parentEl.insertBefore(backdropEl, this.searchInputContainerEl);
     return backdropEl;
   }
+
+  updateDrawerHeight() {
+    this.searchInputContainerEl.style.maxHeight =
+      this.searchInputContainerEl.scrollHeight + "px";
+  }
+
+  updateSearchTop() {
+    if (!this.primaryNavEl) return;
+
+    const navBottom = this.primaryNavEl.getBoundingClientRect().bottom;
+    const searchTop = Math.max(0, Math.round(navBottom));
+
+    document.documentElement.style.setProperty(
+      SEARCH_TOP_CUSTOM_PROPERTY,
+      `${searchTop}px`,
+    );
+  }
+
+  handleViewportChange() {
+    if (!this.isOpen()) return;
+
+    this.updateSearchTop();
+    this.updateDrawerHeight();
+  }
+
+  addViewportListeners() {
+    window.addEventListener("resize", this.handleViewportChange);
+    window.addEventListener("scroll", this.handleViewportChange, {
+      passive: true,
+    });
+  }
+
+  removeViewportListeners() {
+    window.removeEventListener("resize", this.handleViewportChange);
+    window.removeEventListener("scroll", this.handleViewportChange);
+  }
 }
 
 /**
@@ -80,6 +134,7 @@ export function initSearchToggle() {
     SELECTORS.searchInputContainer,
   );
   const searchInputEl = document.querySelector(SELECTORS.searchInput);
+  const primaryNavEl = document.querySelector(SELECTORS.primaryNav);
 
   if (!searchToggleEl || !searchInputContainerEl || !searchInputEl) return;
 
@@ -87,6 +142,7 @@ export function initSearchToggle() {
     searchToggleEl,
     searchInputContainerEl,
     searchInputEl,
+    primaryNavEl,
   });
 
   // If the mobile nav is about to open, close search first.

--- a/foundation_cms/static/js/components/primary_nav/search.js
+++ b/foundation_cms/static/js/components/primary_nav/search.js
@@ -43,6 +43,7 @@ class PrimaryNavSearchDrawerController {
     this.addViewportListeners();
     this.searchInputEl.focus({ preventScroll: true });
 
+    // Re-measure after open classes/listeners settle so pushdown layout is reflected.
     requestAnimationFrame(() => {
       if (!this.isOpen()) return;
 

--- a/foundation_cms/static/scss/components/primary_nav.scss
+++ b/foundation_cms/static/scss/components/primary_nav.scss
@@ -391,15 +391,17 @@ html[lang="nl"] body .primary-nav-ns {
   @include primary-nav-menu-item-max-widths(xlarge, 8rem, 5rem, 7rem, 7rem);
 }
 
+$primary-nav-search-top: var(--primary-nav-search-top, #{$primary-nav-height});
+
 .search-open-backdrop {
   position: fixed;
-  top: $primary-nav-height;
+  top: $primary-nav-search-top;
   left: 0;
   width: 100%;
-  height: calc(100vh - #{$primary-nav-height});
+  height: calc(100vh - #{$primary-nav-search-top});
   background: rgb(0 0 0 / 30%);
   z-index: 8;
-  transition: all 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
   pointer-events: none;
   opacity: 0;
 }
@@ -415,11 +417,11 @@ body:has(.search-input-container.search-open) {
   background: $white;
   max-height: 0;
   will-change: max-height;
-  transition: all 0.3s ease-in-out;
+  transition: max-height 0.3s ease-in-out;
   overflow: hidden;
   position: fixed;
   z-index: 9;
-  top: $primary-nav-height;
+  top: $primary-nav-search-top;
   width: 100vw;
 
   .grid-container {


### PR DESCRIPTION
# Description

Fixes the redesigned primary nav search drawer when a Donation Pushdown Banner is active.

<img width="750" alt="image" src="https://github.com/user-attachments/assets/81bd6b5f-cf3d-4ab4-a327-8c08f481eab0" />

Previously, opening search while the pushdown banner was visible caused the search drawer/input to overlap the donation banner area. The search UI was positioned from the default nav height instead of the nav’s actual rendered position after the banner pushed it down.

This update measures the current bottom edge of the primary nav when search opens and stores it in `--primary-nav-search-top`. The search drawer and backdrop now use that value so they anchor directly below the nav. The value is also refreshed on scroll/resize while search is open so it stays aligned as the pushdown banner/page position changes.

A real pushdown donate banner has been created on the review app so this can be tested against the actual CMS-driven banner state.


Link to sample test page: https://foundation-s-tp1-4016-s-ji5r5r.mofostaging.net/en/
Related PRs/issues: [Jira ticket](https://mozilla-hub.atlassian.net/browse/TP1-4016)