### PR TITLE
Add django cookies to Civic cookie control

### DIFF
--- a/foundation_cms/static/js/civic_cookie_control/init.js
+++ b/foundation_cms/static/js/civic_cookie_control/init.js
@@ -204,6 +204,9 @@ if (!COOKIE_CONTROL_API_KEY) {
         "en",
       ),
       necessaryCookies: [
+        // Django csrftoken/sessionid cookies — required for logged-in editing
+        "csrftoken",
+        "sessionid",
         "OptanonConsent",
         "OptanonAlertBoxClosed",
         "OptanonControl",


### PR DESCRIPTION
# Description

This PR will add a couple of necessary cookies to Civic and fix errors editors are experiencing publishing pages.

Link to sample test page:
Related PRs/issues: TP1-4071