### PR TITLE
Security: Cross-Site Scripting (XSS) via `|safe` filter on Sosha Toolkit Embed Code

### DIFF
--- a/foundation_cms/campaigns/templates/campaigns/components/campaign_page/form_state/03_sharing.html
+++ b/foundation_cms/campaigns/templates/campaigns/components/campaign_page/form_state/03_sharing.html
@@ -7,7 +7,7 @@
     <div class="petition__share-button-wrapper">
         {% if petition_cta.sosha_toolkit_embed_code %}
             <div class="petition__share-embed">
-                {{ petition_cta.sosha_toolkit_embed_code|safe }}
+                {{ petition_cta.sosha_toolkit_embed_code }}
             </div>
         {% else %}
             <div class="petition__share-buttons">


### PR DESCRIPTION
## Summary

Security: Cross-Site Scripting (XSS) via `|safe` filter on Sosha Toolkit Embed Code

## Problem

**Severity**: `High` | **File**: `foundation_cms/campaigns/templates/campaigns/components/campaign_page/form_state/03_sharing.html:L12`

In the sharing state template, the `sosha_toolkit_embed_code` is rendered using the `|safe` filter. This output is not escaped by Django's template engine, allowing any HTML or JavaScript placed in this field to be executed in the user's browser. If an attacker can manipulate this field (e.g., via a compromised admin account or CSRF), they can inject malicious scripts, leading to session hijacking or data exfiltration.

## Solution

Avoid using `|safe` on user-editable content. If raw HTML is absolutely required for social sharing widgets, sanitize the input using a library like `bleach` before saving it to the database, or strictly validate the format of the embed code in the model's `clean()` method to ensure it only contains expected elements.

## Changes

- `foundation_cms/campaigns/templates/campaigns/components/campaign_page/form_state/03_sharing.html` (modified)