### PR TITLE
Add backend for filter and sort search results

### DIFF
--- a/foundation_cms/search/utils.py
+++ b/foundation_cms/search/utils.py
@@ -9,6 +9,16 @@ SUPPORTED_SEARCH_LANGUAGES = {
     "pt-BR": "portuguese",
 }
 
+SEARCH_SORTS = ("relevance", "newest", "oldest")
+
+SECTION_SLUGS = {
+    "all": None,
+    "what-we-do": "what-we-do",
+    "research": "research",
+    "press-release": "press-release",
+    "event": "event",
+}
+
 
 def get_search_backend_for_locale(locale_code=None):
     """
@@ -24,3 +34,13 @@ def get_search_backend_for_locale(locale_code=None):
 
     # Fallback to default backend
     return get_search_backend(), "default"
+
+
+def normalize_sort(value, default="relevance"):
+    value = (value or default).strip().lower()
+    return value if value in SEARCH_SORTS else default
+
+
+def normalize_content_type(value, default="all"):
+    value = (value or default).strip().lower()
+    return value if value in SECTION_SLUGS else default

--- a/foundation_cms/search/utils.py
+++ b/foundation_cms/search/utils.py
@@ -44,3 +44,7 @@ def normalize_sort(value, default="relevance"):
 def normalize_content_type(value, default="all"):
     value = (value or default).strip().lower()
     return value if value in SECTION_SLUGS else default
+
+
+def normalize_topic(value):
+    return (value or "").strip().lower()

--- a/foundation_cms/search/views.py
+++ b/foundation_cms/search/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.db.models import Count
 from django.http import JsonResponse
 from django.template.response import TemplateResponse
 from wagtail.contrib.search_promotions.models import Query
@@ -14,6 +15,7 @@ from foundation_cms.search.utils import (
     get_search_backend_for_locale,
     normalize_content_type,
     normalize_sort,
+    normalize_topic,
 )
 from foundation_cms.utils import get_default_locale, localize_queryset
 
@@ -27,6 +29,10 @@ from foundation_cms.utils import get_default_locale, localize_queryset
 
 def search(request):
     search_query = request.GET.get("query", None)
+    content_type = normalize_content_type(request.GET.get("content_type", "all"))
+    sort = normalize_sort(request.GET.get("sort", "relevance"))
+    selected_topic = normalize_topic(request.GET.get("topic"))
+    related_topics = []
     page = request.GET.get("page", 1)
     total_search_results = 0
     current_locale = Locale.get_active()
@@ -38,7 +44,6 @@ def search(request):
         base_queryset = Page.objects.live().filter(locale=current_locale)
 
         # Optional section filter by content_type slug
-        content_type = normalize_content_type(request.GET.get("content_type", "all"))
         section_slug = SECTION_SLUGS[content_type]
         if section_slug:
             section_root = Page.objects.live().filter(locale=current_locale, slug=section_slug).first()
@@ -49,6 +54,10 @@ def search(request):
                 # unknown/missing section root for this locale => empty result
                 base_queryset = base_queryset.none()
 
+        # Optional topic filter by tag slug
+        if selected_topic:
+            base_queryset = base_queryset.filter(topic_relations__tag__slug=selected_topic).distinct()
+
         # Get appropriate search backend
         search_backend, backend_type = get_search_backend_for_locale(locale_code)
         search_results = search_backend.search(search_query, base_queryset)
@@ -56,6 +65,24 @@ def search(request):
 
         # Extract IDs preserving backend's relevance order
         result_ids = [result.id for result in search_results]
+
+        # Build related topic facets from current query result set only
+        related_topics_qs = (
+            Page.objects.filter(id__in=result_ids)
+            .values("topic_relations__tag__slug", "topic_relations__tag__name")
+            .exclude(topic_relations__tag__slug__isnull=True)
+            .exclude(topic_relations__tag__name__isnull=True)
+            .annotate(count=Count("id", distinct=True))
+            .order_by("-count", "topic_relations__tag__name")
+        )
+        related_topics = [
+            {
+                "slug": row["topic_relations__tag__slug"],
+                "name": row["topic_relations__tag__name"],
+                "count": row["count"],
+            }
+            for row in related_topics_qs[:20]
+        ]
 
         # Create position mapping to restore relevance order later
         id_to_position = {id: idx for idx, id in enumerate(result_ids)}
@@ -74,7 +101,6 @@ def search(request):
         search_results = sorted(search_results, key=lambda page: id_to_position.get(page.id, len(result_ids)))
 
         # Optional sorting by publication date
-        sort = normalize_sort(request.GET.get("sort", "relevance"))
         if sort in ("newest", "oldest"):
             with_date = [p for p in search_results if p.first_published_at]
             without_date = [p for p in search_results if not p.first_published_at]
@@ -131,6 +157,8 @@ def search(request):
             "current_locale": current_locale.language_code,
             "sort": sort,
             "content_type": content_type,
+            "selected_topic": selected_topic,
+            "related_topics": related_topics,
         },
     )
 

--- a/foundation_cms/search/views.py
+++ b/foundation_cms/search/views.py
@@ -48,6 +48,9 @@ def search(request):
         # Extract IDs preserving backend's relevance order
         result_ids = [result.id for result in backend_results]
 
+        # Remove duplicates while preserving order (in case the backend returns duplicates)
+        result_ids = list(dict.fromkeys(result_ids))
+
         # Optional section filter by content_type slug
         section_slug = SECTION_SLUGS[content_type]
         if section_slug and result_ids:

--- a/foundation_cms/search/views.py
+++ b/foundation_cms/search/views.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Count
 from django.http import JsonResponse
@@ -28,7 +27,7 @@ from foundation_cms.utils import get_default_locale, localize_queryset
 
 
 def search(request):
-    search_query = request.GET.get("query", None)
+    search_query = (request.GET.get("query") or "").strip()
     content_type = normalize_content_type(request.GET.get("content_type", "all"))
     sort = normalize_sort(request.GET.get("sort", "relevance"))
     selected_topic = normalize_topic(request.GET.get("topic"))
@@ -44,10 +43,10 @@ def search(request):
         base_queryset = Page.objects.live().filter(locale=current_locale)
 
         search_backend, backend_type = get_search_backend_for_locale(locale_code)
-        search_results = search_backend.search(search_query, base_queryset)
+        backend_results = search_backend.search(search_query, base_queryset)
 
         # Extract IDs preserving backend's relevance order
-        result_ids = [result.id for result in search_results]
+        result_ids = [result.id for result in backend_results]
 
         # Optional section filter by content_type slug
         section_slug = SECTION_SLUGS[content_type]
@@ -83,6 +82,7 @@ def search(request):
         total_search_results = len(result_ids)
 
         # Build related topic facets from current query result set only
+        search_results = []
         if result_ids:
             related_topics_qs = (
                 Page.objects.filter(id__in=result_ids)
@@ -101,28 +101,16 @@ def search(request):
                 for row in related_topics_qs[:20]
             ]
 
-            print(f"Related topics: {related_topics}")  # Debugging line to check related topics
-
             # Create position mapping to restore relevance order later
             id_to_position = {pid: idx for idx, pid in enumerate(result_ids)}
 
-            # Pre-fetch ContentTypes for ALL unique page types
-            unique_page_types = {result.__class__ for result in search_results}
-            if unique_page_types:
-                ContentType.objects.get_for_models(*unique_page_types)
-
             # Build optimized QuerySet with FK prefetch and specific() call
             search_results = list(
-                Page.objects.filter(id__in=result_ids)
-                .select_related("search_image", "content_type")
-                .specific()
+                Page.objects.filter(id__in=result_ids).select_related("search_image", "content_type").specific()
             )
 
             # Restore backend relevance order
             search_results.sort(key=lambda page: id_to_position.get(page.id, len(result_ids)))
-
-        else:
-            search_results = []
 
         # Optional sorting by publication date
         if sort in ("newest", "oldest"):
@@ -141,7 +129,7 @@ def search(request):
         # Log only on initial submission, not on pagination clicks
         if is_initial_search_submit:
             SearchEvent.objects.create(
-                query_string=search_query.strip().lower(),
+                query_string=search_query.lower(),
                 language_code=current_locale.language_code,
                 results_count=total_search_results,
             )

--- a/foundation_cms/search/views.py
+++ b/foundation_cms/search/views.py
@@ -9,7 +9,12 @@ from wagtail.search.query import PlainText
 
 from foundation_cms.campaigns.models.campaign_page import CampaignPage
 from foundation_cms.search.models import SearchEvent
-from foundation_cms.search.utils import get_search_backend_for_locale
+from foundation_cms.search.utils import (
+    SECTION_SLUGS,
+    get_search_backend_for_locale,
+    normalize_content_type,
+    normalize_sort,
+)
 from foundation_cms.utils import get_default_locale, localize_queryset
 
 # To enable logging of search queries for use with the "Promoted search results" module
@@ -31,6 +36,18 @@ def search(request):
     if search_query:
         locale_code = current_locale.language_code
         base_queryset = Page.objects.live().filter(locale=current_locale)
+
+        # Optional section filter by content_type slug
+        content_type = normalize_content_type(request.GET.get("content_type", "all"))
+        section_slug = SECTION_SLUGS[content_type]
+        if section_slug:
+            section_root = Page.objects.live().filter(locale=current_locale, slug=section_slug).first()
+            if section_root:
+                # child pages of /section-slug/
+                base_queryset = base_queryset.descendant_of(section_root, inclusive=False)
+            else:
+                # unknown/missing section root for this locale => empty result
+                base_queryset = base_queryset.none()
 
         # Get appropriate search backend
         search_backend, backend_type = get_search_backend_for_locale(locale_code)
@@ -55,6 +72,21 @@ def search(request):
 
         # Restore backend relevance order
         search_results = sorted(search_results, key=lambda page: id_to_position.get(page.id, len(result_ids)))
+
+        # Optional sorting by publication date
+        sort = normalize_sort(request.GET.get("sort", "relevance"))
+        if sort in ("newest", "oldest"):
+            with_date = [p for p in search_results if p.first_published_at]
+            without_date = [p for p in search_results if not p.first_published_at]
+
+            with_date = sorted(
+                with_date,
+                key=lambda p: p.first_published_at,
+                reverse=(sort == "newest"),
+            )
+
+            # Keep items without publication date at the end
+            search_results = with_date + without_date
 
         # Log only on initial submission, not on pagination clicks
         if is_initial_search_submit:
@@ -97,6 +129,8 @@ def search(request):
             "total_search_results": total_search_results,
             "keep_contributing_pages": keep_contributing_pages,
             "current_locale": current_locale.language_code,
+            "sort": sort,
+            "content_type": content_type,
         },
     )
 

--- a/foundation_cms/search/views.py
+++ b/foundation_cms/search/views.py
@@ -43,62 +43,86 @@ def search(request):
         locale_code = current_locale.language_code
         base_queryset = Page.objects.live().filter(locale=current_locale)
 
-        # Optional section filter by content_type slug
-        section_slug = SECTION_SLUGS[content_type]
-        if section_slug:
-            section_root = Page.objects.live().filter(locale=current_locale, slug=section_slug).first()
-            if section_root:
-                # child pages of /section-slug/
-                base_queryset = base_queryset.descendant_of(section_root, inclusive=False)
-            else:
-                # unknown/missing section root for this locale => empty result
-                base_queryset = base_queryset.none()
-
-        # Optional topic filter by tag slug
-        if selected_topic:
-            base_queryset = base_queryset.filter(topic_relations__tag__slug=selected_topic).distinct()
-
-        # Get appropriate search backend
         search_backend, backend_type = get_search_backend_for_locale(locale_code)
         search_results = search_backend.search(search_query, base_queryset)
-        total_search_results = search_results.count()
 
         # Extract IDs preserving backend's relevance order
         result_ids = [result.id for result in search_results]
 
+        # Optional section filter by content_type slug
+        section_slug = SECTION_SLUGS[content_type]
+        if section_slug and result_ids:
+            section_root = (
+                Page.objects.live()
+                .filter(locale=current_locale, slug=section_slug)
+                .order_by("depth", "path", "id")
+                .first()
+            )
+
+            if section_root:
+                section_ids = set(
+                    Page.objects.live()
+                    .filter(id__in=result_ids)
+                    .descendant_of(section_root, inclusive=False)
+                    .values_list("id", flat=True)
+                )
+                result_ids = [pid for pid in result_ids if pid in section_ids]
+            else:
+                result_ids = []
+
+        # Optional topic filter by tag slug (AFTER search backend, to avoid FilterFieldError on tag slug lookups)
+        if selected_topic and result_ids:
+            topic_ids = set(
+                Page.objects.filter(
+                    id__in=result_ids,
+                    topic_relations__tag__slug=selected_topic,
+                ).values_list("id", flat=True)
+            )
+            result_ids = [pid for pid in result_ids if pid in topic_ids]
+
+        total_search_results = len(result_ids)
+
         # Build related topic facets from current query result set only
-        related_topics_qs = (
-            Page.objects.filter(id__in=result_ids)
-            .values("topic_relations__tag__slug", "topic_relations__tag__name")
-            .exclude(topic_relations__tag__slug__isnull=True)
-            .exclude(topic_relations__tag__name__isnull=True)
-            .annotate(count=Count("id", distinct=True))
-            .order_by("-count", "topic_relations__tag__name")
-        )
-        related_topics = [
-            {
-                "slug": row["topic_relations__tag__slug"],
-                "name": row["topic_relations__tag__name"],
-                "count": row["count"],
-            }
-            for row in related_topics_qs[:20]
-        ]
+        if result_ids:
+            related_topics_qs = (
+                Page.objects.filter(id__in=result_ids)
+                .values("topic_relations__tag__slug", "topic_relations__tag__name")
+                .exclude(topic_relations__tag__slug__isnull=True)
+                .exclude(topic_relations__tag__name__isnull=True)
+                .annotate(count=Count("id", distinct=True))
+                .order_by("-count", "topic_relations__tag__name")
+            )
+            related_topics = [
+                {
+                    "slug": row["topic_relations__tag__slug"],
+                    "name": row["topic_relations__tag__name"],
+                    "count": row["count"],
+                }
+                for row in related_topics_qs[:20]
+            ]
 
-        # Create position mapping to restore relevance order later
-        id_to_position = {id: idx for idx, id in enumerate(result_ids)}
+            print(f"Related topics: {related_topics}")  # Debugging line to check related topics
 
-        # Pre-fetch ContentTypes for ALL unique page types
-        unique_page_types = {result.__class__ for result in search_results}
-        if unique_page_types:
-            ContentType.objects.get_for_models(*unique_page_types)
+            # Create position mapping to restore relevance order later
+            id_to_position = {pid: idx for idx, pid in enumerate(result_ids)}
 
-        # Build optimized QuerySet with FK prefetch and specific() call
-        search_results = (
-            Page.objects.filter(id__in=result_ids).select_related("search_image", "content_type").specific()
-        )
+            # Pre-fetch ContentTypes for ALL unique page types
+            unique_page_types = {result.__class__ for result in search_results}
+            if unique_page_types:
+                ContentType.objects.get_for_models(*unique_page_types)
 
-        # Restore backend relevance order
-        search_results = sorted(search_results, key=lambda page: id_to_position.get(page.id, len(result_ids)))
+            # Build optimized QuerySet with FK prefetch and specific() call
+            search_results = list(
+                Page.objects.filter(id__in=result_ids)
+                .select_related("search_image", "content_type")
+                .specific()
+            )
+
+            # Restore backend relevance order
+            search_results.sort(key=lambda page: id_to_position.get(page.id, len(result_ids)))
+
+        else:
+            search_results = []
 
         # Optional sorting by publication date
         if sort in ("newest", "oldest"):

--- a/foundation_cms/templates/search/search_page.html
+++ b/foundation_cms/templates/search/search_page.html
@@ -24,9 +24,9 @@
                 </div>
 
                 {# TEMP DEBUG PLACEHOLDER: remove when frontend is finalized #}
-                <div class="cell small-12 large-8 large-offset-2" style="margin: 1rem 0; padding: 1rem; border: 1px dashed">
+                <div class="cell small-12 large-8 large-offset-2 margin-vertical-1 padding-1 border-dashed">
                     <strong>Search debug placeholder</strong>
-                    <ul style="margin-top: .5rem;">
+                    <ul>
                         <li><strong>query:</strong> {{ search_query|default:"(empty)" }}</li>
                         <li><strong>sort:</strong> {{ sort|default:"relevance" }}</li>
                         <li><strong>content_type:</strong> {{ content_type|default:"all" }}</li>

--- a/foundation_cms/templates/search/search_page.html
+++ b/foundation_cms/templates/search/search_page.html
@@ -23,6 +23,33 @@
                     {% include "search/_search_form.html" with form_class="search-form" input_class="search-form__input" submit_classnames="search-form__submit-button" %}
                 </div>
 
+                {# TEMP DEBUG PLACEHOLDER: remove when frontend is finalized #}
+                <div class="cell small-12 large-8 large-offset-2" style="margin: 1rem 0; padding: 1rem; border: 1px dashed">
+                    <strong>Search debug placeholder</strong>
+                    <ul style="margin-top: .5rem;">
+                        <li><strong>query:</strong> {{ search_query|default:"(empty)" }}</li>
+                        <li><strong>sort:</strong> {{ sort|default:"relevance" }}</li>
+                        <li><strong>content_type:</strong> {{ content_type|default:"all" }}</li>
+                        <li><strong>selected_topic:</strong> {{ selected_topic|default:"(none)" }}</li>
+                        <li><strong>total_search_results:</strong> {{ total_search_results }}</li>
+                        <li>
+                            <strong>related_topics ({{ related_topics|length }}):</strong>
+                            {% if related_topics %}
+                                <ul>
+                                    {% for topic in related_topics %}
+                                        <li>
+                                            slug={{ topic.slug }}, name="{{ topic.name }}", count={{ topic.count }}
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                (none)
+                            {% endif %}
+                        </li>
+                    </ul>
+                </div>
+                {# END TEMP DEBUG PLACEHOLDER #}
+
                 {% if search_results %}
                     {% include "search/_search_results.html" %}
                     {% include "patterns/components/_pagination.html" with page_obj=search_results viewname="search" %}


### PR DESCRIPTION
# Description

This PR updates the `Search app` backend by adding support for filtering and sorting search results without changing existing templates or search result rendering flow.

Link to sample test page: https://foundation-s-tp1-3964-a-acxfzi.mofostaging.net/en/
Related PRs/issues: [TP1-3964](https://mozilla-hub.atlassian.net/browse/TP1-3964) 

**Main changes**
- Added content type filtering via `content_type` query param.
- Added topic filtering via `topic` query param.
- Added sorting support via `sort` query param: `relevance` (default), `newest`, `oldest`
- Updated result count to reflect the final filtered result set.
- Updated payload based on current query result subset

**Tests**
- Visit the [review app](https://foundation-s-tp1-3964-a-acxfzi.mofostaging.net/en/) and submit a typical query. Results will be returned as before.
- Verify sorting adding query params: 
    - `/en/search/?query=<search_term>&sort=newest`
    - `/en/search/?query=<search_term>&sort=oldest`
- Verify content type filter adding query params (`all` content by default): 
    - `/en/search/?query=<search_term>&content_type=research`
    - `/en/search/?query=<search_term>&content_type=event`
    - `/en/search/?query=<search_term>&content_type=press-release`
    - `/en/search/?query=<search_term>&content_type=what-we-do`
- Verify topic filter adding query params: 
    - `/en/search/?query=<search_term>&topic=<topic_slug>`
