### PR TITLE
TP1-4110: Update Gallery Hub truncation and hero media fit

### DIFF
--- a/foundation_cms/static/scss/components/gallery_hub/_project.scss
+++ b/foundation_cms/static/scss/components/gallery_hub/_project.scss
@@ -208,6 +208,7 @@
 
   &__description {
     @include mofo-text-style($body-text-styles, "regular", $body-font-family);
+    @include text-line-clamp(2);
 
     margin: 0 0 rem-calc(8);
   }
@@ -379,7 +380,6 @@ body.redesign h2.gallery-hub-project__title {
 
     .gallery-hub-project__description {
       @include mofo-text-style($body-text-styles, "small", $body-font-family);
-      @include text-line-clamp(2);
 
       margin-bottom: rem-calc(8);
     }
@@ -510,7 +510,6 @@ body.redesign h2.gallery-hub-project__title {
 
     .gallery-hub-project__description {
       @include mofo-text-style($body-text-styles, "small", $body-font-family);
-      @include text-line-clamp(2);
 
       margin-bottom: rem-calc(10);
     }

--- a/foundation_cms/static/scss/pages/project_page.scss
+++ b/foundation_cms/static/scss/pages/project_page.scss
@@ -81,7 +81,7 @@ body.template-project-page {
       display: block;
       width: 100%;
       aspect-ratio: math.div(3, 2);
-      object-fit: cover;
+      object-fit: contain;
     }
 
     &__frame {


### PR DESCRIPTION
## Description

Updates the Gallery Hub and Project Page media treatment for TP1-4110 so long project copy stays within the Gallery Hub layout and hero images remain fully visible.

## What Changed

- Limits Gallery Hub project titles and ledes to two lines.
- Fits Project Page hero images within the carousel without cropping.

## QA

Review app:

- [Gallery Hub](https://foundation-s-tp1-4110-g-zuh3y1.mofostaging.net/en/gallery/)
- [Project Page](https://foundation-s-tp1-4110-g-zuh3y1.mofostaging.net/en/gallery/gallery-project-13/)

Verify that:

- Longer Gallery Hub titles and ledes truncate after two lines.
- Project Page hero images remain fully visible without cropping.
- Project Page carousel controls continue to work.

## Screenshots

### Gallery Hub

| Before | After |
| --- | --- |
| <img width="636" height="358" alt="Gallery Hub before — unclamped lede recreation" src="https://github.com/user-attachments/assets/53d7159f-7e6e-4aa5-ab1f-f479ae0ac5c2" /> | <img width="636" height="358" alt="Gallery Hub after — two-line title and lede" src="https://github.com/user-attachments/assets/d1803e89-7b4f-45d6-a071-8a6844f4bd06" /> |

### Project Page hero media

| Before | After |
| --- | --- |
| <img width="992" height="629" alt="Project Page hero before — cover fit recreation" src="https://github.com/user-attachments/assets/146eac89-a2ec-468a-a8b7-dc4e3f739692" /> | <img width="992" height="629" alt="Project Page hero after — contain fit" src="https://github.com/user-attachments/assets/c46eab8b-a350-4a17-8da6-c1fa821a62fd" /> |

Related PRs/issues: [Jira ticket](https://mozilla-hub.atlassian.net/browse/TP1-4110), #16332