### PR TITLE
feat: add Civic Cookie Control banner to legacy base template

### DIFF
--- a/foundation_cms/legacy_apps/static/sass/civic-cookie-control-override.scss
+++ b/foundation_cms/legacy_apps/static/sass/civic-cookie-control-override.scss
@@ -1,0 +1,143 @@
+// Cookie Control v9 (Civic UK) — https://cookiecontrol.com/docs/v9/
+// Legacy-specific version of foundation_cms/static/scss/_cookie_control_override.scss.
+// Mirrors the same styles as the redesign override but uses plain CSS values instead of Foundation mixins (rem-calc, breakpoint, mofo-text-style).
+// Uses legacy font stack (Zilla Slab / Nunito Sans) instead of Mozilla Headline / Mozilla Text.
+
+#ccc {
+  $cc-breakpoint: 1020px;
+  $ccc-notify-padding: 1.5rem; // rem-calc(24)
+
+  // Notification bar
+  #ccc-notify {
+    padding: $ccc-notify-padding !important;
+    box-shadow: 0 -2px 8px 0 rgb(0 0 0 / 25%);
+
+    @media (min-width: $cc-breakpoint) {
+      align-items: normal !important;
+      flex-direction: column !important;
+      max-width: 50rem !important;
+      left: unset !important;
+    }
+
+    .ccc-notify-text {
+      @media (min-width: $cc-breakpoint) {
+        margin-right: $ccc-notify-padding !important;
+      }
+
+      #ccc-notify-title {
+        // mofo-text-style($header-styles, "h6", $header-font-family)
+        // small: font-size 1rem / large (64em+): font-size 1.25rem, line-height 1.1, font-weight 700
+        font-family: "Zilla Slab", serif !important;
+        font-size: 1rem !important;
+        font-weight: 700 !important;
+        line-height: 1.3 !important;
+        color: white;
+        margin-bottom: 0.375rem; // rem-calc(6)
+
+        @media (min-width: 64em) {
+          font-size: 1.25rem !important;
+          line-height: 1.1 !important;
+        }
+
+        + p {
+          // mofo-text-style($body-text-styles, "xsmall"): font-size 0.75rem, line-height 1.3, $body-font-family
+          // font-size falls through to the .ccc-intro/p rule (0.8125rem)
+          font-family: "Nunito Sans", Helvetica, Arial, sans-serif !important;
+          line-height: 150% !important;
+          color: white;
+        }
+      }
+    }
+
+    p {
+      opacity: 1 !important;
+    }
+  }
+
+  // Main settings panel
+  #ccc-content {
+    box-shadow: 0 -2px 8px 0 rgb(0 0 0 / 25%);
+
+    &.ccc-content--light {
+      background: white;
+    }
+  }
+
+  .ccc-notify-buttons {
+    position: static !important;
+    margin: 0.5rem 0 0 !important; // rem-calc(8)
+  }
+
+  .ccc-notify-button {
+    border-radius: 0 !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+
+    &#ccc-notify-accept,
+    &#ccc-notify-reject {
+      // mofo-text-style($body-text-styles, "small"): font-size 0.875rem, line-height 1.3, $body-font-family
+      font-family: "Nunito Sans", Helvetica, Arial, sans-serif !important;
+      font-size: 0.875rem !important; // rem-calc(14)
+      line-height: 1.3 !important;
+      font-weight: 600 !important;
+      padding: 1rem 1.5rem !important;
+      margin-bottom: 0.5rem !important; // rem-calc(8)
+    }
+
+    &.ccc-link.ccc-tabbable.ccc-notify-link {
+      // mofo-text-style($body-text-styles, "xsmall"): font-size 0.75rem, line-height 1.3, $body-font-family
+      font-family: "Nunito Sans", Helvetica, Arial, sans-serif !important;
+      font-size: 0.75rem !important; // rem-calc(12)
+      line-height: 1.3 !important;
+      font-weight: 600 !important;
+      padding: 1rem 1.5rem !important;
+      margin-bottom: 0.5rem !important; // rem-calc(8)
+
+      @media (min-width: $cc-breakpoint) {
+        height: 100% !important;
+      }
+    }
+  }
+
+  .ccc-intro,
+  #ccc-necessary-description,
+  p {
+    font-family: "Nunito Sans", Helvetica, Arial, sans-serif !important;
+    font-size: 0.8125rem !important; // rem-calc(13)
+    line-height: 1.5 !important;
+  }
+
+  .ccc-link {
+    &#ccc-notify-dismiss {
+      top: $ccc-notify-padding !important;
+      right: $ccc-notify-padding !important;
+
+      @media (width >= 400px) {
+        position: absolute !important;
+      }
+
+      path {
+        fill: white;
+      }
+    }
+  }
+
+  .ccc-content--highlight {
+    button.ccc-link.ccc-tabbable:focus {
+      filter: none !important;
+      outline: auto;
+      box-shadow: none;
+    }
+
+    &.ccc-content--light,
+    &.ccc-content--dark {
+      button.ccc-link.ccc-tabbable:not(
+          #ccc-notify-accept,
+          #ccc-notify-reject
+        ):focus {
+        background-color: transparent !important;
+        box-shadow: none !important;
+      }
+    }
+  }
+}

