### PR TITLE
Fix legacy footer newsletter text color

### DIFF
--- a/foundation_cms/static/scss/redesign_migrated_content.scss
+++ b/foundation_cms/static/scss/redesign_migrated_content.scss
@@ -46,6 +46,12 @@
   }
 }
 
+.site-footer-ns {
+  p {
+    color: inherit;
+  }
+}
+
 .primary-nav-ns {
   a[class*="btn"] {
     font-weight: 400;


### PR DESCRIPTION
# Description

Fixes the newsletter signup text rendering black in the redesign footer on legacy pages.

Legacy styles apply `color: #000` directly to paragraph elements, overriding the light color inherited from the redesign footer. This adds a footer-scoped compatibility rule so footer paragraphs inherit the intended color without changing paragraph text elsewhere on legacy pages.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/7ea48591-852b-4548-9387-00d38daa0a3e" />

## How to test

1. Open the sample legacy page.
2. Confirm the introductory paragraph renders black.
3. Scroll to the redesign footer.
4. Confirm the newsletter text renders light against the dark background.
5. Confirm the remainder of the footer looks unchanged.

Link to sample test page: https://foundation-s-tp1-3609-f-lb8n5r.mofostaging.net/en/tp1-3609-legacy-footer-test/
Related PRs/issues: [Jira ticket](https://mozilla-hub.atlassian.net/browse/TP1-3609)