### PR TITLE
feat(cookie-control): localize optionalCookies label/description text

### DIFF
--- a/foundation_cms/static/js/civic_cookie_control/init.js
+++ b/foundation_cms/static/js/civic_cookie_control/init.js
@@ -17,6 +17,99 @@ const COLORS = {
   black: "#000000",
 };
 
+// optionalCookies config, minus the localized `label`/`description` text
+// (sourced from LOCALE_TEXT[locale].optionalCookies via withOptionalCookiesText).
+const BASE_OPTIONAL_COOKIES = [
+  {
+    name: "analytics",
+    cookies: [
+      "_ga",
+      "_ga_*",
+      "_gid",
+      "_gat",
+      "_dc_gtm_",
+      "AMP_TOKEN",
+      "_gat_*",
+      "_gac_",
+      "__utma",
+      "__utmt",
+      "__utmb",
+      "__utmc",
+      "__utmz",
+      "__utmv",
+      "__utmx",
+      "__utmxx",
+      "FPAU",
+      "FPID",
+      "FPLC",
+      "vuid",
+      "Player",
+      "continuous_play_v3",
+      "fundraiseup_stat",
+    ],
+    onAccept: function () {
+      gtag("consent", "update", { analytics_storage: "granted" });
+    },
+    onRevoke: function () {
+      gtag("consent", "update", { analytics_storage: "denied" });
+    },
+  },
+  {
+    name: "marketing",
+    cookies: [
+      "GPS",
+      "VISITOR_INFO1_LIVE",
+      "PREF",
+      "YSC",
+      "DEVICE_INFO",
+      "LOGIN_INFO",
+      "VISITOR_PRIVACY_METADATA",
+      "lu",
+      "xs",
+      "c_user",
+      "m_user",
+      "pl",
+      "dbln",
+      "aks",
+      "aksb",
+      "sfau",
+      "ick",
+      "csm",
+      "s",
+      "datr",
+      "sb",
+      "fr",
+      "oo",
+      "ddid",
+      "locale",
+      "_fbp",
+      "_fbc",
+      "js_ver",
+      "rc",
+      "campaign_click_url",
+      "wd",
+      "usida",
+      "presence",
+      "__Secure-YNID",
+      "__Secure-ROLLOUT_TOKEN",
+    ],
+    onAccept: function () {
+      gtag("consent", "update", {
+        ad_storage: "granted",
+        ad_personalization: "granted",
+        ad_user_data: "granted",
+      });
+    },
+    onRevoke: function () {
+      gtag("consent", "update", {
+        ad_storage: "denied",
+        ad_personalization: "denied",
+        ad_user_data: "denied",
+      });
+    },
+  },
+];
+
 /**
  * Returns the text config with CCPA-specific overrides applied when in CCPA mode:
  * - `title` and `settings` are set to the CCPA opt-out label from CCPA_TITLE
@@ -38,6 +131,27 @@ function withCCPATitle(text, ccpaConfig, withinCCPA, locale = "en") {
         intro: "",
       }
     : text;
+}
+
+/**
+ * Merges localized `label`/`description` text into the static optionalCookies
+ * config (name, cookies, onAccept/onRevoke), keyed by category name. Falls
+ * back to the English text for any category not yet translated.
+ *
+ * @param {Array<object>} baseOptionalCookies - optionalCookies config without label/description.
+ * @param {object|undefined} localizedText - LOCALE_TEXT[locale].optionalCookies, keyed by category name.
+ * @returns {Array<object>} optionalCookies config with label/description applied.
+ */
+function withOptionalCookiesText(baseOptionalCookies, localizedText) {
+  return baseOptionalCookies.map((cookie) => {
+    const fallback = LOCALE_TEXT.en.optionalCookies[cookie.name];
+    const localized = localizedText?.[cookie.name];
+    return {
+      ...cookie,
+      label: localized?.label ?? fallback.label,
+      description: localized?.description ?? fallback.description,
+    };
+  });
 }
 
 if (!COOKIE_CONTROL_API_KEY) {
@@ -148,116 +262,19 @@ if (!COOKIE_CONTROL_API_KEY) {
         "__Host-airtable-session",
         "__Host-airtable-session.sig",
       ],
-      optionalCookies: [
-        {
-          name: "analytics",
-          label: "Analytics Cookies",
-          description:
-            "These cookies allow us to count visits and traffic sources so we can " +
-            "measure and improve the performance of our site. They help us to know " +
-            "which pages are the most and least popular and see how visitors move around " +
-            "the site. All information these cookies collect is aggregated and therefore anonymous. " +
-            "If you do not allow these cookies we will not know when you have visited our site, " +
-            "and will not be able to monitor its performance.",
-          cookies: [
-            "_ga",
-            "_ga_*",
-            "_gid",
-            "_gat",
-            "_dc_gtm_",
-            "AMP_TOKEN",
-            "_gat_*",
-            "_gac_",
-            "__utma",
-            "__utmt",
-            "__utmb",
-            "__utmc",
-            "__utmz",
-            "__utmv",
-            "__utmx",
-            "__utmxx",
-            "FPAU",
-            "FPID",
-            "FPLC",
-            "vuid",
-            "Player",
-            "continuous_play_v3",
-            "fundraiseup_stat",
-          ],
-          onAccept: function () {
-            gtag("consent", "update", { analytics_storage: "granted" });
-          },
-          onRevoke: function () {
-            gtag("consent", "update", { analytics_storage: "denied" });
-          },
-        },
-        {
-          name: "marketing",
-          label: "Marketing Cookies",
-          description:
-            "These cookies may be set through our site by our advertising partners. " +
-            "They may be used by those companies to build a profile of your interests " +
-            "and show you relevant adverts on other sites. They do not store directly " +
-            "personal information, but are based on uniquely identifying your browser and " +
-            "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
-          cookies: [
-            "GPS",
-            "VISITOR_INFO1_LIVE",
-            "PREF",
-            "YSC",
-            "DEVICE_INFO",
-            "LOGIN_INFO",
-            "VISITOR_PRIVACY_METADATA",
-            "lu",
-            "xs",
-            "c_user",
-            "m_user",
-            "pl",
-            "dbln",
-            "aks",
-            "aksb",
-            "sfau",
-            "ick",
-            "csm",
-            "s",
-            "datr",
-            "sb",
-            "fr",
-            "oo",
-            "ddid",
-            "locale",
-            "_fbp",
-            "_fbc",
-            "js_ver",
-            "rc",
-            "campaign_click_url",
-            "wd",
-            "usida",
-            "presence",
-            "__Secure-YNID",
-            "__Secure-ROLLOUT_TOKEN",
-          ],
-          onAccept: function () {
-            gtag("consent", "update", {
-              ad_storage: "granted",
-              ad_personalization: "granted",
-              ad_user_data: "granted",
-            });
-          },
-          onRevoke: function () {
-            gtag("consent", "update", {
-              ad_storage: "denied",
-              ad_personalization: "denied",
-              ad_user_data: "denied",
-            });
-          },
-        },
-      ],
+      optionalCookies: withOptionalCookiesText(
+        BASE_OPTIONAL_COOKIES,
+        LOCALE_TEXT.en.optionalCookies,
+      ),
       locales: Object.entries(LOCALE_TEXT)
         .filter(([locale]) => locale !== "en")
-        .map(([locale, { text, ccpaConfig }]) => ({
+        .map(([locale, { text, ccpaConfig, optionalCookies }]) => ({
           locale,
           text: withCCPATitle(text, ccpaConfig, response.withinCCPA, locale),
+          optionalCookies: withOptionalCookiesText(
+            BASE_OPTIONAL_COOKIES,
+            optionalCookies,
+          ),
           ...(response.withinCCPA && ccpaConfig && { ccpaConfig }),
         })),
     };

--- a/foundation_cms/static/js/civic_cookie_control/text.js
+++ b/foundation_cms/static/js/civic_cookie_control/text.js
@@ -2,7 +2,10 @@
 // English is the default; other locales only need keys that differ.
 // CookieControl text keys: https://cookiecontrol.com/docs/v9/
 //
-// TODO(TP1-4033): revise accept/reject button labels across all locales once optional category names are confirmed. "Analytics Cookies" may not be accurate.
+// TODO: Revise accept/reject button labels across all locales once optional category names are confirmed.
+//       All accept/reject text was copied as-is from OneTrust, but OneTrust's English copy says
+//       "Accept/Reject Analytics Cookies" while its non-English copy says a generic "accept/reject all cookies" instead
+//         — the two were already out of sync in the source and need to be reconciled.
 
 const CCPA_CONFIG_SHARED = {
   url: "https://www.mozilla.org/privacy/websites/",

--- a/foundation_cms/static/js/civic_cookie_control/text.js
+++ b/foundation_cms/static/js/civic_cookie_control/text.js
@@ -1,11 +1,6 @@
 // Localized text for Cookie Control v9 (Civic UK)
 // English is the default; other locales only need keys that differ.
 // CookieControl text keys: https://cookiecontrol.com/docs/v9/
-//
-// TODO: Revise accept/reject button labels across all locales once optional category names are confirmed.
-//       All accept/reject text was copied as-is from OneTrust, but OneTrust's English copy says
-//       "Accept/Reject Analytics Cookies" while its non-English copy says a generic "accept/reject all cookies" instead
-//         — the two were already out of sync in the source and need to be reconciled.
 
 const CCPA_CONFIG_SHARED = {
   url: "https://www.mozilla.org/privacy/websites/",
@@ -35,8 +30,8 @@ const LOCALE_TEXT = {
       notifyTitle: "Help Mozilla with Analytics",
       notifyDescription:
         "We use some essential cookies to make this website. We'd like to set additional cookies to understand how you use mozillafoundation.org. Your settings improve our services.",
-      accept: "Accept Analytics Cookies",
-      reject: "Reject Analytics Cookies",
+      accept: "Accept All",
+      reject: "Reject All",
       settings: "Consent Settings",
       // setting panel
       title: "Privacy Preference Center",

--- a/foundation_cms/static/js/civic_cookie_control/text.js
+++ b/foundation_cms/static/js/civic_cookie_control/text.js
@@ -48,6 +48,27 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close",
     },
+    optionalCookies: {
+      analytics: {
+        label: "Analytics Cookies",
+        description:
+          "These cookies allow us to count visits and traffic sources so we can " +
+          "measure and improve the performance of our site. They help us to know " +
+          "which pages are the most and least popular and see how visitors move around " +
+          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
+          "If you do not allow these cookies we will not know when you have visited our site, " +
+          "and will not be able to monitor its performance.",
+      },
+      marketing: {
+        label: "Marketing Cookies",
+        description:
+          "These cookies may be set through our site by our advertising partners. " +
+          "They may be used by those companies to build a profile of your interests " +
+          "and show you relevant adverts on other sites. They do not store directly " +
+          "personal information, but are based on uniquely identifying your browser and " +
+          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+      },
+    },
     ccpaConfig: {
       description:
         "When you visit our website, we store cookies on your browser to collect information. The information collected might relate to you, your preferences or your device, and is mostly used to make the site work as you expect it to and to provide a more personalized web experience. However, you can choose not to allow certain types of cookies, which may impact your experience of the site and the services we are able to offer. Click on the different category headings to find out more and change our default settings according to your preference. You cannot opt-out of our First Party Strictly Necessary Cookies as they are deployed in order to ensure the proper functioning of our website (such as prompting the cookie banner and remembering your settings, to log into your account, to redirect you when you log out, etc.). For more information about the First and Third Party Cookies used please follow this link.",

--- a/foundation_cms/static/js/civic_cookie_control/text.js
+++ b/foundation_cms/static/js/civic_cookie_control/text.js
@@ -52,21 +52,12 @@ const LOCALE_TEXT = {
       analytics: {
         label: "Analytics Cookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can " +
-          "measure and improve the performance of our site. They help us to know " +
-          "which pages are the most and least popular and see how visitors move around " +
-          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
-          "If you do not allow these cookies we will not know when you have visited our site, " +
-          "and will not be able to monitor its performance.",
+          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
       },
       marketing: {
         label: "Marketing Cookies",
         description:
-          "These cookies may be set through our site by our advertising partners. " +
-          "They may be used by those companies to build a profile of your interests " +
-          "and show you relevant adverts on other sites. They do not store directly " +
-          "personal information, but are based on uniquely identifying your browser and " +
-          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
       },
     },
     ccpaConfig: {
@@ -105,21 +96,12 @@ const LOCALE_TEXT = {
       analytics: {
         label: "Analytics Cookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can " +
-          "measure and improve the performance of our site. They help us to know " +
-          "which pages are the most and least popular and see how visitors move around " +
-          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
-          "If you do not allow these cookies we will not know when you have visited our site, " +
-          "and will not be able to monitor its performance.",
+          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
       },
       marketing: {
         label: "Marketing Cookies",
         description:
-          "These cookies may be set through our site by our advertising partners. " +
-          "They may be used by those companies to build a profile of your interests " +
-          "and show you relevant adverts on other sites. They do not store directly " +
-          "personal information, but are based on uniquely identifying your browser and " +
-          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
       },
     },
     ccpaConfig: {
@@ -157,21 +139,12 @@ const LOCALE_TEXT = {
       analytics: {
         label: "Analytics Cookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can " +
-          "measure and improve the performance of our site. They help us to know " +
-          "which pages are the most and least popular and see how visitors move around " +
-          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
-          "If you do not allow these cookies we will not know when you have visited our site, " +
-          "and will not be able to monitor its performance.",
+          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
       },
       marketing: {
         label: "Marketing Cookies",
         description:
-          "These cookies may be set through our site by our advertising partners. " +
-          "They may be used by those companies to build a profile of your interests " +
-          "and show you relevant adverts on other sites. They do not store directly " +
-          "personal information, but are based on uniquely identifying your browser and " +
-          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
       },
     },
     ccpaConfig: {
@@ -209,21 +182,12 @@ const LOCALE_TEXT = {
       analytics: {
         label: "Analytics Cookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can " +
-          "measure and improve the performance of our site. They help us to know " +
-          "which pages are the most and least popular and see how visitors move around " +
-          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
-          "If you do not allow these cookies we will not know when you have visited our site, " +
-          "and will not be able to monitor its performance.",
+          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
       },
       marketing: {
         label: "Marketing Cookies",
         description:
-          "These cookies may be set through our site by our advertising partners. " +
-          "They may be used by those companies to build a profile of your interests " +
-          "and show you relevant adverts on other sites. They do not store directly " +
-          "personal information, but are based on uniquely identifying your browser and " +
-          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
       },
     },
     ccpaConfig: {
@@ -261,21 +225,12 @@ const LOCALE_TEXT = {
       analytics: {
         label: "Analytics Cookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can " +
-          "measure and improve the performance of our site. They help us to know " +
-          "which pages are the most and least popular and see how visitors move around " +
-          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
-          "If you do not allow these cookies we will not know when you have visited our site, " +
-          "and will not be able to monitor its performance.",
+          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
       },
       marketing: {
         label: "Marketing Cookies",
         description:
-          "These cookies may be set through our site by our advertising partners. " +
-          "They may be used by those companies to build a profile of your interests " +
-          "and show you relevant adverts on other sites. They do not store directly " +
-          "personal information, but are based on uniquely identifying your browser and " +
-          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
       },
     },
     ccpaConfig: {
@@ -313,21 +268,12 @@ const LOCALE_TEXT = {
       analytics: {
         label: "Analytics Cookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can " +
-          "measure and improve the performance of our site. They help us to know " +
-          "which pages are the most and least popular and see how visitors move around " +
-          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
-          "If you do not allow these cookies we will not know when you have visited our site, " +
-          "and will not be able to monitor its performance.",
+          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
       },
       marketing: {
         label: "Marketing Cookies",
         description:
-          "These cookies may be set through our site by our advertising partners. " +
-          "They may be used by those companies to build a profile of your interests " +
-          "and show you relevant adverts on other sites. They do not store directly " +
-          "personal information, but are based on uniquely identifying your browser and " +
-          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
       },
     },
     ccpaConfig: {
@@ -366,21 +312,12 @@ const LOCALE_TEXT = {
       analytics: {
         label: "Analytics Cookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can " +
-          "measure and improve the performance of our site. They help us to know " +
-          "which pages are the most and least popular and see how visitors move around " +
-          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
-          "If you do not allow these cookies we will not know when you have visited our site, " +
-          "and will not be able to monitor its performance.",
+          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
       },
       marketing: {
         label: "Marketing Cookies",
         description:
-          "These cookies may be set through our site by our advertising partners. " +
-          "They may be used by those companies to build a profile of your interests " +
-          "and show you relevant adverts on other sites. They do not store directly " +
-          "personal information, but are based on uniquely identifying your browser and " +
-          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
       },
     },
     ccpaConfig: {
@@ -418,21 +355,12 @@ const LOCALE_TEXT = {
       analytics: {
         label: "Analytics Cookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can " +
-          "measure and improve the performance of our site. They help us to know " +
-          "which pages are the most and least popular and see how visitors move around " +
-          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
-          "If you do not allow these cookies we will not know when you have visited our site, " +
-          "and will not be able to monitor its performance.",
+          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
       },
       marketing: {
         label: "Marketing Cookies",
         description:
-          "These cookies may be set through our site by our advertising partners. " +
-          "They may be used by those companies to build a profile of your interests " +
-          "and show you relevant adverts on other sites. They do not store directly " +
-          "personal information, but are based on uniquely identifying your browser and " +
-          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
       },
     },
     ccpaConfig: {

--- a/foundation_cms/static/js/civic_cookie_control/text.js
+++ b/foundation_cms/static/js/civic_cookie_control/text.js
@@ -2,7 +2,6 @@
 // English is the default; other locales only need keys that differ.
 // CookieControl text keys: https://cookiecontrol.com/docs/v9/
 //
-// optionalCookies labels/descriptions per locale are defined in TP1-4033.
 // TODO(TP1-4033): revise accept/reject button labels across all locales once optional category names are confirmed. "Analytics Cookies" may not be accurate.
 
 const CCPA_CONFIG_SHARED = {
@@ -91,17 +90,16 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
-    // TODO(TP1-4033): replace with localized translation
     optionalCookies: {
       analytics: {
-        label: "Analytics Cookies",
+        label: "Leistungs-Cookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
+          "Diese Cookies ermöglichen es uns, Besuche und Verkehrsquellen zu zählen, damit wir die Leistung unserer Website messen und verbessern können. Sie unterstützen uns bei der Beantwortung der Fragen, welche Seiten am beliebtesten sind, welche am wenigsten genutzt werden und wie sich Besucher auf der Website bewegen. Alle von diesen Cookies erfassten Informationen werden aggregiert und sind deshalb anonym. Wenn Sie diese Cookies nicht zulassen, können wir nicht wissen, wann Sie unsere Website besucht haben.",
       },
       marketing: {
-        label: "Marketing Cookies",
+        label: "Cookies für Marketingzwecke",
         description:
-          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "Diese Cookies können über unsere Website von unseren Werbepartnern gesetzt werden. Sie können von diesen Unternehmen verwendet werden, um ein Profil Ihrer Interessen zu erstellen und Ihnen relevante Anzeigen auf anderen Websites zu zeigen. Sie speichern nicht direkt personenbezogene Daten, basieren jedoch auf einer einzigartigen Identifizierung Ihres Browsers und Internet-Geräts. Wenn Sie diese Cookies nicht zulassen, werden Sie weniger gezielte Werbung erleben.",
       },
     },
     ccpaConfig: {
@@ -134,17 +132,16 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
-    // TODO(TP1-4033): replace with localized translation
     optionalCookies: {
       analytics: {
-        label: "Analytics Cookies",
+        label: "Cookies de rendimiento",
         description:
-          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
+          "Estas cookies nos permiten contar las visitas y fuentes de circulación para poder medir y mejorar el desempeño de nuestro sitio. Nos ayudan a saber qué páginas son las más o menos populares, y ver cuántas personas visitan el sitio. Toda la información que recogen estas cookies es agregada y, por lo tanto, anónima. Si no permite estas cookies no sabremos cuándo visitó nuestro sitio, y por lo tanto no podremos saber cuándo lo visitó.",
       },
       marketing: {
-        label: "Marketing Cookies",
+        label: "Cookies dirigidas",
         description:
-          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "Estas cookies pueden estar en todo el sitio web, colocadas por nuestros socios publicitarios. Estos negocios pueden utilizarlas para crear un perfil de sus intereses y mostrarle anuncios relevantes en otros sitios. No almacenan información personal directamente, sino que se basan en la identificación única de su navegador y dispositivo de acceso al Internet. Si no permite estas cookies, tendrá menos publicidad dirigida.",
       },
     },
     ccpaConfig: {
@@ -177,17 +174,16 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
-    // TODO(TP1-4033): replace with localized translation
     optionalCookies: {
       analytics: {
-        label: "Analytics Cookies",
+        label: "Cookies de performance",
         description:
-          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
+          "Ces cookies nous permettent de déterminer le nombre de visites et les sources du trafic, afin de mesurer et d’améliorer les performances de notre site Web. Ils nous aident également à identifier les pages les plus / moins visitées et d’évaluer comment les visiteurs naviguent sur le site Web. Toutes les informations collectées par ces cookies sont agrégées et donc anonymisées. Si vous n'acceptez pas ces cookies, nous ne serons pas informé de votre visite sur notre site.",
       },
       marketing: {
-        label: "Marketing Cookies",
+        label: "Cookies pour une publicité ciblée",
         description:
-          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "Ces cookies peuvent être mis en place au sein de notre site Web par nos partenaires publicitaires. Ils peuvent être utilisés par ces sociétés pour établir un profil de vos intérêts et vous proposer des publicités pertinentes sur d'autres sites Web. Ils ne stockent pas directement des données personnelles, mais sont basés sur l'identification unique de votre navigateur et de votre appareil Internet. Si vous n'autorisez pas ces cookies, votre publicité sera moins ciblée.",
       },
     },
     ccpaConfig: {
@@ -220,17 +216,16 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
-    // TODO(TP1-4033): replace with localized translation
     optionalCookies: {
       analytics: {
-        label: "Analytics Cookies",
+        label: "Prestatiecookies",
         description:
-          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
+          "Deze cookies stellen ons in staat bezoekers en hun herkomst te tellen zodat we de prestatie van onze website kunnen analyseren en verbeteren. Ze helpen ons te begrijpen welke pagina’s het meest en minst populair zijn en hoe bezoekers zich door de gehele site bewegen. Alle informatie die deze cookies verzamelen wordt geaggregeerd en is daarom anoniem. Als u deze cookies niet toestaat, weten wij niet wanneer u onze site heeft bezocht.",
       },
       marketing: {
-        label: "Marketing Cookies",
+        label: "Doelgroepgerichte cookies",
         description:
-          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "Deze cookies kunnen door onze adverteerders op onze website worden ingesteld. Ze worden wellicht door die bedrijven gebruikt om een profiel van uw interesses samen te stellen en u relevante advertenties op andere websites te tonen. Ze slaan geen directe persoonlijke informatie op, maar ze zijn gebaseerd op unieke identificatoren van uw browser en internetapparaat. Als u deze cookies niet toestaat, zult u minder op u gerichte advertenties zien.",
       },
     },
     ccpaConfig: {
@@ -263,17 +258,16 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
-    // TODO(TP1-4033): replace with localized translation
     optionalCookies: {
       analytics: {
-        label: "Analytics Cookies",
+        label: "Pliki cookie wydajności",
         description:
-          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
+          "Te pliki cookie umożliwiają nam zliczanie wizyt i źródeł ruchu, dzięki czemu możemy mierzyć i poprawiać wydajność naszej witryny. Pomagają one ustalić, które strony są najbardziej i najmniej popularne i zobaczyć, jak odwiedzający poruszają się po stronie. Wszystkie informacje zbierane przez te pliki cookie są agregowane i tym samym anonimowe. Jeśli użytkownik nie zezwoli na stosowanie tych plików cookie, nie będziemy wiedzieć, kiedy odwiedził naszą stronę internetową.",
       },
       marketing: {
-        label: "Marketing Cookies",
+        label: "Pliki cookie związane z reklamami i ich odbiorcami",
         description:
-          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "Te pliki cookie mogą być ustawiane przez naszych partnerów reklamowych za pośrednictwem naszej strony internetowej. Mogą one być wykorzystywane przez te firmy do budowania profilu zainteresowań użytkownika i wyświetlania odpowiednich reklam na innych stronach. Nie przechowują one bezpośrednio danych osobowych, lecz opierają się na jednoznacznej identyfikacji przeglądarki i sprzętu internetowego. Jeśli użytkownik nie zezwoli na stosowanie tych plików cookie, doświadcza mniej ukierunkowanych reklam.",
       },
     },
     ccpaConfig: {
@@ -307,17 +301,16 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
-    // TODO(TP1-4033): replace with localized translation
     optionalCookies: {
       analytics: {
-        label: "Analytics Cookies",
+        label: "Cookies de desempenho",
         description:
-          "These cookies allow us to count visits and traffic sources so we can measure and improve the performance of our site. They help us to know which pages are the most and least popular and see how visitors move around the site. All information these cookies collect is aggregated and therefore anonymous. If you do not allow these cookies we will not know when you have visited our site, and will not be able to monitor its performance.",
+          "Estes cookies permitem-nos contar visitas e fontes de tráfego, para que possamos medir e melhorar o desempenho do nosso website. Eles ajudam-nos a saber quais são as páginas mais e menos populares e a ver como os visitantes se movimentam pelo website. Todas as informações recolhidas por estes cookies são agregadas e, por conseguinte, anónimas. Se não permitir estes cookies, não saberemos quando visitou o nosso site.",
       },
       marketing: {
-        label: "Marketing Cookies",
+        label: "Cookies de publicidade",
         description:
-          "These cookies may be set through our site by our advertising partners. They may be used by those companies to build a profile of your interests and show you relevant adverts on other sites. They do not store directly personal information, but are based on uniquely identifying your browser and internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+          "Estes cookies podem ser estabelecidos através do nosso site pelos nossos parceiros de publicidade. Podem ser usados por essas empresas para construir um perfil sobre os seus interesses e mostrar-lhe anúncios relevantes em outros websites. Eles não armazenam diretamente informações pessoais, mas são baseados na identificação exclusiva do seu navegador e dispositivo de internet. Se não permitir estes cookies, terá menos publicidade direcionada.",
       },
     },
     ccpaConfig: {
@@ -350,7 +343,7 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
-    // TODO(TP1-4033): replace with localized translation
+    // TODO: replace with localized translation
     optionalCookies: {
       analytics: {
         label: "Analytics Cookies",

--- a/foundation_cms/static/js/civic_cookie_control/text.js
+++ b/foundation_cms/static/js/civic_cookie_control/text.js
@@ -100,6 +100,28 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
+    // TODO(TP1-4033): replace with localized translation
+    optionalCookies: {
+      analytics: {
+        label: "Analytics Cookies",
+        description:
+          "These cookies allow us to count visits and traffic sources so we can " +
+          "measure and improve the performance of our site. They help us to know " +
+          "which pages are the most and least popular and see how visitors move around " +
+          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
+          "If you do not allow these cookies we will not know when you have visited our site, " +
+          "and will not be able to monitor its performance.",
+      },
+      marketing: {
+        label: "Marketing Cookies",
+        description:
+          "These cookies may be set through our site by our advertising partners. " +
+          "They may be used by those companies to build a profile of your interests " +
+          "and show you relevant adverts on other sites. They do not store directly " +
+          "personal information, but are based on uniquely identifying your browser and " +
+          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+      },
+    },
     ccpaConfig: {
       description:
         "Wenn Sie unsere Website besuchen, speichern wir in Ihrem Browser Cookies, um Informationen zu sammeln. Hierbei kann es sich um Informationen über Sie, Ihre Einstellungen oder Ihr Gerät handeln. Meist werden die Informationen verwendet, um die erwartungsgemäße Funktion der Website zu gewährleisten und Ihnen ein personalisierteres Website-Erlebnis zu bieten. Sie können jedoch bestimmte Arten von Cookies nicht zulassen. Dies führt möglicherweise zu einer beeinträchtigten Erfahrung der von uns zur Verfügung gestellten Website und Dienste. Klicken Sie auf die verschiedenen Kategorieüberschriften, um mehr zu erfahren und unsere Standardeinstellungen nach Ihren Wünschen zu ändern. Sie können unsere unbedingt erforderlichen Erstanbieter-Cookies nicht ablehnen, da sie eingesetzt werden, um das ordnungsgemäße Funktionieren unserer Website zu gewährleisten (wie z.B. das Aufrufen des Cookie-Banners und das Speichern Ihrer Einstellungen, das Anmelden in Ihrem Konto, das Weiterleiten beim Abmelden usw.) Weitere Informationen über die verwendeten Erst- und Drittanbieter-Cookies finden Sie unter diesem Link.",
@@ -129,6 +151,28 @@ const LOCALE_TEXT = {
         "Estas cookies son necesarias para que el sitio web funcione y no se pueden desactivar en nuestros sistemas. Usualmente están configuradas para responder a acciones hechas por usted para recibir servicios, tales como ajustar sus preferencias de privacidad, iniciar sesión en el sitio, o llenar formularios. Usted puede configurar su navegador para bloquear o alertar la presencia de estas cookies, pero algunas partes del sitio web no funcionarán. Estas cookies no guardan ninguna información personal identificable.",
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
+    },
+    // TODO(TP1-4033): replace with localized translation
+    optionalCookies: {
+      analytics: {
+        label: "Analytics Cookies",
+        description:
+          "These cookies allow us to count visits and traffic sources so we can " +
+          "measure and improve the performance of our site. They help us to know " +
+          "which pages are the most and least popular and see how visitors move around " +
+          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
+          "If you do not allow these cookies we will not know when you have visited our site, " +
+          "and will not be able to monitor its performance.",
+      },
+      marketing: {
+        label: "Marketing Cookies",
+        description:
+          "These cookies may be set through our site by our advertising partners. " +
+          "They may be used by those companies to build a profile of your interests " +
+          "and show you relevant adverts on other sites. They do not store directly " +
+          "personal information, but are based on uniquely identifying your browser and " +
+          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+      },
     },
     ccpaConfig: {
       description:
@@ -160,6 +204,28 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
+    // TODO(TP1-4033): replace with localized translation
+    optionalCookies: {
+      analytics: {
+        label: "Analytics Cookies",
+        description:
+          "These cookies allow us to count visits and traffic sources so we can " +
+          "measure and improve the performance of our site. They help us to know " +
+          "which pages are the most and least popular and see how visitors move around " +
+          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
+          "If you do not allow these cookies we will not know when you have visited our site, " +
+          "and will not be able to monitor its performance.",
+      },
+      marketing: {
+        label: "Marketing Cookies",
+        description:
+          "These cookies may be set through our site by our advertising partners. " +
+          "They may be used by those companies to build a profile of your interests " +
+          "and show you relevant adverts on other sites. They do not store directly " +
+          "personal information, but are based on uniquely identifying your browser and " +
+          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+      },
+    },
     ccpaConfig: {
       description:
         "Lorsque vous visitez notre site Web, nous stockons des cookies sur votre navigateur pour collecter des informations. Ces informations collectées peuvent être liées à vous, à vos préférences ou à votre appareil, et sont principalement utilisées pour faire fonctionner le site comme vous le souhaitez et pour fournir une expérience Web plus personnalisée. Toutefois, vous pouvez choisir de ne pas autoriser certains types de cookies, ce qui peut avoir un impact sur votre expérience du site et des services que nous offrons. Cliquez sur les différents titres de catégories pour en savoir plus et modifier nos paramètres par défaut selon vos préférences. Vous ne pouvez pas vous désinscrire de nos Cookies Strictement Nécessaires internes lorsqu'ils sont déployés afin d'assurer le bon fonctionnement de notre site Web (tels que pour afficher le bandeau des cookies, pour vous connecter à votre compte, pour rediriger votre session lorsque vous quittez votre compte, etc.) Pour plus d'Informations sur les cookies internes et de tiers utilisés, veuillez consulter le lien suivant.",
@@ -190,6 +256,28 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
+    // TODO(TP1-4033): replace with localized translation
+    optionalCookies: {
+      analytics: {
+        label: "Analytics Cookies",
+        description:
+          "These cookies allow us to count visits and traffic sources so we can " +
+          "measure and improve the performance of our site. They help us to know " +
+          "which pages are the most and least popular and see how visitors move around " +
+          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
+          "If you do not allow these cookies we will not know when you have visited our site, " +
+          "and will not be able to monitor its performance.",
+      },
+      marketing: {
+        label: "Marketing Cookies",
+        description:
+          "These cookies may be set through our site by our advertising partners. " +
+          "They may be used by those companies to build a profile of your interests " +
+          "and show you relevant adverts on other sites. They do not store directly " +
+          "personal information, but are based on uniquely identifying your browser and " +
+          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+      },
+    },
     ccpaConfig: {
       description:
         'Als u onze website bezoekt, slaan we cookies in uw browser op om informatie in te zamelen. De informatie die we inzamelen kan betrekking hebben op u, uw voorkeuren of uw apparaat en wordt voornamelijk gebruikt om de website correct te laten werken en om de gebruikerservaring beter aan u persoonlijk te kunnen aanpassen. U kunt ervoor kiezen om bepaalde soorten cookies te blokkeren. Dit kan een nadelige invloed hebben op uw ervaring van de website en de diensten die we aanbieden. Klik op de namen voor de verschillende categorieën voor meer informatie en om onze standaardinstellingen naar uw wensten te wijzigen. U kunt onze interne "strikt noodzakelijke cookies" niet blokkeren, omdat deze worden gebruikt om de website juist te laten functioneren (bijvoorbeeld om de cookiebanner te activeren, uw instellingen te herinneren, in uw account in te loggen en u correct om te leiden nadat u uitlogt, enz.) Voor meer informatie over de gebruikte interne en externe cookies kunt u op deze link klikken.',
@@ -219,6 +307,28 @@ const LOCALE_TEXT = {
         "Te pliki cookie są niezbędne dla funkcjonowania strony internetowej i nie mogą być wyłączone w naszych systemach. Są one zazwyczaj ustawiane tylko w odpowiedzi na działania podejmowane przez użytkownika, które sprowadzają się do zapytania o usługi, takie jak ustawienie preferencji prywatności, logowanie lub wypełnianie formularzy. Można ustawić przeglądarkę tak, aby blokowała lub ostrzegała o tych plikach cookie, ale niektóre części witryny nie będą wtedy działały. Te pliki cookie nie przechowują żadnych danych osobowych.",
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
+    },
+    // TODO(TP1-4033): replace with localized translation
+    optionalCookies: {
+      analytics: {
+        label: "Analytics Cookies",
+        description:
+          "These cookies allow us to count visits and traffic sources so we can " +
+          "measure and improve the performance of our site. They help us to know " +
+          "which pages are the most and least popular and see how visitors move around " +
+          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
+          "If you do not allow these cookies we will not know when you have visited our site, " +
+          "and will not be able to monitor its performance.",
+      },
+      marketing: {
+        label: "Marketing Cookies",
+        description:
+          "These cookies may be set through our site by our advertising partners. " +
+          "They may be used by those companies to build a profile of your interests " +
+          "and show you relevant adverts on other sites. They do not store directly " +
+          "personal information, but are based on uniquely identifying your browser and " +
+          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+      },
     },
     ccpaConfig: {
       // TODO: source Polish CCPA text; OneTrust has no pl CCPA config. Falling back to English for description and name.
@@ -251,6 +361,28 @@ const LOCALE_TEXT = {
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
     },
+    // TODO(TP1-4033): replace with localized translation
+    optionalCookies: {
+      analytics: {
+        label: "Analytics Cookies",
+        description:
+          "These cookies allow us to count visits and traffic sources so we can " +
+          "measure and improve the performance of our site. They help us to know " +
+          "which pages are the most and least popular and see how visitors move around " +
+          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
+          "If you do not allow these cookies we will not know when you have visited our site, " +
+          "and will not be able to monitor its performance.",
+      },
+      marketing: {
+        label: "Marketing Cookies",
+        description:
+          "These cookies may be set through our site by our advertising partners. " +
+          "They may be used by those companies to build a profile of your interests " +
+          "and show you relevant adverts on other sites. They do not store directly " +
+          "personal information, but are based on uniquely identifying your browser and " +
+          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+      },
+    },
     ccpaConfig: {
       description:
         "Quando visita o nosso site, armazenamos cookies no seu navegador para recolher informações. Esta informação pode ser sobre si, as suas preferências ou o seu dispositivo e é utilizada principalmente para fazer o website funcionar conforme o esperado e proporcionar-lhe uma experiência de navegação mais personalizada. No entanto, o bloqueio de alguns tipos de cookies pode afetar a sua experiência no website e os serviços que podemos oferecer. Clique nos cabeçalhos das diferentes categorias para saber mais e alterar as nossas configurações predefinidas. Não pode optar por não receber os nossos cookies originais estritamente necessários, pois eles são implantados para garantir o funcionamento adequado do nosso site (como fazer aparecer a faixa de cookies e lembrar as suas configurações, entrar na sua conta, redirecioná-lo quando sair, etc.). Para obter mais informações sobre os cookies originais e os cookies de terceiros utilizados, siga este link.",
@@ -280,6 +412,28 @@ const LOCALE_TEXT = {
         "Vidakuzi hivi ni muhimu kwa tovuti kufanya kazi na haziwezi kuzimwa katika mifumo yetu. Kwa kawaida huwekwa tu kulingana na hatua unazofanya ambazo ni sawa na ombi la huduma, kama vile kuweka mapendeleo yako ya faragha, kuingia au kujaza fomu. Unaweza kuweka kivinjari chako kukuzuia au kukuarifu kuhusu vidakuzi hivi, lakini baadhi ya sehemu za tovuti hazitafanya kazi. Vidakuzi hivi havihifadhi maelezo yoyote yanayoweza kumtambulisha mtu binafsi.",
       // visible label / aria-label for the close button
       closeLabel: "Close", // TODO: replace with localized translation
+    },
+    // TODO(TP1-4033): replace with localized translation
+    optionalCookies: {
+      analytics: {
+        label: "Analytics Cookies",
+        description:
+          "These cookies allow us to count visits and traffic sources so we can " +
+          "measure and improve the performance of our site. They help us to know " +
+          "which pages are the most and least popular and see how visitors move around " +
+          "the site. All information these cookies collect is aggregated and therefore anonymous. " +
+          "If you do not allow these cookies we will not know when you have visited our site, " +
+          "and will not be able to monitor its performance.",
+      },
+      marketing: {
+        label: "Marketing Cookies",
+        description:
+          "These cookies may be set through our site by our advertising partners. " +
+          "They may be used by those companies to build a profile of your interests " +
+          "and show you relevant adverts on other sites. They do not store directly " +
+          "personal information, but are based on uniquely identifying your browser and " +
+          "internet device. If you do not allow these cookies, you will experience less targeted advertising.",
+      },
     },
     ccpaConfig: {
       description:


### PR DESCRIPTION
Related PRs/issues: [Jira TP1-4068](https://mozilla-hub.atlassian.net/browse/TP1-4068)

# Description

- Extracts the `optionalCookies` (analytics/marketing) `label`/`description` strings out of `init.js` and into `text.js`, alongside the rest of the Cookie Control text config
- Adds `withOptionalCookiesText` in `init.js` to merge the static category config (name, cookies, callbacks) with localized text per locale, mirroring the existing `withCCPATitle` pattern for `text`/`ccpaConfig`
- Adds real `optionalCookies` translations for de, es, fr, nl, pl, and pt; `sw` still uses the English placeholder pending translation
- Fixes the English `accept`/`reject` notify-banner button labels from "Accept/Reject Analytics Cookies" to "Accept All"/"Reject All" — verified live that clicking either button actually toggles both the analytics and marketing categories together, not just analytics, so the old wording was inaccurate and inconsistent with the other locales' generic "accept/reject all" phrasing

**Note**: Reviewing commit by commit is easier than the full diff at once

# To Test
Run this branch locally. Make sure you have `COOKIE_CONTROL_API_KEY` env var set
- [ ] Loaded the site and clicked "Accept All"/"Reject All" on the notify banner — confirmed both `analytics` and `marketing` optional categories are set together (`{"analytics":"accepted","marketing":"accepted"}` / `{"analytics":"revoked","marketing":"revoked"}`)
- [ ] Switch browser language to a non-English locale and confirm the banner renders the translated analytics/marketing labels and descriptions
- [ ] Confirm `sw` still falls back to English optionalCookies text as expected