--- a/foundation_cms/legacy_apps/static/sass/main.scss
+++ b/foundation_cms/legacy_apps/static/sass/main.scss
@@ -73,6 +73,7 @@
 
 // Cookie Banner
 @import "./onetrust-override.scss";
+@import "./civic-cookie-control-override";
 
 // MozFest
 

--- a/foundation_cms/legacy_apps/templates/pages/base.html
+++ b/foundation_cms/legacy_apps/templates/pages/base.html
@@ -42,6 +42,19 @@
         <!-- The current GTM ID replaced an unkown GTM container with no clear access -->
             <meta name="gtm-identifier" content="GTM-PQQ8H6PM">
             <script nonce="{{ request.csp_nonce }}">window.dataLayer = window.dataLayer || [];</script>
+            <script nonce="{{ request.csp_nonce }}">
+                // Consent Mode v2: deny all by default before GTM loads.
+                // Civic updates these via onAccept/onRevoke callbacks.
+                // https://cookiecontrol.com/docs/v9/optional-categories#step-1-site-cleanup
+                // https://developers.google.com/tag-platform/security/guides/consent
+                function gtag(){dataLayer.push(arguments);}
+                gtag("consent", "default", {
+                    "ad_storage": "denied",
+                    "analytics_storage": "denied",
+                    "ad_personalization": "denied",
+                    "ad_user_data": "denied"
+                });
+            </script>
             <script nonce="{{ request.csp_nonce }}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
                 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
                                                           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -163,6 +176,9 @@
             <script src="{% static "legacy_apps/_js/main.compiled.js" %}"></script>
             <script src="{% static "foundation_cms/_js/redesign_migrated_content.compiled.js" %}"></script>
         {% endblock %}
+
+        <script src="https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js" type="text/javascript"></script>
+        <script src="{% static 'foundation_cms/_js/civic_cookie_control/init.compiled.js' %}"></script>
 
         {% block extra_scripts %}{% endblock %}
     </body>


### PR DESCRIPTION
# Description

Add Civic Cookie Control banner to legacy base template. (Mimicking the setup we have for redesign pages)

Related PRs/issues: [Jira Ticket](https://mozilla-hub.atlassian.net/browse/TP1-4024)

# To Test

We haven't gotten our actual Civic subscription yet. For now this will have to be tested locally.

1. Ensure `https://cc.cdn.civiccomputing.com` is added to your .env for
    - `CSP_SCRIPT_SRC`
    - and `CSP_STYLE_SRC`
2. Add `COOKIE_CONTROL_API_KEY` to your .env. Key can be found on [Civic Dashboard](https://products.civicuk.com/account-management/licences) (click on ... on the `COOKIE CONTROL Multi-site PRO Edition (v9)`)
3. Check out this branch
4. `docker compose up`
5. Go to http://localhost:8000/cms/sites/ and make the following updates
    - redesign: update the host from `localhost` to something. e.g., `new.localhost`
    - legacy: update the host from `legacy.localhost` to `localhost`
6. Go to http://localhost:8000
7. See if Civic' cookie banner shows up. Note that layout will look the same as redesign pages, but font family will be legacy site fonts (Nunito and Zilla Slab)
