### PR TITLE
Update donor contact form to translate recaptcha warning

### DIFF
--- a/foundation_cms/templates/patterns/blocks/themes/default/fragments/donor_help_contact_us_form/formassembly_head.html
+++ b/foundation_cms/templates/patterns/blocks/themes/default/fragments/donor_help_contact_us_form/formassembly_head.html
@@ -172,7 +172,7 @@ The code snippet below is based on FormAssembly form revision #6
                 disabledDiv.id = 'disabled-explanation';
                 disabledDiv.className = 'captchaHelp';
                 disabledDiv.style.display = 'block';
-                disabledDiv.textContent = recaptchaDisabledText;
+                disabledDiv.textContent = '\u00A0' + recaptchaDisabledText;
 
                 oneFieldDiv.appendChild(recaptchaElement);
                 oneFieldDiv.appendChild(errorDiv);

--- a/foundation_cms/templates/patterns/blocks/themes/default/fragments/donor_help_contact_us_form/formassembly_head.html
+++ b/foundation_cms/templates/patterns/blocks/themes/default/fragments/donor_help_contact_us_form/formassembly_head.html
@@ -158,15 +158,21 @@ The code snippet below is based on FormAssembly form revision #6
                 var errorDiv = document.createElement('div');
                 errorDiv.className = 'g-captcha-error';
 
+                // Localized recaptcha injected at render time
+                var recaptchaHelpText = "{% trans 'reCAPTCHA helps prevent automated form spam.'|escapejs %}";
+                var recaptchaDisabledText = "{% trans 'The submit button will be disabled until you complete the CAPTCHA.'|escapejs %}";
+                var recaptchaErrorText = "{% trans 'The CAPTCHA was not completed successfully.'|escapejs %}";
+
                 var helpDiv = document.createElement('div');
                 helpDiv.className = 'captchaHelp';
-                helpDiv.innerHTML = 'reCAPTCHA helps prevent automated form spam.<br>';
+                helpDiv.textContent = recaptchaHelpText;
+                helpDiv.appendChild(document.createElement('br'));
 
                 var disabledDiv = document.createElement('div');
                 disabledDiv.id = 'disabled-explanation';
                 disabledDiv.className = 'captchaHelp';
                 disabledDiv.style.display = 'block';
-                disabledDiv.innerHTML = 'The submit button will be disabled until you complete the CAPTCHA.';
+                disabledDiv.textContent = recaptchaDisabledText;
 
                 oneFieldDiv.appendChild(recaptchaElement);
                 oneFieldDiv.appendChild(errorDiv);
@@ -210,7 +216,7 @@ The code snippet below is based on FormAssembly form revision #6
 
             var captchaError = '';
             if (captchaError == '1') {
-                var errMsgText = 'The CAPTCHA was not completed successfully.';
+                var errMsgText = recaptchaErrorText;
                 var errMsgDiv = document.createElement('div');
                 errMsgDiv.id = "tfa_captcha_text-E";
                 errMsgDiv.className = "err errMsg";


### PR DESCRIPTION
# Description

This PR updates untranslated `reCAPTCHA warning text on Donor Contact Form` pages by moving hardcoded JS strings to Django i18n translations, so warnings render in the active page locale.

Review app: https://foundation-s-tp1-4011-u-zscbtf.mofostaging.net/cms/pages/564/edit/
Test page: https://foundation-s-tp1-4011-u-zscbtf.mofostaging.net/en/donate-help/
Related issue: [TP1-4011](https://mozilla-hub.atlassian.net/browse/TP1-4011)

#### Main changes
- Replaced hardcoded reCAPTCHA warning/error strings with translated strings
- Kept safe JS rendering using escapejs and textContent to avoid string escaping/XSS issues.

#### How to test
1. In Wagtail CMS, edit/create a [General Page](https://foundation-s-tp1-4011-u-zscbtf.mofostaging.net/cms/pages/564/edit/) that includes the Donor Help Contact Us Form block.
2. Open the localized URL on the site and verify the `reCAPTCHA warning text` is translated (e.g. [fr version](https://foundation-s-tp1-4011-u-zscbtf.mofostaging.net/fr/donate-help/)) . 
Be sure that specific locale has _non-empty_ translated entries.

### Images
<img width="1322" height="633" alt="image" src="https://github.com/user-attachments/assets/0913cb07-4124-4009-bc06-761e41ca2472" />
